### PR TITLE
Fix message processor not invoking fault sequence with hl7

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -139,8 +139,12 @@ public class ForwardingService implements Task, ManagedLifecycle {
     private boolean isDeactivatedAtStartup= false;
     
     private boolean isNonHTTP = false;
+
+	private boolean isHL7 = false;
     
     Pattern httpPattern = Pattern.compile("^(http|https):");
+
+	Pattern hl7Pattern = Pattern.compile("^(hl7):");
 	
 	public ForwardingService(MessageProcessor messageProcessor, BlockingMsgSender sender,
 	                         SynapseEnvironment synapseEnvironment, long threshouldInterval) {
@@ -433,6 +437,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	        if (endpointDefinition.getAddress() != null) {
 	            endpointReferenceValue = endpointDefinition.getAddress();
 	            isNonHTTP = !isHTTPEndPoint(endpointReferenceValue);
+		        isHL7 = isHL7Endpoint(endpointReferenceValue);
 	        } 
 			try {
 				// Send message to the client
@@ -468,7 +473,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 							outCtx = sender.send(ep, messageContext);
 						}
 
-                        if (isNonHTTP) {
+                        if (isNonHTTP && !isHL7) {
                             /*
                              * There is no status codes to deal with JMS eps. So
                              * merely set it as a success if there's no any
@@ -823,7 +828,17 @@ public class ForwardingService implements Task, ManagedLifecycle {
         Matcher match = httpPattern.matcher(epAddress);
         return match.find();
     }
-    
+
+	/**
+	 * Return true if this is a hl7 endpoint.
+	 * @param epAddress
+	 * @return true if endpoint starts with hl7
+     */
+	private boolean isHL7Endpoint(String epAddress) {
+		Matcher match = hl7Pattern.matcher(epAddress);
+		return match.find();
+	}
+
     /**
      * + * Used to determine the family of HTTP status codes to which the given
      * code

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -137,7 +137,10 @@ public class ForwardingService implements Task, ManagedLifecycle {
      * Specifies whether the service should be started as deactivated or not
      */
     private boolean isDeactivatedAtStartup= false;
-    
+
+    /**
+     * Specifies whether we should consider the response of the message in determining the success of message forwarding
+     */
     private boolean isResponseValidationNotRequired = false;
     
     Pattern httpPattern = Pattern.compile("^(http|https|hl7):");
@@ -431,9 +434,9 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			EndpointDefinition endpointDefinition = abstractEndpoint.getDefinition();
 			String endpointReferenceValue = null;
 	        if (endpointDefinition.getAddress() != null) {
-	            endpointReferenceValue = endpointDefinition.getAddress();
+		        endpointReferenceValue = endpointDefinition.getAddress();
 		        isResponseValidationNotRequired = !isResponseValidationRequiredEndpoint(endpointReferenceValue);
-	        } 
+	        }
 			try {
 				// Send message to the client
 				while (!isSuccessful && !isTerminated) {

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -138,13 +138,9 @@ public class ForwardingService implements Task, ManagedLifecycle {
      */
     private boolean isDeactivatedAtStartup= false;
     
-    private boolean isNonHTTP = false;
-
-	private boolean isHL7 = false;
+    private boolean isResponseValidationNotRequired = false;
     
-    Pattern httpPattern = Pattern.compile("^(http|https):");
-
-	Pattern hl7Pattern = Pattern.compile("^(hl7):");
+    Pattern httpPattern = Pattern.compile("^(http|https|hl7):");
 	
 	public ForwardingService(MessageProcessor messageProcessor, BlockingMsgSender sender,
 	                         SynapseEnvironment synapseEnvironment, long threshouldInterval) {
@@ -436,8 +432,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			String endpointReferenceValue = null;
 	        if (endpointDefinition.getAddress() != null) {
 	            endpointReferenceValue = endpointDefinition.getAddress();
-	            isNonHTTP = !isHTTPEndPoint(endpointReferenceValue);
-		        isHL7 = isHL7Endpoint(endpointReferenceValue);
+		        isResponseValidationNotRequired = !isResponseValidationRequiredEndpoint(endpointReferenceValue);
 	        } 
 			try {
 				// Send message to the client
@@ -473,7 +468,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 							outCtx = sender.send(ep, messageContext);
 						}
 
-                        if (isNonHTTP && !isHL7) {
+                        if (isResponseValidationNotRequired) {
                             /*
                              * There is no status codes to deal with JMS eps. So
                              * merely set it as a success if there's no any
@@ -504,7 +499,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
                          * If an exception is thrown in a JMS scenario then we
                          * have to consider it as a failure.
                          */
-                        if (isNonHTTP) {
+                        if (isResponseValidationNotRequired) {
                             isSuccessful = false;
 						} else if (outCtx != null && "true".equals(outCtx.getProperty(
 								ForwardingProcessorConstants.BLOCKING_SENDER_ERROR))) {
@@ -824,20 +819,10 @@ public class ForwardingService implements Task, ManagedLifecycle {
 
 	}
     
-    private boolean isHTTPEndPoint(String epAddress) {
+    private boolean isResponseValidationRequiredEndpoint(String epAddress) {
         Matcher match = httpPattern.matcher(epAddress);
         return match.find();
     }
-
-	/**
-	 * Return true if this is a hl7 endpoint.
-	 * @param epAddress
-	 * @return true if endpoint starts with hl7
-     */
-	private boolean isHL7Endpoint(String epAddress) {
-		Matcher match = hl7Pattern.matcher(epAddress);
-		return match.find();
-	}
 
     /**
      * + * Used to determine the family of HTTP status codes to which the given


### PR DESCRIPTION
When a hl7 endpoint is used with forwarding message processor, it goes
to reply sequence even after a transport failure. This commit fix this
issue. Fix issue https://github.com/wso2/product-ei/issues/388.