### PR TITLE
[ESBJAVA-5075] Stopping synapse controller delays in order to execute complete flow.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/ServerManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerManager.java
@@ -271,9 +271,6 @@ public class ServerManager {
         // if the system is started then stop if not we are not happy
         if (serverState == ServerState.STARTED || serverState == ServerState.MAINTENANCE) {
 
-            // stop the SynapseController
-            synapseController.stop();
-
             // destroy the created Synapse Environment
             synapseController.destroySynapseEnvironment();
             serverContextInformation.setSynapseEnvironment(null);
@@ -281,6 +278,9 @@ public class ServerManager {
             // destroy the created Synapse Configuration
             synapseController.destroySynapseConfiguration();
             serverContextInformation.setSynapseConfiguration(null);
+
+            // stop the SynapseController
+            synapseController.stop();
 
             changeState(ServerState.STOPPED);
         } else {


### PR DESCRIPTION
When ESB is shutdown, it is needed to close the Inbound Endpoint. With the existing code, it does not happen due to stopping Synapse Controller.
This fix has delayed the stopping Synapse Controller, so Inbound Endpoint can be closed.