### PR TITLE
Adding encode for REST_URL_POSTFIX

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -20,6 +20,8 @@
 package org.apache.synapse.mediators.builtin;
 
 import org.apache.axis2.context.OperationContext;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.SynapseException;
@@ -449,6 +451,19 @@ public class PropertyMediator extends AbstractMediator {
 				_headers.put(HTTP.CONTENT_TYPE, resultValue);
 			}
 		}
+
+        if (PassThroughConstants.REST_URL_POSTFIX.equals(name) && (resultValue instanceof String)) {
+            try {
+                String UTF_8 = "UTF-8";
+                String decodedValue = URIUtil.decode((String) resultValue, UTF_8);
+                String encodedValue = URIUtil.encodePathQuery(decodedValue, UTF_8);
+                axis2MessageCtx.setProperty(PassThroughConstants.REST_URL_POSTFIX, encodedValue);
+            } catch (URIException e) {
+                String msg = "Unable to decode/encode value";
+                log.error(msg, e);
+                throw new SynapseException(msg, e);
+            }
+        }
     }
 
 


### PR DESCRIPTION
This will encode the given rest_uri_postfix value (with charset UTF-8, [1])

Example:
```
<property name="REST_URL_POSTFIX" value="foo bar {" scope="axis2"/>
```

will results
```
wire << "GET /stockquote/foo%20bar%20%7B HTTP/1.1[\r][\n]"
```
URL Encoding is mandatory according to [1], therefore this property needs URL Encoded value. Else ESB converts to URL Encoded value while adding to message context.

[1] [RFC 3986] Uniform Resource Identifier (URI): Generic Syntax - http://tools.ietf.org/html/rfc3986