### PR TITLE
[EI-723] Fix ClassCastException when using fn:exists function

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
@@ -529,7 +529,8 @@ public class SynapseXPath extends SynapsePath {
         domXpath.setNamespaceContext(domNamespaceMap);
         domXpath.setXPathFunctionResolver(new GetPropertyFunctionResolver(synCtx));
         domXpath.setXPathVariableResolver(new DOMSynapseXPathVariableResolver(this.getVariableContext(), synCtx));
-        XPathExpression expr = domXpath.compile(this.getRootExpr().getText());
+        /* Compile the original expression again with Saxon to be evaluated with XPath 2.0 */
+        XPathExpression expr = domXpath.compile(getExpression());
         Object result = expr.evaluate(doomElement);
 
         if (result != null) {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-ei/issues/723

When an XPath is configured, Synapse will compile with jaxon and save it. When evaluating it in message flow synapse will initially try it with jaxon and if it gives an exception (and XPath 2 is configured) it will run it with saxon XPath 2.

Initially, Saxon didn't get the original expression but a changed version that comes through the compiled expression of the jaxon. But this can be changed from the original expression such as integers changed to decimals. 

With this fix, saxon will also use the original expression, not the one that comes through jaxon.