### PR TITLE
Esbjava 4033

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
@@ -62,6 +62,11 @@ public final class VFSConstants {
     public static final String SUBFOLDER_TIMESTAMP = "transport.vfs.SubFolderTimestampFormat";
 
     /**
+     * parameter to set synchronous uploading of the files for a file protocol on host basis
+     */
+    public static final String TRANSPORT_FILE_SEND_FILE_LOCKING = "transport.vfs.SendFileSynchronously";
+
+    /**
      * File Sorting Parameter and values
      * */
     public static final String FILE_SORT_PARAM = "transport.vfs.FileSortAttribute";

--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
@@ -49,6 +49,7 @@ public class VFSOutTransportInfo implements OutTransportInfo {
     private boolean append;
     private boolean fileLocking;
     private Map<String, String> fso = null;
+    private boolean sendFileSynchronously = false;
     //When the folder structure does not exists forcefully create
     private boolean forceCreateFolder = false;
     
@@ -132,6 +133,13 @@ public class VFSOutTransportInfo implements OutTransportInfo {
             this.fileLocking = fileLocking;
         }
 
+        if (properties.containsKey(VFSConstants.TRANSPORT_FILE_SEND_FILE_LOCKING)) {
+            String strSendLocking = properties.get(VFSConstants.TRANSPORT_FILE_SEND_FILE_LOCKING);
+            sendFileSynchronously = Boolean.parseBoolean(strSendLocking);
+        } else {
+            sendFileSynchronously = false;
+        }
+
         if (properties.containsKey(VFSConstants.APPEND)) {
             String strAppend = properties.get(VFSConstants.APPEND);
             append = Boolean.parseBoolean(strAppend);
@@ -186,6 +194,10 @@ public class VFSOutTransportInfo implements OutTransportInfo {
 
     public String getOutFileURI() {
         return outFileURI;
+    }
+
+    public boolean getSendFileSynchronously(){
+        return sendFileSynchronously;
     }
 
     public String getOutFileName() {

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
@@ -63,6 +63,9 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
      */
     private boolean globalFileLockingFlag = true;
 
+    /**
+     * Map to hold lock object for each host per service when operating in synchronous write mode
+     */
     private static final ConcurrentHashMap<String,WriteLockObject> lockingObjects = new ConcurrentHashMap<>();
 
     /**

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
@@ -40,6 +40,7 @@ import org.apache.synapse.commons.vfs.VFSUtils;
 import org.apache.synapse.commons.vfs.VFSOutTransportInfo ;
 
 import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * axis2.xml - transport definition
@@ -61,6 +62,8 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
      * FILE LOCKING IS ENABLED
      */
     private boolean globalFileLockingFlag = true;
+
+    private static final ConcurrentHashMap<String,WriteLockObject> lockingObjects = new ConcurrentHashMap<>();
 
     /**
      * The public constructor
@@ -118,6 +121,44 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
         } else if (outTransportInfo != null && outTransportInfo instanceof VFSOutTransportInfo) {
             vfsOutInfo = (VFSOutTransportInfo) outTransportInfo;
         }
+
+        WriteLockObject lockObject = null;
+        String baseUri = null;
+        if (vfsOutInfo != null) {
+            if (vfsOutInfo.getSendFileSynchronously()) {
+                baseUri = getBaseUri(targetAddress);
+                if (baseUri != null) {
+                    if (!lockingObjects.containsKey(baseUri)) {
+                        lockingObjects.putIfAbsent(baseUri, new WriteLockObject());
+                        log.debug("New locking object created for Synchronous write|MapSize:" + lockingObjects.size());
+                    }
+                    lockObject = lockingObjects.get(baseUri);
+                    lockObject.incrementUsers();
+                }
+            }
+        }
+
+        try {
+            if (lockObject == null) {
+                writeFile(msgCtx, vfsOutInfo);
+            } else {
+                synchronized (lockObject) {
+                    writeFile(msgCtx, vfsOutInfo);
+                }
+            }
+        }catch (AxisFault axisFault){
+            throw axisFault;
+        }catch (Exception e){
+            handleException("Exception occurred while sending output to the destination" + e.getMessage(), e);
+        }finally {
+            if(lockObject != null && (lockObject.decrementAndGetUsers() == 0)){
+                lockingObjects.remove(baseUri);
+                log.debug("locking object removed for after Synchronous write|MapSize:" + lockingObjects.size());
+            }
+        }
+    }
+
+    private void writeFile(MessageContext msgCtx, VFSOutTransportInfo vfsOutInfo) throws AxisFault {
 
         FileSystemOptions fso = null;
         try {
@@ -270,7 +311,7 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
 
     private void populateResponseFile(FileObject responseFile, MessageContext msgContext,
                                       boolean append, boolean lockingEnabled, FileSystemOptions fso) throws AxisFault {
-        
+
         MessageFormatter messageFormatter = getMessageFormatter(msgContext);
         OMOutputFormat format = BaseUtils.getOMOutputFormat(msgContext);
         
@@ -322,5 +363,28 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
                 } catch (InterruptedException ignore) {}
             }
         }
+    }
+
+    /**
+     * This method extracts base uri of vfs string.
+     * @param targetAddress target address of the vfs connection
+     * @return base uri for the vfs connection
+     */
+    private String getBaseUri(String targetAddress) {
+
+        //Remove vfs: part as in InboundEndpoint that part is not used
+        if(targetAddress.contains("vfs:"))
+        {
+            targetAddress = targetAddress.substring(targetAddress.indexOf("vfs:") + 4);
+        }
+
+        int index = targetAddress.indexOf("://");
+        if (index > -1) {
+            int endIndex = targetAddress.indexOf('/', index + 3);
+            if (endIndex > -1) {
+                return targetAddress.substring(0, endIndex);
+            }
+        }
+        return null;
     }
 }

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/WriteLockObject.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/WriteLockObject.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.transport.vfs;
+
+/**
+ * This class is used for locking vfs sender in synchronous write mode
+ */
+public class WriteLockObject {
+
+	/**
+	 * Number of threads using this object for locking
+	 */
+	private int objectUsers = 0;
+
+	public void incrementUsers(){
+		objectUsers++;
+	}
+
+	public int decrementAndGetUsers(){
+		return --objectUsers;
+	}
+}


### PR DESCRIPTION
This fix introduce synchronous write to vfs sender. User can enable this option by using a query parameter at the end of the destinatiion url ?transport.vfs.SendFileSynchronously=true.

e.g. uri="vfs:sftp://ftpuser:root@localhost/files/out?transport.vfs.SendFileSynchronously=true