### PR TITLE
Revert "Not necessary to create XMLHelper again"

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -293,7 +293,8 @@ public class ScriptMediator extends AbstractMediator {
     private Object mediateWithExternalScript(MessageContext synCtx)
             throws ScriptException, NoSuchMethodException {
         ScriptEngineWrapper sew = prepareExternalScript(synCtx);
-        ScriptMessageContext scriptMC = new ScriptMessageContext(synCtx, xmlHelper);
+        XMLHelper helper = XMLHelper.getArgHelper(sew.getEngine());
+        ScriptMessageContext scriptMC = new ScriptMessageContext(synCtx, helper);
         processJSONPayload(synCtx, scriptMC);
         Invocable invocableScript = (Invocable) sew.getEngine();
 


### PR DESCRIPTION
Reverting this due to a Groovy test failure. 