### PR TITLE
fixing ESBJAVA-4284

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
@@ -18,8 +18,8 @@ package org.apache.synapse.transport.passthru;
 
 import org.apache.http.nio.NHttpConnection;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
+import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -99,7 +99,7 @@ public class SourceContext {
 
 		if (writer != null) {
 			if (!isError) {      // If there is an error we do not release the buffer to the factory
-                ByteBuffer buffer = writer.getBuffer();
+                ControlledByteBuffer buffer = writer.getBuffer();
 				sourceConfiguration.getBufferFactory().release(buffer);
 			}
 		}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
@@ -19,8 +19,7 @@ package org.apache.synapse.transport.passthru;
 import org.apache.axis2.context.MessageContext;
 import org.apache.http.nio.NHttpConnection;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
-
-import java.nio.ByteBuffer;
+import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 
 /**
  * When a connection is created, an object of this class is stored in the Connection Context.
@@ -119,7 +118,7 @@ public class TargetContext {
 
         if (writer != null) {
             if (!isError) {      // If there is an error we do not release the buffer to the factory
-                ByteBuffer buffer = writer.getBuffer();
+                ControlledByteBuffer buffer = writer.getBuffer();
                 targetConfiguration.getBufferFactory().release(buffer);
             }
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/ControlledByteBuffer.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/ControlledByteBuffer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.passthru.util;
+
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ControlledByteBuffer {
+    private ByteBuffer byteBuffer;
+
+    private AtomicBoolean inputMode = new AtomicBoolean(true);
+
+    public ControlledByteBuffer(ByteBuffer byteBuffer) {
+        this.byteBuffer = byteBuffer;
+    }
+
+    public ByteBuffer getByteBuffer() {
+        return this.byteBuffer;
+    }
+
+    public boolean setInputMode() {
+        return this.inputMode.compareAndSet(false, true);
+    }
+
+    public boolean setOutputMode() {
+        return this.inputMode.compareAndSet(true, false);
+    }
+
+    public void forceSetInputMode() {
+        this.inputMode = new AtomicBoolean(true);
+    }
+
+    public void flip() {
+        this.byteBuffer.flip();
+    }
+
+    public void clear() {
+        this.byteBuffer.clear();
+    }
+
+    public void compact() {
+        this.byteBuffer.compact();
+    }
+
+    public int position() {
+        return this.byteBuffer.position();
+    }
+
+    public void put(byte b) {
+        this.byteBuffer.put(b);
+    }
+
+    public void putInt(int value) {
+        this.byteBuffer.putInt(value);
+    }
+
+    public ByteBuffer put(byte[] src, int offset, int length) {
+        return this.byteBuffer.put(src, offset, length);
+    }
+
+    public boolean hasRemaining() {
+        return this.byteBuffer.hasRemaining();
+    }
+
+    public byte get() {
+        return this.byteBuffer.get();
+    }
+
+    public ByteBuffer get(byte[] dst, int offset, int length) {
+        return this.byteBuffer.get(dst, offset, length);
+    }
+
+    public int remaining() {
+        return this.byteBuffer.remaining();
+    }
+}


### PR DESCRIPTION
fix for https://wso2.org/jira/browse/ESBJAVA-4284
Message building fails at high concurrency, when the out sequence is content aware. 
This is fixed by introducing a wrapper class for ByteBuffer (ControlledByteBuffer), which includes the ByteBuffer and its corresponding read/write flag