### PR TITLE
Add offline instrumentation for jacoco coverage

### DIFF
--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -41,32 +41,42 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-commons.exec
+                            </value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-commons.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-commons.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-commons.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -206,6 +216,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <properties />

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -82,7 +82,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>${argLine}</argLine>
 					<systemProperties>
 						<property>
 							<name>org.xml.sax.driver</name>
@@ -91,6 +90,12 @@
 						<property>
 							<name>javax.xml.validation.SchemaFactory:http://www.w3.org/2001/XMLSchema</name>
 							<value>org.apache.xerces.jaxp.validation.XMLSchemaFactory</value>
+						</property>
+						<property>
+							<name>jacoco-agent.destfile</name>
+							<value>
+								target/coverage-reports/jacoco-unit-core.exec
+							</value>
 						</property>
 					</systemProperties>
 					<forkMode>pertest</forkMode>
@@ -102,25 +107,29 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<destFile>${basedir}/target/coverage-reports/jacoco-unit-core.exec</destFile>
-				</configuration>
+				<version>${maven.jacoco.plugin.version}</version>
 				<executions>
 					<execution>
-						<id>jacoco-initialize</id>
+						<id>default-instrument</id>
 						<goals>
-							<goal>prepare-agent</goal>
+							<goal>instrument</goal>
 						</goals>
 					</execution>
 					<execution>
-						<id>jacoco-site</id>
-						<phase>test</phase>
+						<id>default-restore-instrumented-classes</id>
+						<goals>
+							<goal>restore-instrumented-classes</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-report</id>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>report</goal>
 						</goals>
 						<configuration>
-							<dataFile>${basedir}/target/coverage-reports/jacoco-unit-core.exec</dataFile>
-							<outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+							<dataFile>target/coverage-reports/jacoco-unit-core.exec</dataFile>
+							<outputDirectory>target/coverage-reports/site</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -356,6 +365,12 @@
             <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.agent</artifactId>
+			<classifier>runtime</classifier>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 <properties>
 		<version.orbit.rabbitmq>3.6.6.wso2v1</version.orbit.rabbitmq>

--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -60,7 +60,7 @@
                                 <artifactItem>
                                     <groupId>org.jacoco</groupId>
                                     <artifactId>org.jacoco.ant</artifactId>
-                                    <version>${jacoco.version}</version>
+                                    <version>${jacoco.ant.version}</version>
                                 </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
@@ -184,7 +184,7 @@
                     <dependency>
                         <groupId>org.jacoco</groupId>
                         <artifactId>org.jacoco.ant</artifactId>
