### PR TITLE
Fix [EI-705] - JSON-Schema Validation Issue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -269,10 +269,10 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
                     //there is only one element in the report
                     if (itrErrorMessages.hasNext()) {
                         ProcessingMessage processingMessage = itrErrorMessages.next();
-                        synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, processingMessage.getMessage());
-                        synCtx.setProperty(SynapseConstants.ERROR_DETAIL, processingMessage.asException()
-                                .getMessage());
-                        synCtx.setProperty(SynapseConstants.ERROR_EXCEPTION, processingMessage.asException());
+                        String errorMessage = processingMessage.getMessage();
+                        synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, errorMessage);
+                        synCtx.setProperty(SynapseConstants.ERROR_DETAIL, "Error while validating Json message "
+                                + errorMessage);
                     }
                     // super.mediate() invokes the "on-fail" sequence of mediators
                     ContinuationStackManager.addReliantContinuationState(synCtx, 0, getMediatorPosition());


### PR DESCRIPTION
Fixing issue of validation fail after unsuccessful validation.
Please refer issue [1] for detail. Fix is to reset the varibles
in validate mediator upon an exception.

[1]. https://github.com/wso2/product-ei/issues/705