### PR TITLE
Change a misleading warning log

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -399,7 +399,7 @@ public class TargetHandler implements NHttpClientEventHandler {
             sendFault = false;
         } else if (state == ProtocolState.REQUEST_DONE) {
             informWriterError(conn);
-            log.warn("Connection closed by target host before receiving the request");
+            log.warn("Connection closed by target host after sending the request");
             sendFault = true;
         }
 


### PR DESCRIPTION
Mentioned logs are printed if the state=REQUEST_DONE which means after request is sent.
