### PR TITLE
removing Content type header check

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/PassThroughTransportUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/PassThroughTransportUtils.java
@@ -155,11 +155,6 @@ public class PassThroughTransportUtils {
                 iter.remove();
             }
 
-            if (HTTP.CONTENT_TYPE.equalsIgnoreCase(headerName)
-                && !targetConfiguration.isPreserveHttpHeader(HTTP.CONTENT_TYPE)) {
-                iter.remove();
-            }
-
             if (HTTP.DATE_HEADER.equalsIgnoreCase(headerName)
                 && !targetConfiguration.isPreserveHttpHeader(HTTP.DATE_HEADER)) {
                 iter.remove();


### PR DESCRIPTION
Now we are using http.headers.preserve in  passthru-http.properties to preserve Content-Type header. However, as we always preserve Content-Type header and never removes it, we shouldn't always check if the header should be preserved. Therefore, this fix removes checking content-type header.
