### PR TITLE
Make foreach mediator implements ManagedLifecycle

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
@@ -26,10 +26,12 @@ import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axis2.AxisFault;
+import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.continuation.ContinuationStackManager;
+import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.util.MessageHelper;
@@ -38,10 +40,13 @@ import org.apache.synapse.util.xpath.SynapseXPath;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ForEachMediator extends AbstractMediator {
+public class ForEachMediator extends AbstractMediator implements ManagedLifecycle {
 
     /* The xpath that will list the elements to be split */
     private SynapseXPath expression = null;
+
+    /** Reference to the synapse environment */
+    private SynapseEnvironment synapseEnv;
 
     private SequenceMediator sequence;
 
@@ -283,6 +288,38 @@ public class ForEachMediator extends AbstractMediator {
         }
         resultContainer.setDetachedElements(elementList);
         return resultContainer;
+    }
+
+    @Override
+    public void init(SynapseEnvironment se) {
+        synapseEnv = se;
+
+        if (null != sequence) {
+            sequence.init(se);
+        } else if (null != sequenceRef) {
+            SequenceMediator refferedSeq =
+                    (SequenceMediator) se.getSynapseConfiguration().
+                            getSequence(sequenceRef);
+
+            if (refferedSeq == null || refferedSeq.isDynamic()) {
+                se.addUnavailableArtifactRef(sequenceRef);
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (null != sequence) {
+            sequence.destroy();
+        } else if (null != sequenceRef) {
+            SequenceMediator refferedSeq =
+                    (SequenceMediator) synapseEnv.getSynapseConfiguration().
+                            getSequence(sequenceRef);
+
+            if (refferedSeq == null || refferedSeq.isDynamic()) {
+                synapseEnv.removeUnavailableArtifactRef(sequenceRef);
+            }
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
@@ -45,7 +45,7 @@ public class ForEachMediator extends AbstractMediator implements ManagedLifecycl
     /* The xpath that will list the elements to be split */
     private SynapseXPath expression = null;
 
-    /** Reference to the synapse environment */
+    /* Reference to the synapse environment */
     private SynapseEnvironment synapseEnv;
 
     private SequenceMediator sequence;


### PR DESCRIPTION
JIRA Issue: https://wso2.org/jira/browse/ESBJAVA-5227

This change implements ManagedLifecycle interface in ForEach mediator.
Before this change, init() of child mediators of ForEach mediator didn't invoke.
Hence, initialization such as datasources in DBReport/DBLookup didn't happen and mediator failed during message mediation.
This fix is to invoke init() method of child mediators of ForEach mediator.