### PR TITLE
Fix caching functionality for JMS Message Store

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
@@ -131,7 +131,7 @@ public class JmsProducer implements MessageProducer {
             }
             return false;
         } else {
-            store.cleanup(null, session, false);
+            store.reset(null, session, false);
         }
         if (logger.isDebugEnabled()) {
             logger.debug(getId() + ". Stored MessageID : " + synCtx.getMessageID());

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
@@ -72,6 +72,7 @@ public class JmsProducer implements MessageProducer {
         }
         if (!checkConnection()) {
             logger.warn(getId() + ". Ignored MessageID : " + synCtx.getMessageID());
+            store.setCachedProducer(null);
             return false;
         }
         StorableMessage message = MessageConverter.toStorableMessage(synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
@@ -108,8 +108,14 @@ public class JmsStore extends AbstractMessageStore {
     private long retryTime = -1;
     /** Guaranteed delivery enable or disable flag */
     private boolean isGuaranteedDeliveryEnable = false;
+    /** Preserve session for caching */
+    private MessageProducer cachedProducer;
 
     public MessageProducer getProducer() {
+        if (cacheLevel == 1 && cachedProducer != null) {
+            return cachedProducer;
+        }
+
         JmsProducer producer = new JmsProducer(this);
         producer.setId(nextProducerId());
         Throwable throwable = null;
@@ -157,6 +163,9 @@ public class JmsStore extends AbstractMessageStore {
         }
         if (logger.isDebugEnabled()) {
             logger.debug(nameString() + " created message producer " + producer.getId());
+        }
+        if (cacheLevel == 1) {
+            cachedProducer = producer;
         }
         return producer;
     }
@@ -468,6 +477,22 @@ public class JmsStore extends AbstractMessageStore {
     }
 
     /**
+     * Resets the JMS session for next message
+     *
+     * @param connection  JMS Connection
+     * @param session     JMS Session associated with the given connection
+     * @param error       Is this method called upon an error
+     * @return  {@code true} if the reset is successful. {@code false} otherwise.
+     */
+    public boolean reset(Connection connection, Session session, boolean error) {
+        if (cacheLevel == 1 && !error) {
+            return false;
+        } else {
+            return cleanup(connection, session, error);
+        }
+    }
+
+    /**
      * Cleans up the JMS Connection and Session associated with a JMS client.
      *
      * @param connection  JMS Connection
@@ -476,6 +501,7 @@ public class JmsStore extends AbstractMessageStore {
      * @return {@code true} if the cleanup is successful. {@code false} otherwise.
      */
     public boolean cleanup(Connection connection, Session session, boolean error) {
+        cachedProducer = null;
         if (connection == null && error) {
             return true;
         }

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
@@ -493,38 +493,6 @@ public class JmsStore extends AbstractMessageStore {
     }
 
     /**
-     * Resets the JMS session for next message
-     *
-     * @param connection  JMS Connection
-     * @param session     JMS Session associated with the given connection
-     * @param error       Is this method called upon an error
-     * @return  {@code true} if the reset is successful. {@code false} otherwise.
-     */
-    public boolean reset(Connection connection, Session session, boolean error) {
-        if (cacheLevel == 1 && !error) {
-            return false;
-        } else {
-            return cleanup(connection, session, error);
-        }
-    }
-
-    /**
-     * Resets the JMS session for next message
-     *
-     * @param connection  JMS Connection
-     * @param session     JMS Session associated with the given connection
-     * @param error       Is this method called upon an error
-     * @return  {@code true} if the reset is successful. {@code false} otherwise.
-     */
-    public boolean reset(Connection connection, Session session, boolean error) {
-        if (cacheLevel == 1 && !error) {
-            return false;
-        } else {
-            return cleanup(connection, session, error);
-        }
-    }
-
-    /**
      * Cleans up the JMS Connection and Session associated with a JMS client.
      *
      * @param connection  JMS Connection

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsStore.java
@@ -493,6 +493,38 @@ public class JmsStore extends AbstractMessageStore {
     }
 
     /**
+     * Resets the JMS session for next message
+     *
+     * @param connection  JMS Connection
+     * @param session     JMS Session associated with the given connection
+     * @param error       Is this method called upon an error
+     * @return  {@code true} if the reset is successful. {@code false} otherwise.
+     */
+    public boolean reset(Connection connection, Session session, boolean error) {
+        if (cacheLevel == 1 && !error) {
+            return false;
+        } else {
+            return cleanup(connection, session, error);
+        }
+    }
+
+    /**
+     * Resets the JMS session for next message
+     *
+     * @param connection  JMS Connection
+     * @param session     JMS Session associated with the given connection
+     * @param error       Is this method called upon an error
+     * @return  {@code true} if the reset is successful. {@code false} otherwise.
+     */
+    public boolean reset(Connection connection, Session session, boolean error) {
+        if (cacheLevel == 1 && !error) {
+            return false;
+        } else {
+            return cleanup(connection, session, error);
+        }
+    }
+
+    /**
      * Cleans up the JMS Connection and Session associated with a JMS client.
      *
      * @param connection  JMS Connection
@@ -539,6 +571,10 @@ public class JmsStore extends AbstractMessageStore {
                                        "]. Required parameters are not available.");
         }
         super.setParameters(parameters);
+    }
+
+    public void setCachedProducer(MessageProducer cachedProducer) {
+        this.cachedProducer = cachedProducer;
     }
 
     private boolean initme() {


### PR DESCRIPTION
Enable cache connection
```
   <parameter name="store.jms.cache.connection">true</parameter>
```
Eg: 
```
<messageStore` xmlns="http://ws.apache.org/ns/synapse"
              class="org.apache.synapse.message.store.impl.jms.JmsStore"
              name="JMSStore">
   <parameter name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
   <parameter name="store.producer.guaranteed.delivery.enable">false</parameter>
   <parameter name="store.jms.cache.connection">true</parameter>
   <parameter name="store.failover.message.store.name">JMSStore</parameter>
   <parameter name="java.naming.provider.url">repository/conf/jndi.properties</parameter>
   <parameter name="store.jms.destination">JMSMS</parameter>
   <parameter name="store.jms.JMSSpecVersion">1.1</parameter>
</messageStore>

```