### PR TITLE
Removed setters that enabled timeoutOn and timeoutDuration to differ.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/AsyncCallback.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/AsyncCallback.java
@@ -90,16 +90,13 @@ public class AsyncCallback implements AxisCallback {
         return timeOutOn;
     }
 
-    public void setTimeOutOn(long timeOutOn) {
-        this.timeOutOn = timeOutOn;
-    }
-
     public long getTimeoutDuration() {
         return timeoutDuration;
     }
 
-    public void setTimeoutDuration(long timeoutDuration) {
+    public void setTimeout(long timeoutDuration) {
         this.timeoutDuration = timeoutDuration;
+        this.timeOutOn = System.currentTimeMillis() + timeoutDuration;
     }
 
     public int getTimeOutAction() {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -490,19 +490,16 @@ public class Axis2FlexibleMEPClient {
                 // TimeoutHandler can detect timed out callbacks and take appropriate action.
                 if (!endpoint.isDynamicTimeoutEndpoint()) {
                     long endpointTimeout = endpoint.getEffectiveTimeout();
-                    callback.setTimeOutOn(System.currentTimeMillis() + endpointTimeout);
+                    callback.setTimeout(endpointTimeout);
                     callback.setTimeOutAction(endpoint.getTimeoutAction());
-                    callback.setTimeoutDuration(endpointTimeout);
                 } else {
                     long endpointTimeout = endpoint.evaluateDynamicEndpointTimeout(synapseOutMessageContext);
-                    callback.setTimeOutOn(System.currentTimeMillis() + endpointTimeout);
+                    callback.setTimeout(endpointTimeout);
                     callback.setTimeOutAction(endpoint.getTimeoutAction());
-                    callback.setTimeoutDuration(endpointTimeout);
                 }
             } else {
                 long globalTimeout = synapseOutMessageContext.getEnvironment().getGlobalTimeout();
-                callback.setTimeOutOn(System.currentTimeMillis() + globalTimeout);
-                callback.setTimeoutDuration(globalTimeout);
+                callback.setTimeout(globalTimeout);
             }
 
         }


### PR DESCRIPTION
Previously, a developer would have to remember to set both variables when modifying this logic -- otherwise the application would not work as expected.