### PR TITLE
Fix issue with when an artifact is just enabled stats

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -69,6 +69,7 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 				StatisticDataUnit statisticDataUnit = new StatisticDataUnit();
 				statisticDataUnit.setComponentName(componentName);
 				statisticDataUnit.setComponentType(componentType);
+				statisticDataUnit.setTracingEnabled(isCollectingTracing);
 				statisticDataUnit.setCurrentIndex(StatisticDataCollectionHelper.getFlowPosition(messageContext));
 				if(aspectConfiguration != null) {
 					statisticDataUnit.setComponentId(aspectConfiguration.getUniqueId());

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/BasicStatisticDataUnit.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/BasicStatisticDataUnit.java
@@ -41,6 +41,11 @@ public class BasicStatisticDataUnit {
 	private String statisticId;
 
 	/**
+	 * Is tracing enabled for a component
+	 */
+	private boolean isTracingEnabled = false;
+
+	/**
 	 * Is this message flow is a out_only flow
 	 */
 	private boolean isOutOnlyFlow;
@@ -80,6 +85,14 @@ public class BasicStatisticDataUnit {
 
 	public void setCurrentIndex(int currentIndex) {
 		this.currentIndex = currentIndex;
+	}
+
+	public boolean isTracingEnabled() {
+		return isTracingEnabled;
+	}
+
+	public void setTracingEnabled(boolean tracingEnabled) {
+		isTracingEnabled = tracingEnabled;
 	}
 
 	public boolean isOutOnlyFlow() {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
@@ -132,6 +132,11 @@ public class StatisticsLog {
 	 */
 	private int immediateParent;
 
+	/**
+	 * Flag indicates whether tracing enabled for the component
+	 */
+	private boolean isTracingEnabled;
+
 	public StatisticsLog(StatisticDataUnit statisticDataUnit) {
 		this.parentIndex = statisticDataUnit.getParentIndex();
 		this.currentIndex = statisticDataUnit.getCurrentIndex();
@@ -147,6 +152,7 @@ public class StatisticsLog {
 		this.componentType = statisticDataUnit.getComponentType();
 		this.hashCode = statisticDataUnit.getHashCode();
 		this.componentId = statisticDataUnit.getComponentId();
+		this.isTracingEnabled = statisticDataUnit.isTracingEnabled();
 	}
 
 	public StatisticsLog(ComponentType componentType, String componentName, int parentIndex) {
@@ -314,5 +320,13 @@ public class StatisticsLog {
 
 	public void setHashCode(Integer hashCode) {
 		this.hashCode = hashCode;
+	}
+
+	public boolean isTracingEnabled() {
+		return isTracingEnabled;
+	}
+
+	public void setTracingEnabled(boolean tracingEnabled) {
+		isTracingEnabled = tracingEnabled;
 	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/TracingDataCollectionHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/TracingDataCollectionHelper.java
@@ -151,6 +151,8 @@ public class TracingDataCollectionHelper {
 		String flowId = messageFlowLogs.get(0).getMessageFlowId();
 		Integer entrypointHashcode = messageFlowLogs.get(0).getHashCode();
 
+		boolean isTracingEnabledForFlow = messageFlowLogs.get(0).isTracingEnabled();
+
 		for (int index = 0; index < messageFlowLogs.size(); index++) {
 			StatisticsLog currentStatLog = messageFlowLogs.get(index);
 
@@ -159,6 +161,11 @@ public class TracingDataCollectionHelper {
 
 			// Skip the rest of things, if message tracing is disabled
 			if (!RuntimeStatisticCollector.isCollectingPayloads()) {
+				continue;
+			}
+
+			// Skip flow is tracing is not enabled for the flow (from UI)
+			if (!isTracingEnabledForFlow) {
 				continue;
 			}
 


### PR DESCRIPTION
When artifact is just enabled stats, tracing collector throws null pointer exception.
Since the actual cause for this was tracer collector is not ware whether artifact tracing is enabled