### PR TITLE
Fix ESBJAVA-5205

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -585,15 +585,18 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
 
                 try {
                     formatter.writeTo(msgContext, format, out, false);
-                }catch (RemoteException fault){
+                } catch (RemoteException fault) {
                     IOUtils.closeQuietly(out);
                     throw fault;
+                } finally {
+                    //Serialization should be set as complete so that the state of the socket can be
+                    // reset to readable
+                    pipe.setSerializationComplete(true);
                 }
-                pipe.setSerializationComplete(true);
                 out.close();
             }
             
-             conn.requestOutput();
+            conn.requestOutput();
         } else {
             // nothing much to do as we have started the response already
             if (errorCode != null) {


### PR DESCRIPTION
The issue occurs when the communication between the backend and the
server is brought down while the backend responds. CPU starts spinning
since the client socket is marked writable and there is no content to
be written due to an exception that has occurred when serializing the
content.
Resolves: https://wso2.org/jira/browse/ESBJAVA-5205