### PR TITLE
Fix ESBJAVA-4493, fix issue with message storing

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/store/MessageStoreMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/store/MessageStoreMediator.java
@@ -159,8 +159,11 @@ public class MessageStoreMediator extends AbstractMediator{
                 // with the nio transport, this causes the listener not to write a 202
                 // Accepted response, as this implies that Synapse does not yet know if
                 // a 202 or 200 response would be written back.
-                ((Axis2MessageContext) synCtx).getAxis2MessageContext().getOperationContext().setProperty(
-                        org.apache.axis2.Constants.RESPONSE_WRITTEN, "SKIP");
+                Axis2MessageContext msgCtx = (Axis2MessageContext) synCtx;
+                if (null != msgCtx.getAxis2MessageContext() && null != msgCtx.getAxis2MessageContext().getOperationContext()) {
+                    msgCtx.getAxis2MessageContext().getOperationContext().setProperty(
+                            org.apache.axis2.Constants.RESPONSE_WRITTEN, "SKIP");
+                }
 
                 return true;
             } else {


### PR DESCRIPTION
Store mediator logic tries to take operation context when using inbound-endpoint. This will generate a null-pointer exception.