### PR TITLE
Add coverage module to aggregate unit test coverage

### DIFF
--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.synapse</groupId>
+        <artifactId>Apache-Synapse</artifactId>
+        <version>2.1.7-wso2v22-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.synapse</groupId>
+    <artifactId>synapse-code-coverage</artifactId>
+
+    <name>Apache Synapse - Code Coverage</name>
+    <description>Apache Synapse - Code Coverage</description>
+    <packaging>pom</packaging>
+    <url>http://synapse.apache.org</url>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine} -Xms256m -Xmx2048m</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-dependency-ant</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jacoco</groupId>
+                                    <artifactId>org.jacoco.ant</artifactId>
+                                    <version>${jacoco.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${basedir}/target/jacoco-jars</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo message="Generating JaCoCo Reports" />
+                                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                    <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                                </taskdef>
+                                <mkdir dir="${basedir}/target/coverage-report" />
+                                <report>
+                                    <executiondata>
+                                        <fileset dir="../core/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../commons/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../extensions/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../tasks/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../transports/core/nhttp/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../transports/core/pipe/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../transports/core/vfs/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                        <fileset dir="../transports/optional/fix/target/coverage-reports">
+                                            <include name="jacoco-unit*.exec" />
+                                        </fileset>
+                                    </executiondata>
+                                    <structure name="Overall Synapse Code Coverage Summary">
+                                        <group name="synapse-core">
+                                            <classfiles>
+                                                <fileset dir="../core/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../core/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-commons">
+                                            <classfiles>
+                                                <fileset dir="../commons/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../commons/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-extensions">
+                                            <classfiles>
+                                                <fileset dir="../extensions/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../extensions/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-tasks">
+                                            <classfiles>
+                                                <fileset dir="../tasks/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../tasks/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-transport-nhttp">
+                                            <classfiles>
+                                                <fileset dir="../transports/core/nhttp/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../transports/core/nhttp/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-transport-pipe">
+                                            <classfiles>
+                                                <fileset dir="../transports/core/pipe/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../transports/core/pipe/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-transport-vfs">
+                                            <classfiles>
+                                                <fileset dir="../transports/core/vfs/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../transports/core/vfs/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                        <group name="synapse-transport-fix">
+                                            <classfiles>
+                                                <fileset dir="../transports/optional/fix/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="../transports/optional/fix/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                    </structure>
+                                    <html destdir="${basedir}/target/coverage-report/site" />
+                                    <xml destfile="${basedir}/target/coverage-report/coverage-report.xml" />
+                                    <csv destfile="${basedir}/target/coverage-report/coverage-report.csv" />
+                                </report>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -981,6 +981,7 @@
       <module>modules/distribution</module>
       <module>modules/packaging/package-skeleton</module>
       <module>modules/packaging/package-archetype</module>
+      <module>modules/coverage-report</module>
    </modules>
    <properties>
       <maven.javadoc.plugin.version>2.1</maven.javadoc.plugin.version>
@@ -993,6 +994,7 @@
       <maven.site.plugin.version>2.0-beta-6</maven.site.plugin.version>
       <maven.surefire.plugin.version>2.2</maven.surefire.plugin.version>
       <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
+      <jacoco.version>0.7.9</jacoco.version>
       <maven.assembly.plugin.version>2.2-beta-2</maven.assembly.plugin.version>
       <maven.bundle.plugin.version>1.4.0</maven.bundle.plugin.version>
       <maven.dependency.plugin.version>2.0</maven.dependency.plugin.version>


### PR DESCRIPTION
This module will collect all the unit test exec files and merge the result. The coverage report can be found on target/coverage-report/site directory.