### PR TITLE
[ESBJAVA-5202] - Log mediator does not behave correctly when XML element is an element that stores a sourced JSON payload

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -197,7 +197,7 @@ public class LogMediator extends AbstractMediator {
         sb.append(getSimpleLogMessage(synCtx));
         try {
             org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-            if (JsonUtil.hasAJsonPayload(a2mc)) {
+            if (JsonUtil.hasAJsonPayload(a2mc) && synCtx.getEnvelope() == null) {
                 sb.append(separator).append("Payload: ").append(JsonUtil.jsonPayloadToString(a2mc));
             } else if (synCtx.getEnvelope() != null) {
                 sb.append(separator).append("Envelope: ").append(synCtx.getEnvelope());

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -197,6 +197,8 @@ public class LogMediator extends AbstractMediator {
         sb.append(getSimpleLogMessage(synCtx));
         try {
             org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+            // If there is a XML element which store sourced JSON payload, synCtx.getEnvelope() will not be null.
+            // So need to check it also to avoid log in JSON format i.e. {"value" : "test"}
             if (JsonUtil.hasAJsonPayload(a2mc) && synCtx.getEnvelope() == null) {
                 sb.append(separator).append("Payload: ").append(JsonUtil.jsonPayloadToString(a2mc));
             } else if (synCtx.getEnvelope() != null) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -199,10 +199,11 @@ public class LogMediator extends AbstractMediator {
             org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
             // If there is a XML element which store sourced JSON payload, synCtx.getEnvelope() will not be null.
             // So need to check it also to avoid log in JSON format i.e. {"value" : "test"}
-            if (JsonUtil.hasAJsonPayload(a2mc) && synCtx.getEnvelope() == null) {
-                sb.append(separator).append("Payload: ").append(JsonUtil.jsonPayloadToString(a2mc));
-            } else if (synCtx.getEnvelope() != null) {
+            if (synCtx.getEnvelope() != null) {
                 sb.append(separator).append("Envelope: ").append(synCtx.getEnvelope());
+            }
+            else if (JsonUtil.hasAJsonPayload(a2mc)) {
+                sb.append(separator).append("Payload: ").append(JsonUtil.jsonPayloadToString(a2mc));
             }
         } catch (Exception e) {
             SOAPEnvelope envelope = synCtx.isSOAP11() ? OMAbstractFactory.getSOAP11Factory().getDefaultEnvelope()


### PR DESCRIPTION
This PR fixes the behavior of Log mediator for XML elements which store sourced JSON payload.