### PR TITLE
Make escaping quotes of JSON configurable

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -362,11 +362,15 @@ public class PayloadFactoryMediator extends AbstractMediator {
                     if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE) &&
                             (!trimmedReplacementValue.startsWith("{") && !trimmedReplacementValue.startsWith("["))) {
                         replacementValue = escapeSpecialChars(replacementValue);
-                        // skip double quotes if replacement is boolean or null or valid json number
-                        if (!trimmedReplacementValue.equals("true") && !trimmedReplacementValue.equals("false")
-                            && !trimmedReplacementValue.equals("null") && !validJsonNumber
-                                .matcher(trimmedReplacementValue).matches()) {
-                            replacementValue = "\"" + replacementValue + "\"";
+                        // Check for following property which will force the string to include quotes
+                        Object force_string_quote = synCtx.getProperty("QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON");
+                        if (force_string_quote != null && ((String) force_string_quote).equalsIgnoreCase("true")) {
+                            // skip double quotes if replacement is boolean or null or valid json number
+                            if (!trimmedReplacementValue.equals("true") && !trimmedReplacementValue.equals("false")
+                                    && !trimmedReplacementValue.equals("null") && !validJsonNumber
+                                    .matcher(trimmedReplacementValue).matches()) {
+                                replacementValue = "\"" + replacementValue + "\"";
+                            }
                         }
                     }
                     else if ((mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) &&


### PR DESCRIPTION
Fixes the issue where double quotes are escaped when a JSON double quoted string value is passed through arguments to payload mediator. Need to add below property to disable escaping quotes of valid JSON strings.
 ```xml
<property name="QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON" value="true"/>
```
This is to make change done in [ESBJAVA-5053]  to be configurable as it breaks the functionality of some connectors.