### PR TITLE
Fixing APIMANAGER-5916

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -312,7 +312,7 @@ public class ServerWorker implements Runnable {
         msgContext.setTo(new EndpointReference(request.getUri()));
         msgContext.setServerSide(true);
         msgContext.setDoingREST(true);
-        if(!request.isEntityEnclosing()){
+        if (!(request.isEntityEnclosing())) {
         	msgContext.setProperty(PassThroughConstants.NO_ENTITY_BODY, Boolean.TRUE);
         }
         

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -264,10 +264,10 @@ public class TargetRequest {
         request.setParams(new DefaultedHttpParams(request.getParams(),
                 targetConfiguration.getHttpParams()));
 
-        //Chucking is not performed for request has "http 1.0" and "GET" http method
+        //Chunking is not performed for request has "http 1.0" and "GET" http method
        if (!((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0)) ||
                (PassThroughConstants.HTTP_GET.equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))) ||
-               RelayUtils.isDeleteRequestWithoutPayload(requestMsgCtx))) {
+               RelayUtils.isDeleteRequestWithoutPayload(requestMsgCtx) || !(hasEntityBody))) {
             this.processChunking(conn, requestMsgCtx);
         }
 


### PR DESCRIPTION
java.lang.ClassCastException occurs when a PUT request is made with empty body, and application/octet-stream content type
and when chunking is disabled. This fix solves that issue.
Fix: https://wso2.org/jira/browse/APIMANAGER-5916
