### PR TITLE
 Fix premature closing of SOAPHeaderBlock elements

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
@@ -32,6 +32,7 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.util.ElementHelper;
 import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.ManagedLifecycle;
@@ -289,10 +290,12 @@ public class SamplingService implements Task, ManagedLifecycle {
 			while (iHeader.hasNext()) {
 				try {
 					Object element = iHeader.next();
-					if (element instanceof OMElement) {
-						newHeaderNodes.add(ElementHelper.toSOAPHeaderBlock((OMElement) element, fac));
+					if (!(element instanceof SOAPHeaderBlock)) {
+						if (element instanceof OMElement) {
+							newHeaderNodes.add(ElementHelper.toSOAPHeaderBlock((OMElement) element, fac));
+						}
+						iHeader.remove();
 					}
-					iHeader.remove();
 				} catch (OMException e) {
 					log.error("Unable to convert to SoapHeader Block", e);
 				} catch (Exception e) {

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/memory/InMemoryProducer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/memory/InMemoryProducer.java
@@ -44,7 +44,7 @@ public class InMemoryProducer implements MessageProducer {
     public boolean storeMessage(MessageContext synCtx) {
         boolean result = false;
         if (synCtx != null) {
-            synCtx.getEnvelope().build();
+            synCtx.getEnvelope().buildWithAttachments();
             synchronized (queueLock) {
                 result = queue.offer(synCtx);
             }


### PR DESCRIPTION
- Message Sampling service (affects message processors) prematurely
  closes SOAPHeaderBlocks in the payload when dispatching the message.
  This fix will avoid removing headers if the header is already a
  SOAPHeaderBlock element.

- Update inmemory message producer to build the message with attachments
  when reading from the store. For Scenarios with SOAP attachments this
  fix needs to be present to build the full message.

Issue: wso2/product-ei#1031