### PR TITLE
Fix ESBJAVA-3480

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -47,6 +47,7 @@ public class PassThroughConfiguration {
                                                          Runtime.getRuntime().availableProcessors();
     private static final int DEFAULT_MAX_ACTIVE_CON = -1;
     private static final int DEFAULT_LISTENER_SHUTDOWN_WAIT_TIME = 0;
+    private Boolean isKeepAliveDisabled = null;
 
     //additional rest dispatch handlers
     private static final String REST_DISPATCHER_SERVICE="rest.dispatcher.service";
@@ -101,7 +102,10 @@ public class PassThroughConfiguration {
     }
 
     public boolean isKeepAliveDisabled() {
-        return getBooleanProperty(PassThroughConfigPNames.DISABLE_KEEPALIVE, false);
+        if (isKeepAliveDisabled == null) {
+            isKeepAliveDisabled = getBooleanProperty(PassThroughConfigPNames.DISABLE_KEEPALIVE, false);
+        }
+        return isKeepAliveDisabled.booleanValue();
     }
 
     public int getMaxActiveConnections() {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
@@ -29,15 +29,13 @@ import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
 import org.apache.synapse.transport.passthru.SourceRequest;
 import org.apache.synapse.transport.passthru.SourceResponse;
+import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
-
-import com.ibm.wsdl.extensions.http.HTTPConstants;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 public class SourceResponseFactory {
     private static Log log = LogFactory.getLog(SourceResponseFactory.class);
@@ -123,11 +121,10 @@ public class SourceResponseFactory {
 			}
 		}
 	}
-		// keep alive
-		String noKeepAlie = (String) msgContext
-				.getProperty(PassThroughConstants.NO_KEEPALIVE);
-		if ("true".equals(noKeepAlie)) {
-			sourceResponse.setKeepAlive(false);
+        // keep alive
+        String noKeepAlive = (String) msgContext.getProperty(PassThroughConstants.NO_KEEPALIVE);
+        if ("true".equals(noKeepAlive) || PassThroughConfiguration.getInstance().isKeepAliveDisabled()) {
+            sourceResponse.setKeepAlive(false);
         } else {
             // If the payload is delayed for GET/HEAD/DELETE, http-core-nio will start processing request, without
             // waiting for the payload. Therefore the delayed payload will be appended to the next request. To avoid

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
@@ -34,6 +34,7 @@ import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
 import org.apache.synapse.transport.passthru.TargetRequest;
+import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 
 import java.net.MalformedURLException;
@@ -157,8 +158,8 @@ public class TargetRequestFactory {
             }
 
             // keep alive
-            String noKeepAlie = (String) msgContext.getProperty(PassThroughConstants.NO_KEEPALIVE);
-            if ("true".equals(noKeepAlie)) {
+            String noKeepAlive = (String) msgContext.getProperty(PassThroughConstants.NO_KEEPALIVE);
+            if ("true".equals(noKeepAlive) || PassThroughConfiguration.getInstance().isKeepAliveDisabled()) {
                 request.setKeepAlive(false);
             }
 


### PR DESCRIPTION
To disable http keepalive setting server wide,
"http.connection.disable.keepalive=true" property can be used
but it didn't work. To solve this, isKeepAliveDisabled method of
PassThroughConfiguration is used.

Fix: https://wso2.org/jira/browse/ESBJAVA-3480