### PR TITLE
Fix for Failover Endpoint Not Retrying 

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -356,6 +356,8 @@ public class Pipe {
     }
 
     public void forceSetSerializationRest(){
+        // If the pipe is reused to send the message out (ex. Failover endpoint retry), need to reset
+        consumerError = false;
         if(this.serializationComplete){
             this.serializationComplete = false;
         }


### PR DESCRIPTION
When "connection reset by peer" exception occurs failover endpoints never made a retry. This fix is to make retry in such exception in failover endpoints.

JIRA: https://wso2.org/jira/browse/ESBJAVA-5120