### PR TITLE
ESBJAVA-5018 Fix skipping wirelogs for particular regex pattern

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
@@ -27,6 +27,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseFactory;
 import org.apache.http.impl.nio.DefaultNHttpClientConnection;
+import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.nio.NHttpClientEventHandler;
 import org.apache.http.nio.NHttpMessageParser;
 import org.apache.http.nio.NHttpMessageWriter;
@@ -45,6 +46,7 @@ import java.net.SocketAddress;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectionKey;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
         implements UpgradableNHttpConnection {
@@ -333,12 +335,26 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
             this.writer.reset();
         }
 
+        private void printLog(final HttpRequest message) {
+            headerlog.debug(id + " >> " + message.getRequestLine().toString());
+            Header[] headers = message.getAllHeaders();
+            for (Header header : headers) {
+                headerlog.debug(id + " >> " + header.toString());
+            }
+        }
+
         public void write(final HttpRequest message) throws IOException, HttpException {
             if (message != null && headerlog.isDebugEnabled()) {
-                headerlog.debug(id + " >> " + message.getRequestLine().toString());
-                Header[] headers = message.getAllHeaders();
-                for (int i = 0; i < headers.length; i++) {
-                    headerlog.debug(id + " >> " + headers[i].toString());
+                String skipLogging = System.getProperty("skip.logging");
+                Object request = session.getAttribute("http.request");
+                if ("true".equals(skipLogging) && request != null) {
+                    String uri = ((HttpRequest) request).getRequestLine().toString();
+                    Pattern pattern = LoggingUtils.getSkipLoggingMatcher();
+                    if (pattern != null && !pattern.matcher(uri).find()) {
+                        printLog(message);
+                    }
+                } else {
+                    printLog(message);
                 }
             }
             if (message != null && accesslog.isInfoEnabled()) {
@@ -368,6 +384,14 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
             this.parser = parser;
         }
 
+        private void printLog(final HttpResponse message) {
+            headerlog.debug(id + " << " + message.getStatusLine().toString());
+            Header[] headers = message.getAllHeaders();
+            for (Header header : headers) {
+                headerlog.debug(id + " << " + header.toString());
+            }
+        }
+
         public void reset() {
             this.parser.reset();
         }
@@ -379,10 +403,16 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
         public HttpResponse parse() throws IOException, HttpException {
             HttpResponse message = this.parser.parse();
             if (message != null && headerlog.isDebugEnabled()) {
-                headerlog.debug(id + " << " + message.getStatusLine().toString());
-                Header[] headers = message.getAllHeaders();
-                for (int i = 0; i < headers.length; i++) {
-                    headerlog.debug(id + " << " + headers[i].toString());
+                String skipLogging = System.getProperty("skip.logging");
+                Object request = session.getAttribute("http.request");
+                if ("true".equals(skipLogging) && request != null) {
+                    String uri = ((HttpRequest) request).getRequestLine().toString();
+                    Pattern pattern = LoggingUtils.getSkipLoggingMatcher();
+                    if (pattern != null && !pattern.matcher(uri).find()) {
+                        printLog(message);
+                    }
+                } else {
+                    printLog(message);
                 }
             }
             if (message != null && accesslog.isInfoEnabled()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingUtils.java
@@ -31,11 +31,23 @@ import org.apache.http.nio.reactor.IOSession;
 import org.apache.http.nio.util.ByteBufferAllocator;
 import org.apache.http.params.HttpParams;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class LoggingUtils {
 
     public final static String HEADER_LOG_ID = "org.apache.synapse.transport.http.headers";
     public final static String WIRE_LOG_ID = "org.apache.synapse.transport.http.wire";
     public final static String ACCESS_LOG_ID = "org.apache.synapse.transport.http.access";
+    private final static Pattern SKIP_LOGGING_PATTERN;
+
+    static {
+        if (System.getProperty("skip.logging.pattern") != null) {
+            SKIP_LOGGING_PATTERN = Pattern.compile(System.getProperty("skip.logging.pattern"));
+        } else {
+            SKIP_LOGGING_PATTERN = null;
+        }
+    }
 
     public static NHttpClientEventHandler decorate(NHttpClientEventHandler handler) {
         Log log = LogFactory.getLog(handler.getClass());
@@ -63,6 +75,10 @@ public class LoggingUtils {
                 responseFactory,
                 allocator,
                 params);
+    }
+
+    public static Pattern getSkipLoggingMatcher() {
+        return SKIP_LOGGING_PATTERN;
     }
 
     public static DefaultNHttpServerConnection createServerConnection(

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/Wire.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/Wire.java
@@ -21,6 +21,7 @@ package org.apache.synapse.transport.http.conn;
 import java.nio.ByteBuffer;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.http.nio.reactor.IOSession;
@@ -52,7 +53,15 @@ class Wire {
                     buffer.insert(0, "\"");
                     buffer.insert(0, header);
                     if (isEnabled()) {
-                        this.log.debug(Thread.currentThread().getName() + " " + buffer.toString());
+                        String line = buffer.toString();
+                        String skipLogging = System.getProperty("skip.logging");
+                        if ("true".equals(skipLogging)) {
+                            Pattern pattern = LoggingUtils.getSkipLoggingMatcher();
+                            if (pattern != null && pattern.matcher(line).find()) {
+                                break;
+                            }
+                        }
+                        this.log.debug(Thread.currentThread().getName() + " " + line);
                     }
 //                    this.log.debug(buffer.toString());
                     synapseBuffer.append(tmpBuffer.toString());
@@ -71,7 +80,16 @@ class Wire {
             buffer.insert(0, '\"');
             buffer.insert(0, header);
             if (isEnabled()) {
-                this.log.debug(Thread.currentThread().getName() + " " + buffer.toString());
+                String line = buffer.toString();
+                String skipLogging = System.getProperty("skip.logging");
+                if ("true".equals(skipLogging)) {
+                    Pattern pattern = LoggingUtils.getSkipLoggingMatcher();
+                    if (pattern != null && !pattern.matcher(line).find()) {
+                        this.log.debug(Thread.currentThread().getName() + " " + line);
+                    }
+                } else {
+                    this.log.debug(Thread.currentThread().getName() + " " + line);
+                }
             }
             tmpBuffer.setLength(0);
             tmpBuffer.append(buffer.toString());


### PR DESCRIPTION
In this Pull request, we have introduced two system properties to enable skipping wire logs for particular regex pattern.

-Dskip.logging=true
-Dskip.logging.pattern=\/carbon*