### PR TITLE
Fix https://github.com/wso2/product-ei/issues/1180.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -78,10 +78,10 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                     log.debug("Initialized the ProxyService : " + proxy.getName());
                 }
 
+                getSynapseConfiguration().addProxyService(proxy.getName(), proxy);
                 AxisService axisService = proxy.buildAxisService(getSynapseConfiguration(),
                                                   getSynapseConfiguration().getAxisConfiguration());
 
-                getSynapseConfiguration().addProxyService(proxy.getName(), proxy);
                 if (axisService == null) {
                     if (log.isDebugEnabled()) {
                         log.debug("Skipping proxy Startup for ProxyService : " + proxy.getName());


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-ei/issues/1180.

## Goals
> Avoid initial message loss in JMS consumer proxies at the deployment time.

## Approach
> Change the order in proxy deployment to add the proxy service before
building the axis2 service.