### PR TITLE
[EI-580]Add "buildMessage" attribute to the failover and loadbalance endpoints

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointFactory.java
@@ -80,6 +80,15 @@ public class FailoverEndpointFactory extends EndpointFactory {
             if (dynamicFO != null && JavaUtils.isFalseExplicitly(dynamicFO)) {
                 failoverEndpoint.setDynamic(false);
             }
+
+            //set buildMassage property
+            String  buildMessageAtt = failoverElement.getAttributeValue(new QName("buildMessage"));
+            if (buildMessageAtt != null) {
+                failoverEndpoint.setBuildMessageAttAvailable(true);
+                if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {
+                    failoverEndpoint.setBuildMessageAtt(true);
+                }
+            }
             
             // process the parameters
             processProperties(failoverEndpoint, epConfig);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointFactory.java
@@ -22,15 +22,21 @@ package org.apache.synapse.config.xml.endpoints;
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.clustering.Member;
+import org.apache.axis2.util.JavaUtils;
+import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.xml.endpoints.utils.LoadbalanceAlgorithmFactory;
 import org.apache.synapse.config.xml.XMLConfigConstants;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.LoadbalanceEndpoint;
 import org.apache.synapse.endpoints.algorithms.LoadbalanceAlgorithm;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Iterator;
@@ -132,6 +138,15 @@ public final class LoadbalanceEndpointFactory extends EndpointFactory {
             String failover = loadbalanceElement.getAttributeValue(new QName("failover"));
             if (failover != null && failover.equalsIgnoreCase("false")) {
                 loadbalanceEndpoint.setFailover(false);
+            }
+
+            //set buildMessage attribute
+            String  buildMessageAtt = loadbalanceElement.getAttributeValue(new QName("buildMessage"));
+            if (buildMessageAtt != null) {
+                loadbalanceEndpoint.setBuildMessageAttAvailable(true);
+                if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {
+                    loadbalanceEndpoint.setBuildMessageAtt(true);
+                }
             }
 
             // process the parameters

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
@@ -119,14 +119,13 @@ public class FailoverEndpoint extends AbstractEndpoint {
                 log.debug(this + " Building the SoapEnvelope");
             }
             //preserving the payload to send next endpoint if needed
-            //If buildMessage attribute available in failover config it is honoured.
-            //else global property is considered
+            // If buildMessage attribute available in failover config it is honoured, else global property is considered
             if (isBuildMessageAttAvailable) {
                 if (buildMessageAtt) {
                     buildMessage(synCtx);
                 }
             } else if (buildMessage) {
-               buildMessage(synCtx);
+                buildMessage(synCtx);
             }
             synCtx.getEnvelope().buildWithAttachments();
             //If the endpoint failed during the sending, we need to keep the original envelope and reuse that for other endpoints
@@ -314,8 +313,7 @@ public class FailoverEndpoint extends AbstractEndpoint {
         try {
             RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
         } catch (IOException | XMLStreamException ex) {
-            String msg = "Error while building the message";
-            handleException(msg, ex);
+            handleException("Error while building the message", ex);
 
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -197,8 +197,7 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
                 // may have to retry this message for failover support
                 if (failover) {
                     //preserving the payload to send next endpoint if needed
-                    //If buildMessage attribute available in failover config it is honoured.
-                    //else global property is considered
+                    // If buildMessage attribute available in LB config it is used, else global property is considered
                     if (isBuildMessageAttAvailable) {
                         if (buildMessageAtt) {
                             buildMessage(synCtx);
@@ -509,8 +508,7 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
         try {
             RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
         } catch (IOException | XMLStreamException ex) {
-            String msg = "Error while building the message";
-            handleException(msg, ex);
+            handleException("Error while building the message", ex);
 
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -94,6 +94,16 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
     /** check message need to be built before sending */
     private boolean buildMessage = false;
 
+    /**
+     * Check if buildMessage attribute explicitly mentioned in config
+     */
+    private boolean isBuildMessageAttAvailable = false;
+
+    /**
+     * Overwrite the global synapse property build.message.on.failover.enable. Default false.
+     */
+    private boolean buildMessageAtt = false;
+
     @Override
     public void init(SynapseEnvironment synapseEnvironment) {
         ConfigurationContext cc =
@@ -187,15 +197,16 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
                 // may have to retry this message for failover support
                 if (failover) {
                     //preserving the payload to send next endpoint if needed
-                    if(buildMessage) {
-                        try {
-                            RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
-                        } catch (IOException | XMLStreamException ex) {
-                            String msg = "Error while building the message";
-                            handleException(msg, ex);
-
+                    //If buildMessage attribute available in failover config it is honoured.
+                    //else global property is considered
+                    if (isBuildMessageAttAvailable) {
+                        if (buildMessageAtt) {
+                            buildMessage(synCtx);
                         }
+                    } else if (buildMessage) {
+                        buildMessage(synCtx);
                     }
+
                     synCtx.getEnvelope().buildWithAttachments();
                     //If the endpoint failed during the sending, we need to keep the original envelope and reuse that for other endpoints
                     if (Boolean.TRUE.equals(((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(
@@ -479,6 +490,28 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
                 }
             }
             return false;
+        }
+    }
+
+    public void setBuildMessageAtt(boolean build) {
+        this.buildMessageAtt = build;
+    }
+
+    public void setBuildMessageAttAvailable(boolean available) {
+        this.isBuildMessageAttAvailable = available;
+    }
+
+    /**
+     * Build the message
+     * @param synCtx Synapse Context
+     */
+    private void buildMessage(MessageContext synCtx) {
+        try {
+            RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
+        } catch (IOException | XMLStreamException ex) {
+            String msg = "Error while building the message";
+            handleException(msg, ex);
+
         }
     }
 }


### PR DESCRIPTION
This attribute allows overwriting the global property
"build.message.on.failover.enable" for a single endpoint config .
Fix https://github.com/wso2/product-ei/issues/580