### PR TITLE
Update Aggregate mediator timeout error handling code

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
@@ -230,7 +230,7 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
                                     correlateExpression.toString(),
                                     completionTimeoutMillis,
                                     minMsg.intValue(),
-                                    maxMsg.intValue(), this);
+                                    maxMsg.intValue(), this, synCtx.getFaultStack().peek());
 
                             if (completionTimeoutMillis > 0) {
                                 synCtx.getConfiguration().getSynapseTimer().
@@ -290,7 +290,7 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
                                         correlation,
                                         completionTimeoutMillis,
                                         minMsg.intValue(),
-                                        maxMsg.intValue(), this);
+                                        maxMsg.intValue(), this, synCtx.getFaultStack().peek());
 
                                 if (completionTimeoutMillis > 0) {
                                     synchronized(aggregate) {


### PR DESCRIPTION
- Invoke the error handler of the closest sequence mediator on the call stack when an error occurs on aggregate mediator timeout condition.

Issue: https://github.com/wso2/product-ei/issues/758