### PR TITLE
Adding TLS change

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientSSLSetupHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientSSLSetupHandler.java
@@ -39,6 +39,9 @@ public class ClientSSLSetupHandler implements SSLSetupHandler {
             "localhost",
             "localhost.localdomain"};
 
+    /** Enabled SSL handshake protocols (e.g. SSLv3, TLSv1) */
+    private String[] httpsProtocols;
+
     static {
         Arrays.sort(LOCALHOSTS);
     }
@@ -138,6 +141,13 @@ public class ClientSSLSetupHandler implements SSLSetupHandler {
     }
 
     public void initalize(SSLEngine sslengine) {
+        /*
+            set handshake protocols if they are specified in transport configuration.
+            eg: <parameter name="HttpsProtocols">TLSv1.1,TLSv1.2</parameter>
+        */
+        if(null != httpsProtocols) {
+            sslengine.setEnabledProtocols(httpsProtocols);
+        }
     }
 
     public void verify(IOSession iosession, SSLSession sslsession) throws SSLException {
@@ -159,6 +169,15 @@ public class ClientSSLSetupHandler implements SSLSetupHandler {
                 throw new SSLException("Certificate Chain Validation failed for host : " + address, e);
             }
         }
+    }
+
+    /**
+     * Set HTTPS protocols if mentioned in axis2 configuration
+     *
+     * @param httpsProtocols  Array of protocols
+     */
+    public void setHttpsProtocols(String[] httpsProtocols) {
+        this.httpsProtocols = httpsProtocols;
     }
 
 }


### PR DESCRIPTION
Previously ```PassThroughHttpSSLSender``` was supporting only for the default TLS type (TLS v1), although listener can be configured.
With this change, the ```PassThroughHttpSSLSender``` can be also changed (if needed, else use the default) as follows in the ```axis2.xml``` file.
```
<transportSender name="https" class="org.apache.synapse.transport.passthru.PassThroughHttpSSLSender">
        
       <parameter name="HttpsProtocols">TLSv1.1,TLSv1.2</parameter>
                  .........
         
</transportSender>

```