### PR TITLE
Fix NullPointerException when using key-expression when request burst just after startup

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
@@ -96,7 +96,9 @@ public class ResolvingEndpoint extends AbstractEndpoint {
             Endpoint ep = synCfg.getEndpoint(key);
             if (ep != null && !ep.isInitialized()) {
                 synchronized (ep) {
-                    ep.init(synapseEnvironment);
+                    if (!ep.isInitialized()) {
+                        ep.init(synapseEnvironment);
+                    }
                 }
             }
             return ep;


### PR DESCRIPTION
This fix thread synchronization issue due to lazy initialization of endpoint when resolving the endpoint during request burst just after startup. This is cause due to AbstractEndpoint updating EP as initialized before LoadbalanceEndpoint get completely initialized with relevant object initialization. During request burst threads check whether initialization is completed and continue using member objects of LoadbalanceEndpoint which cause NPE
Fix:https://wso2.org/jira/browse/ESBJAVA-5089
