### PR TITLE
Add synapse commons datasource test cases

### DIFF
--- a/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceFactoryTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.datasource.factory;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.SynapseCommonsException;
+import org.apache.synapse.commons.datasource.DataSourceInformation;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+/**
+ * Test class for DataSourceFactory
+ */
+public class DataSourceFactoryTest extends TestCase {
+
+    /**
+     * Test create DataSource from DataSourceInformation object
+     */
+    public void testCreateDatasource() {
+        DataSourceInformation dataSourceInformation = createDataSourceInformation();
+        DataSource dataSource = DataSourceFactory.createDataSource(dataSourceInformation);
+        assertNotNull("Datasource not created", dataSource);
+    }
+
+    /**
+     * Test create DataSource from DataSourceInformation object with null url
+     */
+    public void testCreateDatasourceUrlNull() {
+        DataSourceInformation dataSourceInformation = createDataSourceInformation();
+        dataSourceInformation.setUrl(null);
+        try {
+            DataSourceFactory.createDataSource(dataSourceInformation);
+            fail("SynapseCommonsException expected");
+        } catch (SynapseCommonsException e) {
+            assertEquals("Invalid exception message", "Database connection URL cannot be found.", e.getMessage());
+        }
+    }
+
+    /**
+     * Helper method to create DataSourceInformation object
+     */
+    private DataSourceInformation createDataSourceInformation() {
+        Properties properties = new Properties();
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.url", "jdbc:h2:repository/database/test_db");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+        properties.put("synapse.datasources.dataSource1.username", "user1");
+        properties.put("synapse.datasources.dataSource1.password", "user1password");
+        return DataSourceInformationFactory.createDataSourceInformation("dataSource1", properties);
+    }
+}

--- a/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationFactoryTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationFactoryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.datasource.factory;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.SynapseCommonsException;
+import org.apache.synapse.commons.datasource.DataSourceInformation;
+
+import java.util.Properties;
+
+/**
+ * Test class for DataSourceInformationFactory
+ */
+public class DataSourceInformationFactoryTest extends TestCase {
+
+    /**
+     * Test creating DataSourceInformation from given properties
+     */
+    public void testCreateDataSourceInformation() {
+        Properties properties = new Properties();
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.url", "jdbc:h2:repository/database/test_db");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+        DataSourceInformation dataSourceInformation =
+                DataSourceInformationFactory.createDataSourceInformation("dataSource1", properties);
+    }
+
+    /**
+     * Test creating DataSourceInformation data source name = null
+     */
+    public void testCreateDataSourceInformationNameNull() {
+        Properties properties = new Properties();
+        DataSourceInformation dataSourceInformation =
+                DataSourceInformationFactory.createDataSourceInformation(null, properties);
+        assertNull("Expected null value", dataSourceInformation);
+    }
+
+    /**
+     * Test creating DataSourceInformation empty data source name
+     */
+    public void testCreateDataSourceInformationWithEmptyName() {
+        Properties properties = new Properties();
+        DataSourceInformation dataSourceInformation =
+                DataSourceInformationFactory.createDataSourceInformation("", properties);
+        assertNull("Expected null value", dataSourceInformation);
+    }
+
+    /**
+     * Test creating DatasourceInformation without defining db url
+     */
+    public void testCreateDataSourceInformationUrlNull() {
+        Properties properties = new Properties();
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+        try {
+            DataSourceInformationFactory.createDataSourceInformation("dataSource1", properties);
+        } catch (SynapseCommonsException e) {
+            assertEquals("Invalid exception message",
+                    "synapse.datasources.dataSource1.url cannot be found.", e.getMessage());
+        }
+    }
+}

--- a/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationListFactoryTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationListFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.datasource.factory;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.datasource.DataSourceInformation;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Test class for DataSourceInformationListFactory
+ */
+public class DataSourceInformationListFactoryTest extends TestCase {
+
+    /**
+     * Test creating a list of DataSourceInformation objects from properties
+     */
+    public void testCreateDataSourceInformationList() {
+        Properties properties = new Properties();
+        properties.put("synapse.datasources", "dataSource1,dataSource2,dataSource3");
+
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.url", "jdbc:h2:repository/database/test_db1");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+
+        properties.put("synapse.datasources.dataSource2.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource2.url", "jdbc:h2:repository/database/test_db2");
+        properties.put("synapse.datasources.dataSource2.dsName", "dataSource2");
+
+        properties.put("synapse.datasources.dataSource3.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource3.url", "jdbc:h2:repository/database/test_db3");
+        properties.put("synapse.datasources.dataSource3.dsName", "dataSource3");
+
+        List<DataSourceInformation> dataSourceInformations =
+                DataSourceInformationListFactory.createDataSourceInformationList(properties);
+        assertEquals("Invalid no of DataSourceInformation objects created", 3, dataSourceInformations.size());
+    }
+
+    /**
+     * Test creating a list of DataSourceInformation objects from null Properties object
+     */
+    public void testCreateDataSourceInformationListNullProperties() {
+        List<DataSourceInformation> dataSourceInformations =
+                DataSourceInformationListFactory.createDataSourceInformationList(null);
+        assertEquals("Created no of DataSourceInformation objects should be zero", 0, dataSourceInformations.size());
+    }
+
+    /**
+     * Test creating a list of DataSourceInformation objects from properties when "synapse.datasources" is not defined
+     */
+    public void testCreateDataSourceInformationListNamesNotDefined() {
+        Properties properties = new Properties();
+
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.url", "jdbc:h2:repository/database/test_db1");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+
+        properties.put("synapse.datasources.dataSource2.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource2.url", "jdbc:h2:repository/database/test_db2");
+        properties.put("synapse.datasources.dataSource2.dsName", "dataSource2");
+
+        properties.put("synapse.datasources.dataSource3.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource3.url", "jdbc:h2:repository/database/test_db3");
+        properties.put("synapse.datasources.dataSource3.dsName", "dataSource3");
+
+        List<DataSourceInformation> dataSourceInformations =
+                DataSourceInformationListFactory.createDataSourceInformationList(properties);
+        assertEquals("Created no of DataSourceInformation objects should be zero", 0, dataSourceInformations.size());
+    }
+}

