### PR TITLE
 Upgrade json-schema-validator-all version

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -306,6 +306,30 @@
             <artifactId>derby</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
+            <artifactId>libphonenumber</artifactId>
+        </dependency>
 	</dependencies>
 <properties>
 		<version.orbit.rabbitmq>3.6.6.wso2v1</version.orbit.rabbitmq>

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -261,6 +261,26 @@
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
+            <artifactId>libphonenumber</artifactId>
+        </dependency>
     </dependencies>
     
     <properties />

--- a/pom.xml
+++ b/pom.xml
@@ -889,11 +889,41 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>${javax.servlet.version}</version>
          </dependency>
-          <dependency>
+         <dependency>
             <groupId>org.wso2.orbit.com.github.fge</groupId>
             <artifactId>json-schema-validator-all</artifactId>
             <version>${fge.json.schema.validator.version}</version>
-          </dependency>
+         </dependency>
+         <dependency>
+              <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+              <version>${fasterxml.jackson.version}</version>
+         </dependency>
+         <dependency>
+              <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>${fasterxml.jackson.databind.version}</version>
+         </dependency>
+         <dependency>
+              <groupId>org.wso2.orbit.com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <version>${fasterxml.jackson.version}</version>
+         </dependency>
+         <dependency>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <version>${google.guava.version}</version>
+         </dependency>
+         <dependency>
+              <groupId>org.wso2.orbit.joda-time</groupId>
+              <artifactId>joda-time</artifactId>
+              <version>${joda-time.version}</version>
+         </dependency>
+         <dependency>
+              <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
+              <artifactId>libphonenumber</artifactId>
+              <version>${com.googlecode.libphonenumber.version}</version>
+         </dependency>
       </dependencies>
    </dependencyManagement>
     <reporting>
@@ -1058,7 +1088,12 @@
       <project.scm.id>wso2-scm-server</project.scm.id>
       <javax.cache.version>0.5</javax.cache.version>
       <javax.servlet.version>3.0.1</javax.servlet.version>
-      <fge.json.schema.validator.version>2.2.6.wso2v1</fge.json.schema.validator.version>
+      <fge.json.schema.validator.version>2.2.6.wso2v3</fge.json.schema.validator.version>
+      <fasterxml.jackson.version>2.6.1.wso2v1</fasterxml.jackson.version>
+      <fasterxml.jackson.databind.version>2.6.1.wso2v3</fasterxml.jackson.databind.version>
+      <google.guava.version>18.0</google.guava.version>
+      <joda-time.version>2.8.2.wso2v1</joda-time.version>
+      <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>
    </properties>
    <developers>
       <!-- If you are a committer and your name is not listed here, please include/edit -->


### PR DESCRIPTION
This is related to https://wso2.org/jira/browse/ESBJAVA-5079
The json-schema-validator-all version is upgraded to 2.2.6.wso2v3

