### PR TITLE
Message injector to refer registry when fetching message

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/startup/tasks/MessageInjector.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/tasks/MessageInjector.java
@@ -21,6 +21,8 @@ package org.apache.synapse.startup.tasks;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMText;
+import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.util.UIDGenerator;
 import org.apache.axis2.AxisFault;
@@ -41,7 +43,11 @@ import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.task.Task;
 import org.apache.synapse.util.PayloadHelper;
 
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -105,6 +111,11 @@ public class MessageInjector implements Task, ManagedLifecycle {
      * Name of the proxy service which message should be injected
      */
     private String proxyName = null;
+
+    /**
+     * Registry path for message to inject
+     */
+    private String registryKey = null;
 
     /**
      * Store additional properties required at the runtime
@@ -185,6 +196,14 @@ public class MessageInjector implements Task, ManagedLifecycle {
         this.proxyName = proxyName;
     }
 
+    public String getRegistryKey() {
+        return registryKey;
+    }
+
+    public void setRegistryKey(String registryKey) {
+        this.registryKey = registryKey;
+    }
+
     /**
      * Set a property to be used at runtime. These properties will get inserted in message context created
      * at here
@@ -224,8 +243,8 @@ public class MessageInjector implements Task, ManagedLifecycle {
             return;
 		}
 
-		if (message == null) {
-            handleError("message not set");
+		if (message == null && registryKey == null) {
+            handleError("message or registry-key not set");
             return;
 		}
 
@@ -307,22 +326,63 @@ public class MessageInjector implements Task, ManagedLifecycle {
                 mc.setTo(new EndpointReference(to));
             }
 
-            if (format == null) {
-                PayloadHelper.setXMLPayload(mc, message.cloneOMElement());
-            } else {
-                try {
-                    if (SOAP11_FORMAT.equalsIgnoreCase(format)) {
-                        mc.setEnvelope(OMAbstractFactory.getSOAP11Factory().createSOAPEnvelope());
-                    } else if (SOAP12_FORMAT.equalsIgnoreCase(format)) {
-                        mc.setEnvelope(OMAbstractFactory.getSOAP12Factory().createSOAPEnvelope());
-                    } else if (POX_FORMAT.equalsIgnoreCase(format)) {
-                        mc.setDoingPOX(true);
-                    } else if (GET_FORMAT.equalsIgnoreCase(format)) {
-                        mc.setDoingGET(true);
-                    }
+            if (registryKey == null) {
+                if (format == null) {
                     PayloadHelper.setXMLPayload(mc, message.cloneOMElement());
+                } else {
+                    try {
+                        if (SOAP11_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setEnvelope(OMAbstractFactory.getSOAP11Factory().createSOAPEnvelope());
+                        } else if (SOAP12_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setEnvelope(OMAbstractFactory.getSOAP12Factory().createSOAPEnvelope());
+                        } else if (POX_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setDoingPOX(true);
+                        } else if (GET_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setDoingGET(true);
+                        }
+                        PayloadHelper.setXMLPayload(mc, message.cloneOMElement());
+                    } catch (AxisFault axisFault) {
+                        handleError("Error in setting the message payload : " + message);
+                    }
+                }
+            } else {
+                Object entry = mc.getEntry(registryKey);
+                if (entry == null) {
+                    handleError("Key " + registryKey + " not found ");
+                }
+                String text = "";
+                if (entry instanceof OMElement) {
+                    OMElement e = (OMElement) entry;
+                    removeIndentations(e);
+                    text = e.toString();
+                } else if (entry instanceof OMText) {
+                    text = ((OMText) entry).getText();
+                } else if (entry instanceof String) {
+                    text = (String) entry;
+                }
+
+                OMElement omXML = null;
+                try {
+                    omXML = AXIOMUtil.stringToOM(text);
+
+                    if (format == null) {
+                        PayloadHelper.setXMLPayload(mc, omXML);
+                    } else {
+                        if (SOAP11_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setEnvelope(OMAbstractFactory.getSOAP11Factory().createSOAPEnvelope());
+                        } else if (SOAP12_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setEnvelope(OMAbstractFactory.getSOAP12Factory().createSOAPEnvelope());
+                        } else if (POX_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setDoingPOX(true);
+                        } else if (GET_FORMAT.equalsIgnoreCase(format)) {
+                            mc.setDoingGET(true);
+                        }
+                        PayloadHelper.setXMLPayload(mc, omXML);
+                    }
+                } catch (XMLStreamException e) {
+                    handleError("Error parsing XML for JSON conversion, please check your property values return valid XML");
                 } catch (AxisFault axisFault) {
-                    handleError("Error in setting the message payload : " + message);
+                    handleError("Error in setting the message payload : " + omXML);
                 }
             }
 
@@ -375,6 +435,38 @@ public class MessageInjector implements Task, ManagedLifecycle {
     private void handleError(String msg) {
         log.error(msg);
         throw new SynapseException(msg);
+    }
+
+    /**
+     * Helper function to remove indentations.
+     * @param element
+     */
+    private void removeIndentations(OMElement element) {
+        List<OMText> removables = new ArrayList<OMText>();
+        removeIndentations(element, removables);
+        for (OMText node : removables) {
+            node.detach();
+        }
+    }
+
+    /**
+     * Helper function to remove indentations.
+     * @param element
+     * @param removables
+     */
+    private void removeIndentations(OMElement element, List<OMText> removables) {
+        Iterator children = element.getChildren();
+        while (children.hasNext()) {
+            Object next = children.next();
+            if (next instanceof OMText) {
+                OMText text = (OMText) next;
+                if (text.getText().trim().equals("")) {
+                    removables.add(text);
+                }
+            } else if (next instanceof OMElement) {
+                removeIndentations((OMElement) next, removables);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Adding a new parameter for MessageInjector to load the message payload from registry.

Sample config:
```
<task xmlns="http://ws.apache.org/ns/synapse" name="foo_task"
      class="org.apache.synapse.startup.tasks.MessageInjector"
      group="synapse.simple.quartz">
   <trigger count="5" interval="1"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks" name="registryKey" value="gov:/sample_payload.xml"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks" name="injectTo" value="sequence"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks" name="format" value="soap11"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks" name="sequenceName" value="test_seq"/>
</task>
```

**Important:** registry key should start with gov:, conf: prefixes. This is the similar behavior in getting payload format from registry.