### PR TITLE
Fixing ESBJAVA-4891 & APIMANAGER-4200

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -21,11 +21,8 @@ import org.apache.http.nio.ContentDecoder;
 import org.apache.http.nio.ContentEncoder;
 import org.apache.http.nio.IOControl;
 import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
 import org.apache.synapse.transport.passthru.config.BaseConfiguration;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
-import org.apache.synapse.transport.passthru.config.SourceConfiguration;
-import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 
 import java.io.IOException;
@@ -391,8 +388,11 @@ public class Pipe {
             int readRemaining = buffer.remaining();
             int readPosition = buffer.position();
             setInputMode(buffer);
+            int writePosition = buffer.position();
             int writeRemaining = buffer.remaining();
-            return readRemaining == 0 && writeRemaining == readPosition;
+            // in this method we will return true when the buffer is full when reading didn't happened : writePosition == buffer.capacity() && readPosition == 0
+            // we will return true if we have consumed the message partially and when there is remaining to read
+            return (readRemaining == 0 && writeRemaining == readPosition) || (writePosition == buffer.capacity() && readPosition == 0);
         } finally {
             if (isInputMode) {
                 setInputMode(buffer);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/ControlledByteBuffer.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/ControlledByteBuffer.java
@@ -67,6 +67,10 @@ public class ControlledByteBuffer {
         return this.byteBuffer.position();
     }
 
+    public int capacity() {
+        return this.byteBuffer.capacity();
+    }
+
     public void put(byte b) {
         this.byteBuffer.put(b);
     }


### PR DESCRIPTION
This PR contains the fix to determine where we need to apply the consume and discard method. 
There are several incidents where we need to clear the buffer. like when the buffer is full. and also we need to clear the buffer if there is an error occurred during the middle of the message building.
