### PR TITLE
[VFS]Check service activation before processing file

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -422,7 +422,8 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
                     }                 
                     for (FileObject child : children) {
                         // Stop processing any further when put to maintenance mode (shutting down or restarting)
-                        if (state != BaseConstants.STARTED) {
+                        // Stop processing when service get undeployed
+                        if (state != BaseConstants.STARTED || !entry.getService().isActive()) {
                             return;
                         }
                         /**


### PR DESCRIPTION
This is to fix the issue of VFS proxy service processing the polled files even after service get undeployed.
Related JIRA : https://wso2.org/jira/browse/ESBJAVA-5093