### PR TITLE
Revert "[EI_TOOL-72]Fix for clone attribute in Enrich mediator"

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
@@ -98,8 +98,6 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
         OMAttribute cloneAttr = sourceEle.getAttribute(ATT_CLONE);
         if (cloneAttr != null && cloneAttr.getAttributeValue() != null) {
             source.setClone(Boolean.parseBoolean(cloneAttr.getAttributeValue()));
-        } else {
-            source.setClone(false);
         }
 
         if (source.getSourceType() == EnrichMediator.CUSTOM) {


### PR DESCRIPTION
Reverts wso2/wso2-synapse#786 since it's changing the default behaviour of the clone attribute of the enrich mediator