### PR TITLE
Fixing json when empty payload is sent with json content type

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
@@ -26,7 +26,6 @@ import org.apache.axis2.AxisFault;
 import org.apache.axis2.addressing.EndpointReference;
 import org.apache.axis2.builder.Builder;
 import org.apache.axis2.context.MessageContext;
-import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.transport.http.util.URIEncoderDecoder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,7 +42,7 @@ public final class JsonStreamBuilder implements Builder {
         SOAPEnvelope envelope = factory.getDefaultEnvelope();
 
         if (inputStream != null) {
-            OMElement element = JsonUtil.newJsonPayload(messageContext, inputStream, false, false);
+            OMElement element = JsonUtil.getNewJsonPayload(messageContext, inputStream, false, false);
             if (element != null) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("#processDocument. Built JSON payload from JSON stream. MessageID: " + messageContext.getMessageID());

--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
@@ -81,19 +81,4 @@ public final class JsonStreamBuilder implements Builder {
         }
         return envelope;
     }
-
-    /**
-     * Check whether the request HTTP method is required valid payload
-     *
-     * @param msgCtx Message Context of incoming request
-     * @return true if payload required, false otherwise
-     */
-    private boolean isValidPayloadRequired(MessageContext msgCtx) {
-        boolean isRequired = true;
-        if (HTTPConstants.HEADER_GET.equals(msgCtx.getProperty(HTTPConstants.HTTP_METHOD)) || HTTPConstants
-                .HEADER_DELETE.equals(msgCtx.getProperty(HTTPConstants.HTTP_METHOD))) {
-            isRequired = false;
-        }
-        return isRequired;
-    }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonStreamBuilder.java
@@ -49,18 +49,6 @@ public final class JsonStreamBuilder implements Builder {
                     logger.debug("#processDocument. Built JSON payload from JSON stream. MessageID: " + messageContext.getMessageID());
                 }
                 return element;
-            } else {
-                /*
-                * This method required to introduce due the GET request failure with query parameter and content-type=
-                * application/json. Because of the logic implemented with '=' sign below, it expects a valid JSON
-                * string as the query parameter value (string after '=' sign) for GET requests with application/json
-                * content type. Therefore it fails for requests like
-                * https://localhost:8243/services/customer?format=xml and throws axis fault. With this fix, HTTP
-                * method is checked and avoid throwing axis2 fault for GET requests.
-                 */
-                if (isValidPayloadRequired(messageContext)) {
-                    throw new AxisFault("No JSON payload provided.");
-                }
             }
         } else {
             EndpointReference endpointReference = messageContext.getTo();

--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
@@ -476,11 +476,11 @@ public final class JsonUtil {
             InputStream json = toReadOnlyStream(inputStream);
             messageContext.setProperty(ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM, json);
             // read ahead few characters to see if the stream is valid...
+            boolean isEmptyPayload = true;
+            boolean valid = false;
             try {
                 // check for empty/all-whitespace streams
                 int c = json.read();
-                boolean isEmptyPayload = true;
-                boolean valid = false;
                 while (c != -1 && c != '{' && c != '[') {
                     if (c != 32) {
                         isEmptyPayload = false;
@@ -498,26 +498,25 @@ public final class JsonUtil {
                     isObject = false;
                 }
                 json.reset();
-
-                if (!valid) {
-                    if (isEmptyPayload) {
-                        //This is a empty payload so return null without doing further processing.
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("#emptyJsonPayload found.MessageID: " + messageContext.getMessageID());
-                        }
-                        logger.debug("#emptyJsonPayload found.MessageID: " + messageContext.getMessageID());
-                        return null;
-                    }else {
-                        logger.error(
-                                "#newJsonPayload. Could not save JSON payload. Invalid input stream found. MessageID: " +
-                                messageContext.getMessageID());
-                        throw new AxisFault("Payload is not a JSON string.");
-                    }
-                }
             } catch (IOException e) {
                 logger.error("#newJsonPayload. Could not determine availability of the JSON input stream. MessageID: "
                         + messageContext.getMessageID() + ". Error>>> " + e.getLocalizedMessage());
                 return null;
+            }
+            if (!valid) {
+                if (isEmptyPayload) {
+                    //This is a empty payload so return null without doing further processing.
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("#emptyJsonPayload found.MessageID: " + messageContext.getMessageID());
+                    }
+                    logger.debug("#emptyJsonPayload found.MessageID: " + messageContext.getMessageID());
+                    return null;
+                } else {
+                    logger.error(
+                            "#newJsonPayload. Could not save JSON payload. Invalid input stream found. MessageID: " +
+                            messageContext.getMessageID());
+                    throw new AxisFault("Payload is not a JSON string.");
+                }
             }
             QName jsonElement = null;
             if (isObject) {

--- a/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonFormatterTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonFormatterTest.java
@@ -178,7 +178,7 @@ public class JsonFormatterTest extends TestCase {
 
             MessageFormatter formatter = Util.newJsonFormatter();
             MessageContext messageContext = Util.newMessageContext();
-            JsonUtil.newJsonPayload(messageContext, inputStream, false, false);
+            JsonUtil.getNewJsonPayload(messageContext, inputStream, false, false);
             OutputStream out = Util.newOutputStream();
             formatter.writeTo(messageContext, null, out, false);
             assertTrue(JsonDataSourceTest.expectedJSON.equals(out.toString()));
@@ -229,7 +229,7 @@ public class JsonFormatterTest extends TestCase {
         try {
             MessageFormatter formatter = Util.newJsonFormatter();
             MessageContext messageContext = Util.newMessageContext(xmlInput);
-            JsonUtil.newJsonPayload(messageContext, inputStream, false, false);
+            JsonUtil.getNewJsonPayload(messageContext, inputStream, false, false);
             OutputStream out = Util.newOutputStream();
             formatter.writeTo(messageContext, null, out, false);
             assertTrue(jsonOut.equals(out.toString()));

--- a/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonStreamingFormatterTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonStreamingFormatterTest.java
@@ -41,7 +41,7 @@ public class JsonStreamingFormatterTest extends TestCase {
             InputStream inputStream = Util.newInputStream(obj_1.getBytes());
             MessageFormatter formatter = Util.newJsonStreamFormatter();
             MessageContext messageContext = Util.newMessageContext();
-            JsonUtil.newJsonPayload(messageContext, inputStream, true, true);
+            JsonUtil.getNewJsonPayload(messageContext, inputStream, true, true);
             OutputStream out = Util.newOutputStream();
             formatter.writeTo(messageContext, null, out, false);
             assertTrue(obj_1.equals(out.toString()));

--- a/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
@@ -98,7 +98,6 @@ public abstract class AbstractListMediator extends AbstractMediator
         } finally {
             synCtx.setTracingState(parentsEffectiveTraceState);
         }
-
         return returnVal;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -169,7 +169,11 @@ public class PayloadFactoryMediator extends AbstractMediator {
                 handleException("Error creating SOAP Envelope from source " + out, synCtx);
             }
         } else if  (mediaType.equals(JSON_TYPE)) {
-            JsonUtil.newJsonPayload(axis2MessageContext, out, true, true);
+            try {
+                JsonUtil.newJsonPayload(axis2MessageContext, out, true, true);
+            } catch (AxisFault axisFault) {
+                handleException("Error creating JSON Payload from source " + out, synCtx);
+            }
         } else if  (mediaType.equals(TEXT_TYPE)) {
             JsonUtil.removeJsonPayload(axis2MessageContext);
             axis2MessageContext.getEnvelope().getBody().addChild(getTextElement(out));

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -170,7 +170,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
             }
         } else if  (mediaType.equals(JSON_TYPE)) {
             try {
-                JsonUtil.newJsonPayload(axis2MessageContext, out, true, true);
+                JsonUtil.getNewJsonPayload(axis2MessageContext, out, true, true);
             } catch (AxisFault axisFault) {
                 handleException("Error creating JSON Payload from source " + out, synCtx);
             }

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/commons/MessageConverter.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/commons/MessageConverter.java
@@ -40,7 +40,6 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -165,8 +164,7 @@ public final class MessageConverter {
             // XXX: always this section must come after the above step. ie. after applying Envelope.
             // That is to get the existing headers into the new envelope.
             if (axis2Msg.getJsonStream() != null) {
-                JsonUtil.newJsonPayload(axis2Ctx,
-                        new ByteArrayInputStream(axis2Msg.getJsonStream()), true, true);
+                JsonUtil.getNewJsonPayload(axis2Ctx, new ByteArrayInputStream(axis2Msg.getJsonStream()), true, true);
             }
             SynapseMessage synMsg = message.getSynapseMessage();
             synCtx.setTracingState(synMsg.getTracingState());

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -78,7 +78,7 @@ public class SynapseJsonPath extends SynapsePath {
                     if (stream == null) {
                         stream = JsonUtil.getJsonPayload(amc);
                     } else {
-                        JsonUtil.newJsonPayload(amc, stream, true, true);
+                        JsonUtil.getNewJsonPayload(amc, stream, true, true);
                     }
                 } else {
                     // Message Already built.

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -84,7 +84,12 @@ public class SynapseJsonPath extends SynapsePath {
                     // Message Already built.
                     stream = JsonUtil.toJsonStream(amc.getEnvelope().getBody().getFirstElement());
                 }
-                return stringValueOf(stream);
+                if(stream != null) {
+                    return stringValueOf(stream);
+                }else{
+                    log.warn("Json Payload is empty.");
+                    return "";
+                }
             } catch (IOException e) {
                 handleException("Could not find JSON Stream in PassThrough Pipe during JSON path evaluation.", e);
             }

--- a/modules/core/src/test/java/org/apache/synapse/TestMessageContextBuilder.java
+++ b/modules/core/src/test/java/org/apache/synapse/TestMessageContextBuilder.java
@@ -146,7 +146,8 @@ public class TestMessageContextBuilder {
             //synCtx = new Axis2MessageContext(null, testConfig, synEnv);
             SOAPEnvelope envelope = OMAbstractFactory.getSOAP11Factory().getDefaultEnvelope();
             synCtx.setEnvelope(envelope);
-            JsonUtil.newJsonPayload(((Axis2MessageContext) synCtx).getAxis2MessageContext(), contentStringJson, true, true);
+            JsonUtil.getNewJsonPayload(((Axis2MessageContext) synCtx).getAxis2MessageContext(), contentStringJson, true,
+                                       true);
             return synCtx;
         }
         

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
@@ -170,7 +170,7 @@ public class ScriptMessageContext implements MessageContext {
             jsonString = serializeJSON(jsonPayload);
         }
         try {
-            JsonUtil.newJsonPayload(messageContext, jsonString, true, true);
+            JsonUtil.getNewJsonPayload(messageContext, jsonString, true, true);
         } catch (AxisFault axisFault) {
             throw new ScriptException(axisFault);
         }
@@ -711,7 +711,7 @@ public class ScriptMessageContext implements MessageContext {
         }
         // save this JSON object as the new payload.
         try {
-            JsonUtil.newJsonPayload(messageContext, json, 0, json.length, true, true);
+            JsonUtil.getNewJsonPayload(messageContext, json, 0, json.length, true, true);
         } catch (AxisFault axisFault) {
             throw new ScriptException(axisFault);
         }

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
@@ -169,7 +169,11 @@ public class ScriptMessageContext implements MessageContext {
         } else {
             jsonString = serializeJSON(jsonPayload);
         }
-        JsonUtil.newJsonPayload(messageContext, jsonString, true, true);
+        try {
+            JsonUtil.newJsonPayload(messageContext, jsonString, true, true);
+        } catch (AxisFault axisFault) {
+            throw new ScriptException(axisFault);
+        }
         //JsonUtil.setContentType(messageContext);
         Object jsonObject = scriptEngine.eval('(' + jsonString + ')');
         setJsonObject(mc, jsonObject);
@@ -706,7 +710,11 @@ public class ScriptMessageContext implements MessageContext {
             }
         }
         // save this JSON object as the new payload.
-        JsonUtil.newJsonPayload(messageContext, json, 0, json.length, true, true);
+        try {
+            JsonUtil.newJsonPayload(messageContext, json, 0, json.length, true, true);
+        } catch (AxisFault axisFault) {
+            throw new ScriptException(axisFault);
+        }
         //JsonUtil.setContentType(messageContext);
         Object jsonObject = scriptEngine.eval(JsonUtil.newJavaScriptSourceReader(messageContext));
         setJsonObject(mc, jsonObject);


### PR DESCRIPTION
There are three main cases to be considered,

1. Different payload type is sent with JSON content type - With the fix it will throw an axis fault
2. Empty JSON payload sent with JSON content type & 
3. Non-empty JSON payload with JSON content type - Considered it as valid payload and continue with the processing