### PR TITLE
Introduce changes to preserve tasks when clustered

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
+++ b/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
@@ -505,8 +505,15 @@ public class Axis2SynapseController implements SynapseController {
      * {@inheritDoc}
      */
     public void destroySynapseConfiguration(boolean preserveState) {
+        destroySynapseConfiguration(preserveState, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void destroySynapseConfiguration(boolean preserveState, boolean isShuttingDown) {
         if (synapseConfiguration != null) {
-            synapseConfiguration.destroy(preserveState);
+            synapseConfiguration.destroy(preserveState, isShuttingDown);
             synapseConfiguration = null;
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/ServerManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerManager.java
@@ -276,7 +276,7 @@ public class ServerManager {
             serverContextInformation.setSynapseEnvironment(null);
 
             // destroy the created Synapse Configuration
-            synapseController.destroySynapseConfiguration(true);
+            synapseController.destroySynapseConfiguration(true, true);
             serverContextInformation.setSynapseConfiguration(null);
 
             // stop the SynapseController

--- a/modules/core/src/main/java/org/apache/synapse/SynapseController.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseController.java
@@ -83,6 +83,12 @@ public interface SynapseController {
     void destroySynapseConfiguration(boolean preserveState);
 
     /**
+     * Destroys the SynapseConfiguration instance, preserving the artifact's state based on preserveState and specifying
+     * whether or not the server is shutting down with isShuttingDown
+     */
+    void destroySynapseConfiguration(boolean preserveState, boolean isShuttingDown);
+
+    /**
      * Destroys the SynapseConfiguration instance
      */
     void destroySynapseConfiguration();

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/AbstractMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/AbstractMessageProcessor.java
@@ -189,4 +189,12 @@ public abstract class AbstractMessageProcessor implements MessageProcessor {
      * @param preserveState determine whether to preserve the artifacts state or not
      */
     public void destroy(boolean preserveState){}
+
+    /**
+     * Method to undeploy the artifact, preserving the state as specified and notifying if the undeployment is being
+     * called as part of a server shutdown.
+     * @param preserveState whether or not artifact state needs to be preserved
+     * @param isShuttingDown whether destroy is being called in a server shutdown
+     */
+    public abstract void destroy(boolean preserveState, boolean isShuttingDown);
 }

--- a/modules/core/src/main/java/org/apache/synapse/startup/quartz/QuartzTaskManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/quartz/QuartzTaskManager.java
@@ -210,6 +210,14 @@ public class QuartzTaskManager implements TaskManager {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean delete(String taskName, boolean isShuttingDown) {
+        return delete(taskName);
+    }
+
     @Override
     public boolean pause(String name) {
         logger.error("pause not supported. Task name : " + name);
@@ -488,6 +496,14 @@ public class QuartzTaskManager implements TaskManager {
     }
 
     public boolean isTaskExist(String arg0) {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isClusteredTaskManager(){
         return false;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
@@ -49,7 +49,7 @@ public class StartUpController extends AbstractStartup {
         return SimpleQuartzFactory.TASK;
     }
 
-    public void destroy() {
+    public void destroy(boolean isShuttingDown) {
         if (!destroyTask()) {
             return;
         }
@@ -60,13 +60,17 @@ public class StartUpController extends AbstractStartup {
         if (synapseTaskManager.isInitialized()) {
             TaskScheduler taskScheduler = synapseTaskManager.getTaskScheduler();
             if (taskScheduler != null && taskScheduler.isInitialized()) {
-                taskScheduler.deleteTask(taskDescription.getName(), taskDescription.getTaskGroup());
+                taskScheduler.deleteTask(taskDescription.getName(), taskDescription.getTaskGroup(), isShuttingDown);
             }
             TaskDescriptionRepository repository = synapseTaskManager.getTaskDescriptionRepository();
             if (repository != null) {
                 repository.removeTaskDescription(taskDescription.getName());
             }
         }
+    }
+
+    public void destroy() {
+        this.destroy(false);
     }
 
     public void init(SynapseEnvironment synapseEnvironment) {

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskDescription.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskDescription.java
@@ -14,6 +14,11 @@ public final class TaskDescription {
     public static final String INSTANCE = "Instance";
     public static final String DEFAULT_GROUP = "synapse.simple.quartz";
 
+    /**
+     * Constant used to refer to whether or not coordination is enabled where specified explicitly. (eg:- inbound EPs)
+     */
+    public static final String COORDINATION = "COORDINATION";
+
     private String taskName;
 
     private String taskGroup;

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskManager.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskManager.java
@@ -16,6 +16,16 @@ public interface TaskManager {
 
     public boolean delete(String name);
 
+    /**
+     * Method to delete the task with the specified name, specifying whether or not deleting is being done with the
+     * server shutting down.
+     *
+     * @param taskName name of the task to be deleted
+     * @param isShuttingDown whether or not the server is shutting down
+     * @return whether the deletion was successful
+     */
+    public boolean delete(String taskName, boolean isShuttingDown);
+
     public boolean pause(String name);
 
     public boolean pauseAll();
@@ -117,4 +127,10 @@ public interface TaskManager {
      */
     boolean isTaskExist(final String taskName);
 
+    /**
+     * Method to retieve whether the TaskManager is managing tasks in a cluster.
+     *
+     * @return whether or not the TaskManager is for a cluster
+     */
+    boolean isClusteredTaskManager();
 }

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskScheduler.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskScheduler.java
@@ -160,12 +160,16 @@ public class TaskScheduler {
     }
 
     public void deleteTask(String name, String group) {
+        deleteTask(name, group, false);
+    }
+
+    public void deleteTask(String name, String group, boolean isShuttingDown) {
         synchronized (lock) {
             if (!initialized) {
                 logger.error("Could not delete task[" + name + "," + group + "]. Task scheduler not properly initialized.");
                 return;
             }
-            taskManager.delete(name + "::" + group);
+            taskManager.delete(name + "::" + group, isShuttingDown);
         }
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -1024,7 +1024,7 @@
       <js.version>1.7.0.R4.wso2v1</js.version>
       <!-- startup, quartz -->
       <commons-collections.version>3.2.1</commons-collections.version>
-      <quartz.version>2.1.1</quartz.version>
+      <quartz.version>2.3.0</quartz.version>
       <geronimo-spec.version>1.1</geronimo-spec.version>
       <!-- xalan xsltc  -->
       <bcel.version>5.2</bcel.version>


### PR DESCRIPTION
With Quartz's clustering features being introduced in ntask (wso2/carbon-commons/pull/279), we need to ensure that when a node leaves, the relevant tasks remain in the shared database, for other nodes to pick them up (fail-over). With the current architecture, in a graceful shutdown, with the undeployment of artifacts the relevant tasks are deleted, resulting in a deletion from the database.

This PR introduces changes to enable preservation of the relevant tasks, if undeployment is being called during a graceful shutdown.