### PR TITLE
[EI-909] Add "buildMessage" attribute to management console

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointSerializer.java
@@ -49,6 +49,7 @@ public class FailoverEndpointSerializer extends EndpointSerializer {
         endpointElement.addChild(failoverElement);
 
         serializeCommonAttributes(endpoint,endpointElement);
+        failoverElement.addAttribute("buildMessage", Boolean.toString(failoverEndpoint.isBuildMessageAtt()), null);
 
         for (Endpoint childEndpoint : failoverEndpoint.getChildren()) {
             failoverElement.addChild(EndpointSerializer.getElementFromEndpoint(childEndpoint));

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointSerializer.java
@@ -61,6 +61,8 @@ public class LoadbalanceEndpointSerializer extends EndpointSerializer {
             loadbalanceElement.addAttribute("failover", "false", null);
         }
 
+        loadbalanceElement.addAttribute("buildMessage", Boolean.toString(loadbalanceEndpoint.isBuildMessageAtt()), null);
+
         // Serialize endpoint elements which are children of the loadbalance element
         if (loadbalanceEndpoint.getChildren() != null) {
             for (Endpoint childEndpoint : loadbalanceEndpoint.getChildren()) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointFactory.java
@@ -21,6 +21,7 @@ package org.apache.synapse.config.xml.endpoints;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
+import org.apache.axis2.util.JavaUtils;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.endpoints.utils.LoadbalanceAlgorithmFactory;
 import org.apache.synapse.endpoints.Endpoint;
@@ -120,6 +121,15 @@ public class SALoadbalanceEndpointFactory extends EndpointFactory {
             LoadbalanceAlgorithm algorithm = LoadbalanceAlgorithmFactory.
                     createLoadbalanceAlgorithm(loadbalanceElement, endpoints);
             loadbalanceEndpoint.setAlgorithm(algorithm);
+
+            //set buildMessage attribute
+            String  buildMessageAtt = loadbalanceElement.getAttributeValue(new QName("buildMessage"));
+            if (buildMessageAtt != null) {
+                loadbalanceEndpoint.setBuildMessageAttAvailable(true);
+                if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {
+                    loadbalanceEndpoint.setBuildMessageAtt(true);
+                }
+            }
 
             // process the parameters
             processProperties(loadbalanceEndpoint, epConfig);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointSerializer.java
@@ -85,6 +85,7 @@ public class SALoadbalanceEndpointSerializer extends EndpointSerializer {
         loadbalanceElement.addAttribute(XMLConfigConstants.LOADBALANCE_ALGORITHM,
                 loadbalanceEndpoint.getAlgorithm().getClass().getName(),
                 null);
+        loadbalanceElement.addAttribute("buildMessage", Boolean.toString(loadbalanceEndpoint.isBuildMessageAtt()), null);
 
         for (Endpoint childEndpoint : loadbalanceEndpoint.getChildren()) {
             loadbalanceElement.addChild(EndpointSerializer.getElementFromEndpoint(childEndpoint));

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
@@ -285,6 +285,10 @@ public class FailoverEndpoint extends AbstractEndpoint {
         return dynamic;
     }
 
+    public boolean isBuildMessageAtt() {
+        return buildMessageAtt;
+    }
+
     public void setDynamic(boolean dynamic) {
         this.dynamic = dynamic;
     }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -365,6 +365,10 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
         return failover;
     }
 
+    public boolean isBuildMessageAtt() {
+        return buildMessageAtt;
+    }
+
     public void setFailover(boolean failover) {
         this.failover = failover;
     }


### PR DESCRIPTION
Fix the issue of not supporting "buildMessage" attribute of failover and loadbalance endpoint in the management console.
Related issue : wso2/product-ei#909