### PR TITLE
Passing create folder parameter via a transport header - VFS Transport

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
@@ -19,6 +19,7 @@
 
 package org.apache.synapse.commons.vfs;
 
+import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.transport.OutTransportInfo;
 import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.commons.lang.StringUtils;
@@ -186,6 +187,18 @@ public class VFSOutTransportInfo implements OutTransportInfo {
         } else {
             return originalFileURI.substring(VFSConstants.VFS_PREFIX.length());
         }
+    }
+
+    public boolean isForceCreateFolder(MessageContext msgCtx) {
+        // first preference to set on the current message context
+        Map transportHeaders = (Map) msgCtx.getProperty(MessageContext.TRANSPORT_HEADERS);
+        if (transportHeaders != null && "true"
+                .equals((String) transportHeaders.get(VFSConstants.FORCE_CREATE_FOLDER))) {
+            return true;
+        }
+
+        // next check if the OutTransportInfo specifies one
+        return this.isForceCreateFolder();
     }
 
     public void setContentType(String contentType) {

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
@@ -205,7 +205,7 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
                 }
                 
                 //If the reply folder does not exists create the folder structure
-                if (vfsOutInfo.isForceCreateFolder()) {
+                if (vfsOutInfo.isForceCreateFolder(msgCtx)) {
                     String strPath = vfsOutInfo.getOutFileURI();
                     int iIndex = strPath.indexOf("?");
                     if(iIndex > -1){


### PR DESCRIPTION
Refer: https://wso2.org/jira/browse/ESBJAVA-4349
Here give transport.vfs.CreateFolder parameter is passing as property in transport headers. This can be with below config,
remove transport.vfs.CreateFolder parameter from the URI
```
<address uri="vfs:file:///home/wso2/vfs_test/out_done_folder/"/>
```
add as a property in transport headers
```
<property name="transport.vfs.CreateFolder" value="true" scope="transport" type="STRING"/>
```