### PR TITLE
correcting timout bahaviour for endpoints

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointDefinitionFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointDefinitionFactory.java
@@ -151,21 +151,9 @@ public class EndpointDefinitionFactory implements DefinitionFactory{
             if (action != null && action.getText() != null) {
                 String actionString = action.getText();
                 if ("discard".equalsIgnoreCase(actionString.trim())) {
-
                     definition.setTimeoutAction(SynapseConstants.DISCARD);
-
-                    // set timeout duration to 30 seconds, if it is not set explicitly
-                    if (definition.getTimeoutDuration() == 0) {
-                        definition.setTimeoutDuration(30000);
-                    }
                 } else if ("fault".equalsIgnoreCase(actionString.trim())) {
-
                     definition.setTimeoutAction(SynapseConstants.DISCARD_AND_FAULT);
-
-                    // set timeout duration to 30 seconds, if it is not set explicitly
-                    if (definition.getTimeoutDuration() == 0) {
-                        definition.setTimeoutDuration(30000);
-                    }
                 } else {
                     handleException("Invalid timeout action, action : "
                             + actionString + " is not supported");

--- a/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
@@ -239,4 +239,11 @@ public interface SynapseEnvironment {
      * @param handler synapse handler
      */
     public void registerSynapseHandler(SynapseHandler handler);
+
+    /**
+     * Get the global timeout interval for callbacks
+     *
+     * @return global timeout interval
+     */
+    public long getGlobalTimeout();
 }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/AsyncCallback.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/AsyncCallback.java
@@ -46,6 +46,8 @@ public class AsyncCallback implements AxisCallback {
     /** Action to perform when timeout occurs */
     private int timeOutAction = SynapseConstants.NONE;
 
+    private long timeoutDuration;
+
     public AsyncCallback( org.apache.axis2.context.MessageContext messageContext,MessageContext synapseOutMsgCtx) {
         this.synapseOutMsgCtx = synapseOutMsgCtx;
         this.axis2OutMsgCtx = messageContext;
@@ -90,6 +92,14 @@ public class AsyncCallback implements AxisCallback {
 
     public void setTimeOutOn(long timeOutOn) {
         this.timeOutOn = timeOutOn;
+    }
+
+    public long getTimeoutDuration() {
+        return timeoutDuration;
+    }
+
+    public void setTimeoutDuration(long timeoutDuration) {
+        this.timeoutDuration = timeoutDuration;
     }
 
     public int getTimeOutAction() {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -452,8 +452,8 @@ public class Axis2FlexibleMEPClient {
                 axisAnonymousOperation.getMessage(WSDLConstants.MESSAGE_LABEL_OUT_VALUE));
 
         // set the SEND_TIMEOUT for transport sender
-        if (endpoint != null && endpoint.getTimeoutDuration() > 0) {
-            axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getTimeoutDuration());
+        if (endpoint != null && endpoint.getEffectiveTimeout() > 0) {
+            axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getEffectiveTimeout());
         }
 
 
@@ -465,11 +465,15 @@ public class Axis2FlexibleMEPClient {
         if (!outOnlyMessage) {
             if (endpoint != null) {
                 // set the timeout time and the timeout action to the callback, so that the
-                // TimeoutHandler can detect timed out callbacks and take approprite action.
-                callback.setTimeOutOn(System.currentTimeMillis() + endpoint.getTimeoutDuration());
+                // TimeoutHandler can detect timed out callbacks and take appropriate action.
+                long endpointTimeout =  endpoint.getEffectiveTimeout();
+                callback.setTimeOutOn(System.currentTimeMillis() + endpointTimeout);
                 callback.setTimeOutAction(endpoint.getTimeoutAction());
+                callback.setTimeoutDuration(endpointTimeout);
             } else {
-                callback.setTimeOutOn(System.currentTimeMillis());
+                long globalTimeout = synapseOutMessageContext.getEnvironment().getGlobalTimeout();
+                callback.setTimeOutOn(System.currentTimeMillis() + globalTimeout);
+                callback.setTimeoutDuration(globalTimeout);
             }
 
         }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -41,6 +41,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.statistics.StatisticsCollector;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
+import org.apache.synapse.config.SynapseConfigUtils;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.config.SynapseHandlersLoader;
 import org.apache.synapse.continuation.ContinuationStackManager;
@@ -85,6 +86,7 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     private SynapseTaskManager taskManager;
     private RESTRequestHandler restHandler;
     private List<SynapseHandler> synapseHandlers;
+    private long globalTimeout = SynapseConstants.DEFAULT_GLOBAL_TIMEOUT;
 
     /** The StatisticsCollector object */
     private StatisticsCollector statisticsCollector = new StatisticsCollector();
@@ -166,6 +168,8 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
         restHandler = new RESTRequestHandler();
 
         synapseHandlers = SynapseHandlersLoader.loadHandlers();
+
+        this.globalTimeout = SynapseConfigUtils.getGlobalTimeoutInterval();
 
     }
 
@@ -826,6 +830,11 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
      */
     public void registerSynapseHandler(SynapseHandler handler) {
         synapseHandlers.add(handler);
+    }
+
+    @Override
+    public long getGlobalTimeout() {
+        return globalTimeout;
     }
 
     public boolean injectMessage(MessageContext smc, SequenceMediator seq) {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
@@ -135,65 +135,65 @@ public class TimeoutHandler extends TimerTask {
                         }
                         continue;
                     }
-                    if (callback.getTimeOutAction() != SynapseConstants.NONE) {
 
-                        if (callback.getTimeOutOn() <= currentTime) {
-                            //callbackStore.remove(key);
-                            toRemove.add(key);
-                            if (callback.getTimeOutAction() == SynapseConstants.DISCARD_AND_FAULT) {
+                    if (callback.getTimeOutOn() <= currentTime) {
 
-                                // actiavte the fault sequence of the current sequence mediator
-                                MessageContext msgContext = callback.getSynapseOutMsgCtx();
+                        toRemove.add(key);
 
-                                /* Clear the pipe to prevent release of the associated writer buffer
-                                 to the buffer factory.
-                                This is to prevent same buffer is getting released to both source
-                                and target buffer factories. Otherwise when a late response arrives,
-                                buffer is released to both factories and makes system unstable
-                                */
-                                ((Axis2MessageContext) msgContext).getAxis2MessageContext().
-                                                removeProperty(PassThroughConstants.PASS_THROUGH_PIPE);
+                        if (callback.getTimeOutAction() == SynapseConstants.DISCARD_AND_FAULT) {
 
-                                // add an error code to the message context, so that error sequences
-                                // can identify the cause of error
-                                msgContext.setProperty(SynapseConstants.ERROR_CODE,
-                                        SynapseConstants.HANDLER_TIME_OUT);
-                                msgContext.setProperty(SynapseConstants.ERROR_MESSAGE,
-                                        SEND_TIMEOUT_MESSAGE);
+                            // activate the fault sequence of the current sequence mediator
+                            MessageContext msgContext = callback.getSynapseOutMsgCtx();
 
-                                SOAPEnvelope soapEnvelope;
-                                if(msgContext.isSOAP11()){
-                                    soapEnvelope = OMAbstractFactory.getSOAP11Factory().createSOAPEnvelope();
-                                    soapEnvelope.addChild(OMAbstractFactory.getSOAP11Factory().createSOAPBody());
-                                } else {
-                                    soapEnvelope = OMAbstractFactory.getSOAP12Factory().createSOAPEnvelope();
-                                    soapEnvelope.addChild(OMAbstractFactory.getSOAP12Factory().createSOAPBody());
-                                 }
-                                try {
-                                    msgContext.setEnvelope(soapEnvelope);
-                                } catch (Throwable ex) {
-                                    log.error("Exception or Error occurred resetting SOAP Envelope",ex);
-                                    continue;
-                                }
- 
-                                Stack<FaultHandler> faultStack = msgContext.getFaultStack();
-                                if (!faultStack.isEmpty()) {
-                                    FaultHandler faultHandler = faultStack.pop();
-                                    if (faultHandler != null) {
-                                        try {
-                                            faultHandler.handleFault(msgContext);
-                                        } catch (Throwable ex) {
-                                            log.warn("Exception or Error occurred while executing the fault handler", ex);
-                                            continue;
-                                        }
+                            /* Clear the pipe to prevent release of the associated writer buffer
+                               to the buffer factory.
+                               This is to prevent same buffer is getting released to both source
+                               and target buffer factories. Otherwise when a late response arrives,
+                               buffer is released to both factories and makes system unstable
+                            */
+                            ((Axis2MessageContext) msgContext).getAxis2MessageContext().
+                                    removeProperty(PassThroughConstants.PASS_THROUGH_PIPE);
+
+                            // add an error code to the message context, so that error sequences
+                            // can identify the cause of error
+                            msgContext.setProperty(SynapseConstants.ERROR_CODE,
+                                                   SynapseConstants.HANDLER_TIME_OUT);
+                            msgContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                                                   SEND_TIMEOUT_MESSAGE);
+
+                            SOAPEnvelope soapEnvelope;
+                            if (msgContext.isSOAP11()) {
+                                soapEnvelope = OMAbstractFactory.
+                                        getSOAP11Factory().createSOAPEnvelope();
+                                soapEnvelope.addChild(
+                                        OMAbstractFactory.getSOAP11Factory().createSOAPBody());
+                            } else {
+                                soapEnvelope = OMAbstractFactory.
+                                        getSOAP12Factory().createSOAPEnvelope();
+                                soapEnvelope.addChild(
+                                        OMAbstractFactory.getSOAP12Factory().createSOAPBody());
+                            }
+                            try {
+                                msgContext.setEnvelope(soapEnvelope);
+                            } catch (Throwable ex) {
+                                log.error("Exception or Error occurred resetting SOAP Envelope", ex);
+                                continue;
+                            }
+
+                            Stack<FaultHandler> faultStack = msgContext.getFaultStack();
+                            if (!faultStack.isEmpty()) {
+                                FaultHandler faultHandler = faultStack.pop();
+                                if (faultHandler != null) {
+                                    try {
+                                        faultHandler.handleFault(msgContext);
+                                    } catch (Throwable ex) {
+                                        log.warn("Exception or Error occurred while " +
+                                                 "executing the fault handler", ex);
+                                        continue;
                                     }
                                 }
-
                             }
                         }
-
-                    } else if (currentTime > globalTimeout + callback.getTimeOutOn()) {
-                        toRemove.add(key);
                     }
                 }
 
@@ -207,7 +207,7 @@ public class TimeoutHandler extends TimerTask {
 
                     if (!"true".equals(callback.getSynapseOutMsgCtx().getProperty(SynapseConstants.OUT_ONLY))) {
                         log.warn("Expiring message ID : " + key + "; dropping message after " +
-                                "global timeout of : " + (globalTimeout / 1000) + " seconds");
+                                "timeout of : " + (callback.getTimeoutDuration() / 1000) + " seconds");
                     }
                     callbackStore.remove(key);
                 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/EndpointDefinition.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/EndpointDefinition.java
@@ -19,10 +19,14 @@
 
 package org.apache.synapse.endpoints;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.AspectConfigurable;
 import org.apache.synapse.aspects.AspectConfiguration;
+import org.apache.synapse.config.SynapseConfigUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +39,9 @@ import java.util.regex.Pattern;
  * level endpoints to store this information (e.g. AddressEndpoint and WSDLEndpoint).
  */
 public class EndpointDefinition implements AspectConfigurable {
+
+    private static final Log log = LogFactory.getLog(EndpointDefinition.class);
+
     public static final String DYNAMIC_URL_VALUE = "DYNAMIC_URL_VALUE";
 
     /** Who is the leaf level Endpoint which uses me? */
@@ -137,6 +144,11 @@ public class EndpointDefinition implements AspectConfigurable {
     private long timeoutDuration = 0;
 
     /**
+     * Effective timeout interval for the endpoint
+     */
+    private long effectiveTimeout = 0;
+
+    /**
      * action to perform when a timeout occurs (NONE | DISCARD | DISCARD_AND_FAULT) *
      */
     private int timeoutAction = SynapseConstants.NONE;
@@ -168,6 +180,19 @@ public class EndpointDefinition implements AspectConfigurable {
 
     /** A list of error codes which permit the retries for Enabled error Codes */
     private final List<Integer> retryEnabledErrorCodes = new ArrayList<Integer>();
+
+    public EndpointDefinition() {
+        try {
+            // Set the timeout value to global timeout value.
+            // This will be overridden if endpoint timeout is set
+            effectiveTimeout = SynapseConfigUtils.getGlobalTimeoutInterval();
+        } catch (Exception ex) {
+            String msg = "Error while reading global timeout interval";
+            log.error(msg, ex);
+            throw new SynapseException(msg, ex);
+        }
+    }
+
     /**
      * This should return the absolute EPR address referenced by the named endpoint. This may be
      * possibly computed.
@@ -452,12 +477,25 @@ public class EndpointDefinition implements AspectConfigurable {
     }
 
     /**
+     * Get the effective timeout duration for the endpoint
+     *
+     * If endpoint timeout is set explicitly this will return that,
+     * If not global timeout interval is returned
+     *
+     * @return effective timeout duration for the endpoint
+     */
+    public long getEffectiveTimeout() {
+        return effectiveTimeout;
+    }
+
+    /**
      * Set the timeout duration.
      *
      * @param timeoutDuration a duration in milliseconds
      */
     public void setTimeoutDuration(long timeoutDuration) {
         this.timeoutDuration = timeoutDuration;
+        this.effectiveTimeout = timeoutDuration;
     }
 
     public int getTimeoutAction() {

--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
@@ -226,8 +226,8 @@ public class BlockingMsgSenderUtils {
         }
 
         // set the SEND_TIMEOUT for transport sender
-        if (endpoint.getTimeoutDuration() > 0) {
-            axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getTimeoutDuration());
+        if (endpoint.getEffectiveTimeout() > 0) {
+            axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getEffectiveTimeout());
         }
 
         // Check for preserve WS-Addressing


### PR DESCRIPTION
Following issues are corrected.
- When timeout action is set to Fault or Discard and leave the timeout duration field, synapse will put 30s as the timeout. Ideally it should use global timeout interval.
- When timeout action is NONE, timeout duration is set to global timeout interval even we set a timeout interval at the endpoint
- Correct the log message getting printed from TimeoutHandler upon callback expiration. Earlier it was always printing global timeout interval as the expiring time.