### PR TITLE
Modified empty query param implementation

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/templates/uri/parser/Node.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/templates/uri/parser/Node.java
@@ -70,6 +70,10 @@ public abstract class Node {
             {
                 return matchLength;
             }
+            if (next.getToken().startsWith("{")) {
+                uriFragment = uriFragment.substring(matchLength);
+                return matchLength + next.matchAll(uriFragment, variables);
+            }
             // We have matched all the characters in the URI
             // But there are some nodes left to be matched against
             return -1;

--- a/modules/commons/src/test/java/org/apache/synapse/commons/templates/uri/parser/ParserTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/templates/uri/parser/ParserTest.java
@@ -219,6 +219,15 @@ public class ParserTest extends TestCase {
         assertFalse(template.matches("/sanjeewa/test", var));
         var.clear();
 
+        template = new URITemplate("/pattern1?latitude={+latitude}&longitude={+longitude}&floor={+floor}");
+        assertTrue(template.matches("/pattern1?latitude=10&longitude=20&floor=", var));
+        var.clear();
+        assertTrue(template.matches("/pattern1?latitude=10&longitude=&floor=30", var));
+        var.clear();
+        assertTrue(template.matches("/pattern1?latitude=&longitude=20&floor=30", var));
+        var.clear();
+        assertTrue(template.matches("/pattern1?latitude=&longitude=&floor=", var));
+        var.clear();
     }
 
     public void testReservedStringExpansion() throws Exception {


### PR DESCRIPTION
There was regression issue with the previous fix for empty query params in uri-template and implementation changed.