### PR TITLE
[EI-TOOL-74] Fix for Log Separator in Log mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -244,13 +244,9 @@ public class LogMediator extends AbstractMediator {
     }
 
     public void setSeparator(String separator) {
-        if (separator.equals("\\n")) {
-            this.separator = "\n";
-        } else {
-            this.separator = separator;
-        }
+        this.separator = separator.replace("\\n", "\n").replace("\\t", "\t");
     }
-        
+
     public void addProperty(MediatorProperty p) {
         properties.add(p);
     }


### PR DESCRIPTION
When you add "\t" in the log separator field in design view of the log mediator, it is not converted into relevant encoded characters when you switch into source view (Dev Studio). Fixed this issue.
Related issue : https://github.com/wso2/devstudio-tooling-ei/issues/74