--- a/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationRepositoryFactoryTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/datasource/factory/DataSourceInformationRepositoryFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.datasource.factory;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.datasource.DataSourceInformationRepository;
+
+import java.util.Properties;
+
+/**
+ * Test class for DataSourceInformationRepositoryFactory
+ */
+public class DataSourceInformationRepositoryFactoryTest extends TestCase {
+
+    /**
+     * Test creating DataSourceInformationRepositoryFactory from properties
+     */
+    public void testCreateDataSourceInformationRepository() {
+
+        Properties properties = new Properties();
+        properties.put("synapse.datasources", "dataSource1,dataSource2,dataSource3");
+
+        properties.put("synapse.datasources.dataSource1.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource1.url", "jdbc:h2:repository/database/test_db1");
+        properties.put("synapse.datasources.dataSource1.dsName", "dataSource1");
+
+        properties.put("synapse.datasources.dataSource2.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource2.url", "jdbc:h2:repository/database/test_db2");
+        properties.put("synapse.datasources.dataSource2.dsName", "dataSource2");
+
+        properties.put("synapse.datasources.dataSource3.driverClassName", "org.h2.Driver");
+        properties.put("synapse.datasources.dataSource3.url", "jdbc:h2:repository/database/test_db3");
+        properties.put("synapse.datasources.dataSource3.dsName", "dataSource3");
+
+        DataSourceInformationRepository dataSourceInformationRepository =
+                DataSourceInformationRepositoryFactory.createDataSourceInformationRepository(properties);
+        assertNotNull("DataSourceInformationRepository is not created", dataSourceInformationRepository);
+    }
+}

--- a/modules/commons/src/test/java/org/apache/synapse/commons/datasource/serializer/DataSourceInformationSerializerTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/datasource/serializer/DataSourceInformationSerializerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.datasource.serializer;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.datasource.DataSourceInformation;
+import org.wso2.securevault.secret.SecretInformation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Test class for DataSourceInformationSerializer and DataSourceInformationListSerializer
+ */
+public class DataSourceInformationSerializerTest extends TestCase {
+
+    /**
+     * Test serializing DataSourceInformation list
+     */
+    public void testSerializeDataSourceInformation() {
+
+        List<DataSourceInformation> dataSourceInformationList = new ArrayList<>();
+
+        DataSourceInformation dataSourceInformation1 = new DataSourceInformation();
+        dataSourceInformation1.setDriver("org.h2.Driver");
+        dataSourceInformation1.setUrl("jdbc:h2:repository/database/test_db1");
+        dataSourceInformation1.setAlias("dataSource1");
+        SecretInformation secretInformation = new SecretInformation();
+        secretInformation.setUser("user1");
+        secretInformation.setAliasSecret("user1password");
+        dataSourceInformation1.setSecretInformation(secretInformation);
+        dataSourceInformationList.add(dataSourceInformation1);
+
+        DataSourceInformation dataSourceInformation2 = new DataSourceInformation();
+        dataSourceInformation2.setDriver("org.h2.Driver");
+        dataSourceInformation2.setUrl("jdbc:h2:repository/database/test_db2");
+        dataSourceInformation2.setAlias("dataSource2");
+        dataSourceInformationList.add(dataSourceInformation2);
+
+        DataSourceInformation dataSourceInformation3 = new DataSourceInformation();
+        dataSourceInformation3.setDriver("org.h2.Driver");
+        dataSourceInformation3.setUrl("jdbc:h2:repository/database/test_db3");
+        dataSourceInformation3.setAlias("dataSource3");
+        dataSourceInformationList.add(dataSourceInformation3);
+
+        Properties properties = DataSourceInformationListSerializer.serialize(dataSourceInformationList);
+        String dataSources = properties.getProperty("synapse.datasources");
+
+        assertTrue("'dataSource1' cannot be found in datasource list ", dataSources.contains("dataSource1"));
+        assertTrue("'dataSource2' cannot be found in datasource list ", dataSources.contains("dataSource2"));
+        assertTrue("'dataSource3' cannot be found in datasource list ", dataSources.contains("dataSource3"));
+    }
+}


### PR DESCRIPTION
## Purpose
> Test cases to cover the functionality of org.apache.synapse.commons.datasource.factory and org.apache.synapse.commons.datasource.serializer classes