### PR TITLE
fixing ESBJAVA-3843

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/XSLTMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/XSLTMediator.java
@@ -187,6 +187,11 @@ public class XSLTMediator extends AbstractMediator {
             synLog.traceTrace("Message : " + synCtx.getEnvelope());
         }
 
+        if (synCtx.getEnvelope().getBody().getFirstElement() == null) {
+            synLog.auditWarn("Found empty soap body, skipping XSLT transformation and continuing the mediation");
+            return true;
+        }
+
         try {
             performXSLT(synCtx, synLog);
 


### PR DESCRIPTION
If the soap body empty for XSLT mediation, skipping the transformation and continuing the mediation flow with the empty soap body  