### PR TITLE
fixing ESBJAVA-4724

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -137,11 +137,8 @@ public class RelayUtils {
             element = messageBuilder.getDocument(messageContext,
                     bufferedInputStream != null ? bufferedInputStream : in);
         } catch (Exception e) {
-            /*
-            Remove bufferedinputstream content & continue: (for large payloads)
-            reset bufferedInputStream can't be done in this situation
-            */
-            while ((bufferedInputStream.read()) > 0);
+            //Clearing the buffer when there is an exception occurred.
+            consumeAndDiscardMessage(messageContext);
             messageContext.setProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED, Boolean.TRUE);
             handleException("Error while building Passthrough stream", e);
         }


### PR DESCRIPTION
When the incoming payload is larger than the bytebuffer size, clearing only the bufferdInputStream, doesn't solve the issue. Hence consuming the remaining data from pipe and discarding it.