### PR TITLE
Stop VFS file processing during graceful shutdown

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -421,6 +421,10 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
                         log.debug("End Sorting the files.");
                     }                 
                     for (FileObject child : children) {
+                        // Stop processing any further when put to maintenance mode (shutting down or restarting)
+                        if (state != BaseConstants.STARTED) {
+                            return;
+                        }
                         /**
                          * Before starting to process another file, see whether the proxy is stopped or not.
                          */


### PR DESCRIPTION
By adding the following property (enabling blocking mode)

 <property name="ClientApiNonBlocking" scope="axis2" action="remove" />

the unprocessed files moving to processed directory reduces / moves to the failed directory.
Since a graceful shutdown is triggered the unprocessed files should be remain in the IN directory

The associated public JIRA is https://wso2.org/jira/browse/ESBJAVA-5076