-                        <version>${jacoco.version}</version>
+                        <version>${jacoco.ant.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -41,31 +41,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-ext.exec
+                            </value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-ext.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-ext.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-ext.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -309,6 +319,12 @@
         <dependency>
             <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -40,31 +40,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-task.exec
+                            </value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-task.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-task.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-task.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -110,6 +120,12 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/modules/tasks/src/test/java/org/apache/synapse/task/TaskSchedulerFactoryTest.java
+++ b/modules/tasks/src/test/java/org/apache/synapse/task/TaskSchedulerFactoryTest.java
@@ -1,0 +1,30 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.apache.synapse.task;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class TaskSchedulerFactoryTest {
+
+    @Test()
+    public void testGetTaskScheduler() {
+        TaskScheduler taskScheduler = TaskSchedulerFactory.getTaskScheduler("new");
+        Assert.assertNotNull("Task Object null", taskScheduler);
+    }
+}

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -97,32 +97,41 @@
                             <name>net.sourceforge.cobertura.datafile</name>
                             <value>target/cobertura.ser</value>
                         </property>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-nhttp.exec
+                            </value>
+                        </property>
                     </systemProperties>
-                    <argLine>${argLine} -javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
+                    <argLine>-javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-nhttp.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-nhttp.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-nhttp.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -191,6 +200,12 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -91,32 +91,41 @@
                             <name>net.sourceforge.cobertura.datafile</name>
                             <value>target/cobertura.ser</value>
                         </property>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-vfs.exec
+                            </value>
+                        </property>
                     </systemProperties>
-                    <argLine>${argLine} -javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
+                    <argLine>-javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-vfs.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-vfs.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-vfs.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -196,6 +205,12 @@
         <dependency>
             <groupId>org.wso2.orbit.com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -39,31 +39,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>${argLine}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>jacoco-agent.destfile</name>
+                            <value>
+                                target/coverage-reports/jacoco-unit-fix.exec
+                            </value>
+                        </property>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <destFile>${basedir}/target/coverage-reports/jacoco-unit-fix.exec</destFile>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>jacoco-initialize</id>
+                        <id>default-instrument</id>
                         <goals>
-                            <goal>prepare-agent</goal>
+                            <goal>instrument</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>test</phase>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${basedir}/target/coverage-reports/jacoco-unit-fix.exec</dataFile>
-                            <outputDirectory>${basedir}/target/coverage-reports/site</outputDirectory>
+                            <dataFile>target/coverage-reports/jacoco-unit-fix.exec</dataFile>
+                            <outputDirectory>target/coverage-reports/site</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -141,6 +151,12 @@
             <groupId>org.apache.synapse</groupId>
             <artifactId>synapse-core</artifactId>
             <scope>test</scope>            
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,6 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${maven.site.plugin.version}</version>
              </plugin>
-
-             <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-surefire-plugin</artifactId>
-                 <version>${maven.surefire.plugin.version}</version>
-             </plugin>
              <plugin>
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-assembly-plugin</artifactId>
@@ -246,7 +240,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                  <version>${maven.surefire.plugin.version}</version>
                  <configuration>
-                     <!--<argLine>${argLine} -Xms128m -Xmx256m</argLine>-->
+                     <argLine>-Xms128m -Xmx256m</argLine>
                  </configuration>
              </plugin>
              <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                  <version>${maven.surefire.plugin.version}</version>
                  <configuration>
-                     <argLine>${argLine} -Xms128m -Xmx256m</argLine>
+                     <!--<argLine>${argLine} -Xms128m -Xmx256m</argLine>-->
                  </configuration>
              </plugin>
              <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -926,12 +926,6 @@
           <!--Mockito Dependency-->
           <dependency>
               <groupId>org.powermock</groupId>
-              <artifactId>powermock-module-testng</artifactId>
-              <version>${powermock.version}</version>
-              <scope>test</scope>
-          </dependency>
-          <dependency>
-              <groupId>org.powermock</groupId>
               <artifactId>powermock-api-mockito2</artifactId>
               <version>${powermock.version}</version>
               <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -929,6 +929,32 @@
               <artifactId>libphonenumber</artifactId>
               <version>${com.googlecode.libphonenumber.version}</version>
          </dependency>
+          <!--Mockito Dependency-->
+          <dependency>
+              <groupId>org.powermock</groupId>
+              <artifactId>powermock-module-testng</artifactId>
+              <version>${powermock.version}</version>
+              <scope>test</scope>
+          </dependency>
+          <dependency>
+              <groupId>org.powermock</groupId>
+              <artifactId>powermock-api-mockito2</artifactId>
+              <version>${powermock.version}</version>
+              <scope>test</scope>
+          </dependency>
+          <dependency>
+              <groupId>org.powermock</groupId>
+              <artifactId>powermock-module-junit4</artifactId>
+              <version>${powermock.version}</version>
+              <scope>test</scope>
+          </dependency>
+          <dependency>
+              <groupId>org.jacoco</groupId>
+              <artifactId>org.jacoco.agent</artifactId>
+              <classifier>runtime</classifier>
+              <version>${jacoco.agent.version}</version>
+              <scope>test</scope>
+          </dependency>
       </dependencies>
    </dependencyManagement>
     <reporting>
@@ -993,8 +1019,6 @@
       <maven.resources.plugin.version>2.2</maven.resources.plugin.version>
       <maven.site.plugin.version>2.0-beta-6</maven.site.plugin.version>
       <maven.surefire.plugin.version>2.2</maven.surefire.plugin.version>
-      <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
-      <jacoco.version>0.7.9</jacoco.version>
       <maven.assembly.plugin.version>2.2-beta-2</maven.assembly.plugin.version>
       <maven.bundle.plugin.version>1.4.0</maven.bundle.plugin.version>
       <maven.dependency.plugin.version>2.0</maven.dependency.plugin.version>
@@ -1102,6 +1126,11 @@
       <google.guava.version>18.0</google.guava.version>
       <joda-time.version>2.8.2.wso2v1</joda-time.version>
       <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>
+
+      <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
+      <jacoco.agent.version>0.7.2.201409121644</jacoco.agent.version>
+      <jacoco.ant.version>0.7.2.201409121644</jacoco.ant.version>
+      <powermock.version>1.7.1</powermock.version>
    </properties>
    <developers>
       <!-- If you are a committer and your name is not listed here, please include/edit -->


### PR DESCRIPTION
## Purpose
> Add offline instrumentation for jacoco coverage when collecting code coverage.

## Goals
> To include the classes to coverage when the classes use mocking(@PrepareForTest) when unit test. Otherwise jacoco can not include them to coverage when the instrumentation is on the fly. 

