### PR TITLE
[EI-909] Add "buildMessage" attribute to management console

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
@@ -114,6 +114,7 @@ public class XMLConfigConstants {
 
 	public static final String LOADBALANCE_POLICY = "policy";
 	public static final String LOADBALANCE_ALGORITHM = "algorithm";
+	public static final String BUILD_MESSAGE = "buildMessage";
 
     //TODO FIX-RUWAN
     public static final String ALGORITHM_NAME = "policy";

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointFactory.java
@@ -22,6 +22,7 @@ package org.apache.synapse.config.xml.endpoints;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.FailoverEndpoint;
 import org.apache.axis2.util.JavaUtils;
@@ -82,7 +83,7 @@ public class FailoverEndpointFactory extends EndpointFactory {
             }
 
             //set buildMassage property
-            String  buildMessageAtt = failoverElement.getAttributeValue(new QName("buildMessage"));
+            String  buildMessageAtt = failoverElement.getAttributeValue(new QName(XMLConfigConstants.BUILD_MESSAGE));
             if (buildMessageAtt != null) {
                 failoverEndpoint.setBuildMessageAttAvailable(true);
                 if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/FailoverEndpointSerializer.java
@@ -22,6 +22,7 @@ package org.apache.synapse.config.xml.endpoints;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.FailoverEndpoint;
 
@@ -49,6 +50,10 @@ public class FailoverEndpointSerializer extends EndpointSerializer {
         endpointElement.addChild(failoverElement);
 
         serializeCommonAttributes(endpoint,endpointElement);
+
+        if (failoverEndpoint.isBuildMessageAtt()) {
+            failoverElement.addAttribute(XMLConfigConstants.BUILD_MESSAGE, Boolean.toString(failoverEndpoint.isBuildMessageAtt()), null);
+        }
 
         for (Endpoint childEndpoint : failoverEndpoint.getChildren()) {
             failoverElement.addChild(EndpointSerializer.getElementFromEndpoint(childEndpoint));

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointFactory.java
@@ -141,7 +141,7 @@ public final class LoadbalanceEndpointFactory extends EndpointFactory {
             }
 
             //set buildMessage attribute
-            String  buildMessageAtt = loadbalanceElement.getAttributeValue(new QName("buildMessage"));
+            String  buildMessageAtt = loadbalanceElement.getAttributeValue(new QName(XMLConfigConstants.BUILD_MESSAGE));
             if (buildMessageAtt != null) {
                 loadbalanceEndpoint.setBuildMessageAttAvailable(true);
                 if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/LoadbalanceEndpointSerializer.java
@@ -61,6 +61,11 @@ public class LoadbalanceEndpointSerializer extends EndpointSerializer {
             loadbalanceElement.addAttribute("failover", "false", null);
         }
 
+        if (loadbalanceEndpoint.isBuildMessageAtt()) {
+            loadbalanceElement
+                    .addAttribute(XMLConfigConstants.BUILD_MESSAGE, Boolean.toString(loadbalanceEndpoint.isBuildMessageAtt()), null);
+        }
+
         // Serialize endpoint elements which are children of the loadbalance element
         if (loadbalanceEndpoint.getChildren() != null) {
             for (Endpoint childEndpoint : loadbalanceEndpoint.getChildren()) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointFactory.java
@@ -21,7 +21,9 @@ package org.apache.synapse.config.xml.endpoints;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
+import org.apache.axis2.util.JavaUtils;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.endpoints.utils.LoadbalanceAlgorithmFactory;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.SALoadbalanceEndpoint;
@@ -120,6 +122,15 @@ public class SALoadbalanceEndpointFactory extends EndpointFactory {
             LoadbalanceAlgorithm algorithm = LoadbalanceAlgorithmFactory.
                     createLoadbalanceAlgorithm(loadbalanceElement, endpoints);
             loadbalanceEndpoint.setAlgorithm(algorithm);
+
+            //set buildMessage attribute
+            String  buildMessageAtt = loadbalanceElement.getAttributeValue(new QName(XMLConfigConstants.BUILD_MESSAGE));
+            if (buildMessageAtt != null) {
+                loadbalanceEndpoint.setBuildMessageAttAvailable(true);
+                if (JavaUtils.isTrueExplicitly(buildMessageAtt)) {
+                    loadbalanceEndpoint.setBuildMessageAtt(true);
+                }
+            }
 
             // process the parameters
             processProperties(loadbalanceEndpoint, epConfig);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/SALoadbalanceEndpointSerializer.java
@@ -86,6 +86,11 @@ public class SALoadbalanceEndpointSerializer extends EndpointSerializer {
                 loadbalanceEndpoint.getAlgorithm().getClass().getName(),
                 null);
 
+        if (loadbalanceEndpoint.isBuildMessageAtt()) {
+            loadbalanceElement
+                    .addAttribute(XMLConfigConstants.BUILD_MESSAGE, Boolean.toString(loadbalanceEndpoint.isBuildMessageAtt()), null);
+        }
+
         for (Endpoint childEndpoint : loadbalanceEndpoint.getChildren()) {
             loadbalanceElement.addChild(EndpointSerializer.getElementFromEndpoint(childEndpoint));
         }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
@@ -285,6 +285,10 @@ public class FailoverEndpoint extends AbstractEndpoint {
         return dynamic;
     }
 
+    public boolean isBuildMessageAtt() {
+        return buildMessageAtt;
+    }
+
     public void setDynamic(boolean dynamic) {
         this.dynamic = dynamic;
     }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -365,6 +365,10 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
         return failover;
     }
 
+    public boolean isBuildMessageAtt() {
+        return buildMessageAtt;
+    }
+
     public void setFailover(boolean failover) {
         this.failover = failover;
     }


### PR DESCRIPTION
Fix the issue of not supporting "buildMessage" attribute in the management console.