### PR TITLE
Parameter for enable stats globally for all artifacts

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -54,6 +54,11 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 	                                       AspectConfiguration aspectConfiguration, ComponentType componentType) {
 		boolean isCollectingStatistics = (aspectConfiguration != null && aspectConfiguration.isStatisticsEnable());
 
+		// Enable statistics, if user enabled for all artifacts
+		if (!isCollectingStatistics) {
+			isCollectingStatistics = isCollectingStatistics || RuntimeStatisticCollector.isCollectingAllStatistics();
+		}
+
 		boolean isCollectingTracing = false;
 		if (isCollectingProperties() || isCollectingPayloads()) {
 			isCollectingTracing = (aspectConfiguration != null && aspectConfiguration.isTracingEnabled());
@@ -93,7 +98,7 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 			}
 
 			if (aspectConfiguration != null) {
-				statisticDataUnit.setIsIndividualStatisticCollected(aspectConfiguration.isStatisticsEnable());
+				statisticDataUnit.setIsIndividualStatisticCollected(isCollectingStatistics);
 			}
 			StatisticDataCollectionHelper.collectData(messageContext, true, isTracingEnabled, statisticDataUnit);
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -218,6 +218,7 @@ public abstract class RuntimeStatisticCollector {
 	 */
 	public static void setCollectingAllStatistics(boolean state) {
 		isCollectingAllStatistics = state;
+		log.info("Collecting statistics for all artifacts state changed to: " + state);
 	}
 
 	/**

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -25,6 +25,7 @@ import org.apache.synapse.aspects.flow.statistics.data.raw.BasicStatisticDataUni
 import org.apache.synapse.aspects.flow.statistics.log.StatisticEventProcessor;
 import org.apache.synapse.aspects.flow.statistics.log.templates.ParentReopenEvent;
 import org.apache.synapse.aspects.flow.statistics.store.MessageDataStore;
+import org.apache.synapse.aspects.flow.statistics.util.MediationFlowController;
 import org.apache.synapse.aspects.flow.statistics.util.StatisticDataCollectionHelper;
 import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
 import org.apache.synapse.config.SynapseConfigUtils;
@@ -56,6 +57,11 @@ public abstract class RuntimeStatisticCollector {
 	 * Is message context property collection enabled in synapse.properties file.
 	 */
 	private static boolean isCollectingProperties;
+
+	/**
+	 * Is collecting statistics of all artifacts
+	 */
+	private static boolean  isCollectingAllStatistics;
 
 	/**
 	 * Statistic event queue to hold statistic events.
@@ -95,6 +101,9 @@ public abstract class RuntimeStatisticCollector {
 				log.debug("Property collecting is not enabled in \'synapse.properties\' file.");
 			}
 
+			isCollectingAllStatistics = Boolean.parseBoolean(SynapsePropertiesLoader.getPropertyValue(
+					StatisticsConstants.COLLECT_ALL_STATISTICS, String.valueOf(false)));
+
 			statisticEventQueue = new MessageDataStore(queueSize);
 			//Thread to consume queue and update data structures for publishing
 			ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
@@ -109,7 +118,9 @@ public abstract class RuntimeStatisticCollector {
 					SynapseConfigUtils.getGlobalTimeoutInterval() + SynapseConfigUtils.getTimeoutHandlerInterval() +
 					eventConsumerTime;
 			log.info("Statistics Entry Expiration time set to " + eventExpireTime + " milliseconds");
+
 			StatisticEventProcessor.initializeCleaningThread();
+			new MediationFlowController();
 		} else {
 			if (log.isDebugEnabled()) {
 				log.debug("Statistics is not enabled in \'synapse.properties\' file.");
@@ -181,7 +192,7 @@ public abstract class RuntimeStatisticCollector {
 	 * @return true if need to collect payloads.
 	 */
 	public static boolean isCollectingPayloads() {
-		return isStatisticsEnabled & isCollectingPayloads;
+		return isStatisticsEnabled && isCollectingPayloads;
 	}
 
 	/**
@@ -190,7 +201,23 @@ public abstract class RuntimeStatisticCollector {
 	 * @return true if need to collect message-properties.
 	 */
 	public static boolean isCollectingProperties() {
-		return isStatisticsEnabled & isCollectingProperties;
+		return isStatisticsEnabled && isCollectingProperties;
+	}
+
+	/**
+	 * Return whether collecting statistics for all artifacts is enabled (this also needs isStatisticsEnabled)
+	 *
+	 * @return true if need to collect statistics for all artifacts
+     */
+	public static boolean isCollectingAllStatistics() {
+		return isStatisticsEnabled && isCollectingAllStatistics;
+	}
+
+	/**
+	 * Allow external to alter state of collecting statistics for all artifacts, during runtime
+	 */
+	public static void setCollectingAllStatistics(boolean state) {
+		isCollectingAllStatistics = state;
 	}
 
 	/**

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/MediationFlowController.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/MediationFlowController.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.synapse.aspects.flow.statistics.util;
+
+import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.commons.jmx.MBeanRegistrar;
+
+public class MediationFlowController implements MediationFlowControllerMXBean {
+    public MediationFlowController() {
+        MBeanRegistrar.getInstance().registerMBean(this, "Mediation Flow Statistic Controller", "MediationFlowStatisticController");
+    }
+
+    @Override
+    public boolean setCollectingAllStatistics(boolean state) {
+        RuntimeStatisticCollector.setCollectingAllStatistics(state);
+        return true;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/MediationFlowControllerMXBean.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/MediationFlowControllerMXBean.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p/>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.synapse.aspects.flow.statistics.util;
+
+public interface MediationFlowControllerMXBean {
+    public boolean setCollectingAllStatistics(boolean state);
+}

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
@@ -39,6 +39,11 @@ public class StatisticsConstants {
 	public final static String COLLECT_MESSAGE_PROPERTIES = "mediation.flow.statistics.tracer.collect.properties";
 
 	/**
+	 * Enable statistics collecting for all artifacts
+	 */
+	public final static String COLLECT_ALL_STATISTICS = "mediation.flow.statistics.collect.all";
+
+	/**
 	 * Flow statistic queue size.
 	 */
 	public static final String FLOW_STATISTICS_QUEUE_SIZE = "mediation.flow.statistics.queue.size";


### PR DESCRIPTION
This is providing a way to enable statistics across all artifacts in ESB. There are 2 ways you can achieve this.

Method 1:
Add "mediation.flow.statistics.collect.all=true" in synapse.properties file. This would essentially requires "mediation.flow.statistics.enable=true" & restart ESB.

Method 2:
Start ESB with "mediation.flow.statistics.enable=true" in synapse.properties file.
Login to JConsole -> org.apache.synapse -> Message Flow statistics controller -> setCollectingAllStatistics (true)
![image](https://cloud.githubusercontent.com/assets/1543384/16909422/4c1135c0-4cf0-11e6-9826-8222a1ac4799.png)

From either of methods, ESB starts collect statistics on all artifacts that is available.