### PR TITLE
Fix ESBJAVA-5206

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
@@ -141,9 +141,15 @@ public class EIPUtils {
                 }
             }
             enrichingElement = envelope.getBody();
-            if (list != null) {
-                addChildren(list, enrichingElement);
+            //This has to introduce because if on complete expression written to extract SOAPEnvelop ex: "."
+            // then StAXOMBuilder end up in while loop that never exit. This cause to OOM the ESB. Hence the fix is to
+            // validate child element is a SOAPEnvelop
+            for (Object child : list) {
+                if (child instanceof SOAPEnvelope) {
+                    throw new SynapseException("Could not add SOAPEnvelope as child element.");
+                }
             }
+            addChildren(list, enrichingElement);
         } else {
             throw new SynapseException("Could not find matching elements to aggregate.");
         }


### PR DESCRIPTION
This issue was ESB getting OOM when onComplete XPath expression set to "." in the aggregate mediator.
The reason was aggregate mediator enrich messages and with above XPath expression, child element extract as SOAPEnvelop. Then add SOAPEnvelop to SOAPEnvelop end up in while loop in StAXOMBuilder which never exit. Hence fix is to check whether child element is an SOAPEnvelop, then throw an exception.