### PR TITLE
prevent scinetific convertion for long numbers in setPayloadJSON

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMessageContext.java
@@ -797,15 +797,16 @@ public class ScriptMessageContext implements MessageContext {
             out.write('"');
             out.write((((ConsString) obj).toString()).getBytes());
             out.write('"');
-        } else if (obj instanceof Integer ||
-                obj instanceof Long ||
-                obj instanceof Float ||
-                obj instanceof Double ||
-                obj instanceof Short ||
-                obj instanceof BigInteger ||
-                obj instanceof BigDecimal ||
-                obj instanceof Boolean) {
-            out.write(obj.toString().getBytes());
+        } else if (obj instanceof Number) {   
+        	
+        	if(((Number)obj).longValue() - ((Number)obj).doubleValue() == 0)
+    			out.write(String.format("%.0f", obj).getBytes());
+    		else
+    			out.write(obj.toString().getBytes());
+        	
+        } else if(obj instanceof Boolean) {
+        	out.write(obj.toString().getBytes());
+        	
         } else {
             out.write('{');
             out.write('}');

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorTest.java
@@ -137,6 +137,7 @@ public class ScriptMediatorTest extends TestCase {
                 "        l.name = location_object.name;\n" +
                 "        l.tags = location_object.types;\n" +
                 "        l.id = \"ID:\" + (location_object.id);\n" +
+                "        l.long_id = 123456789123 + i\n" +
                 "        response[i] = l;\n" +
                 "    }\n" +
                 "    mc.setPayloadJSON(response);\n" +
@@ -153,7 +154,7 @@ public class ScriptMediatorTest extends TestCase {
         ScriptMediator mediator = new ScriptMediator("js", new LinkedHashMap<Value, Object>(), v, "transform", null);
         boolean result = mediator.mediate(mc);
         String response = JsonUtil.jsonPayloadToString(((Axis2MessageContext) mc).getAxis2MessageContext());
-        String expectedResponse = "[{\"name\":\"Biaggio Cafe\", \"tags\":[\"bar\", \"restaurant\", \"food\", \"establishment\"], \"id\":\"ID:7eaf7\"}, {\"name\":\"Doltone House\", \"tags\":[\"food\", \"establishment\"], \"id\":\"ID:3ef98\"}]";
+        String expectedResponse = "[{\"name\":\"Biaggio Cafe\", \"tags\":[\"bar\", \"restaurant\", \"food\", \"establishment\"], \"id\":\"ID:7eaf7\", \"long_id\":123456789123}, {\"name\":\"Doltone House\", \"tags\":[\"food\", \"establishment\"], \"id\":\"ID:3ef98\", \"long_id\":123456789124}]";
         assertEquals(expectedResponse, response);
         assertEquals(true, result);
     }


### PR DESCRIPTION
prevent scinetific convertion for long numbers in setPayloadJSON (example: 1234567 converts to 1.234567E6)