### PR TITLE
Improve performance of Script Mediator

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -25,6 +25,7 @@ import com.sun.phobos.script.javascript.RhinoScriptEngineFactory;
 import com.sun.script.groovy.GroovyScriptEngineFactory;
 import com.sun.script.jruby.JRubyScriptEngineFactory;
 import com.sun.script.jython.JythonScriptEngineFactory;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMText;
 import org.apache.bsf.xml.XMLHelper;
@@ -40,14 +41,6 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.Value;
 import org.mozilla.javascript.Context;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Map;
-import java.util.Properties;
-import java.util.TreeMap;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import javax.activation.DataHandler;
 import javax.script.Bindings;
 import javax.script.Compilable;
@@ -57,6 +50,14 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * A Synapse mediator that calls a function in any scripting language supported by the BSF.
@@ -90,10 +91,13 @@ public class ScriptMediator extends AbstractMediator {
     private static final String JAVA_SCRIPT = "js";
 
     /**
-     * Name of the java script language with usage of nashorn engine
+     * Name of the java script language with usage of nashorn engine.
      */
     private static final String NASHORN_JAVA_SCRIPT = "nashornJs";
 
+    /**
+     * Name of the nashorn java script engine.
+     */
     private static final String NASHORN = "nashorn";
     /**
      * The registry entry key for a script loaded from the registry
@@ -128,6 +132,15 @@ public class ScriptMediator extends AbstractMediator {
      * Does the ScriptEngine support multi-threading
      */
     private boolean multiThreadedEngine;
+    /**
+     * Reference to an empty JSON object.
+     */
+    private ScriptObjectMirror emptyJsonObject;
+
+    /**
+     * Reference to JSON object which is used to serialize json.
+     */
+    private ScriptObjectMirror jsonSerializer;
     /**
      * The compiled script. Only used for inline scripts
      */
@@ -207,6 +220,7 @@ public class ScriptMediator extends AbstractMediator {
             throw new SynapseException("Script engine is not an Invocable" +
                     " engine for language: " + language);
         }
+
     }
 
     /**
@@ -343,7 +357,7 @@ public class ScriptMediator extends AbstractMediator {
     private ScriptMessageContext getScriptMessageContext(MessageContext synCtx, XMLHelper helper) {
         ScriptMessageContext scriptMC;
         if (language.equals(NASHORN_JAVA_SCRIPT)) {
-            scriptMC = new NashornJavaScriptMessageContext(synCtx, helper);
+            scriptMC = new NashornJavaScriptMessageContext(synCtx, helper, emptyJsonObject, jsonSerializer);
         } else {
             scriptMC = new CommonScriptMessageContext(synCtx, helper);
         }
@@ -588,6 +602,12 @@ public class ScriptMediator extends AbstractMediator {
         }
         if (language.equals(NASHORN_JAVA_SCRIPT)) {
             this.jsEngine = engineManager.getEngineByName(NASHORN);
+            try {
+                emptyJsonObject = (ScriptObjectMirror) scriptEngine.eval("({})");
+                jsonSerializer = (ScriptObjectMirror) scriptEngine.eval("JSON");
+            } catch (ScriptException e) {
+                throw new SynapseException("Error occurred while evaluating empty json object", e);
+            }
         } else {
             this.jsEngine = engineManager.getEngineByExtension("jsEngine");
         }


### PR DESCRIPTION


Fix https://github.com/wso2/product-ei/issues/1117

## Purpose
> Empty JSON and JSON object which is used to serialize js objects, are re evaluated from script engine each time when setpayload json method call happens.

## Goals
> Evaluate empty json object and JSON object in ScriptMediator class.

## Approach
> Evaluate empty json object and JSON object in ScriptMediator class and pass them to message context when initiating the NashornJavaScriptMessageContext. This will avoid evaluating them using script engine, when each time a method call happens.

## User stories
> N/A

## Release note
> Evaluate empty json object and JSON object in ScriptMediator class and pass them to message context when initiating the NashornJavaScriptMessageContext. 
Fix https://github.com/wso2/product-ei/issues/1117

## Documentation
> N/A Since internal performance improvement

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
  > 28%
 - Integration tests
   > 57%

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A
## Migrations (if applicable)
> N/A

## Test environment
> 1.8.0_121
 
## Learning
> N/A