### PR TITLE
Add new property to control empty XML elements without nil attribute

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
@@ -110,6 +110,8 @@ public final class JsonUtil {
 
     private static final boolean xmlNilReadWriteEnabled;
 
+    private static final boolean xmlWriteNullForEmptyElements;
+
     static {
         Properties properties = MiscellaneousUtil.loadProperties("synapse.properties");
         if (properties == null) {
@@ -124,6 +126,7 @@ public final class JsonUtil {
             xmloutAutoArray = true;
             xmloutMultiplePI = false;
             xmlNilReadWriteEnabled = false;
+            xmlWriteNullForEmptyElements = true;
         } else {
             // Preserve the namespace declarations() in the JSON output in the XML -> JSON transformation.
             String process = properties.getProperty(Constants.SYNAPSE_COMMONS_JSON_PRESERVE_NAMESPACE, "false").trim();
@@ -169,6 +172,10 @@ public final class JsonUtil {
             xmlNilReadWriteEnabled = Boolean
                     .parseBoolean(properties.getProperty("synapse.commons.enableXmlNilReadWrite", "false"));
 
+            // Used in XML->JSON conversion. Decides whether to set null or "" for an empty XML element w/o nil attrib
+            xmlWriteNullForEmptyElements = Boolean.parseBoolean(
+                    properties.getProperty("synapse.commons.enableXmlNullForEmptyElement", "true"));
+
         }
     }
 
@@ -210,6 +217,7 @@ public final class JsonUtil {
             .customReplaceSequence(jsonoutCustomReplaceSequence)
             .customRegex(jsonoutcustomRegex)
             .readWriteXmlNil(xmlNilReadWriteEnabled)
+            .writeNullForEmptyElement(xmlWriteNullForEmptyElements)
             .build();
     /// End of JSON/XML INPUT OUTPUT Formatting Configuration.
 

--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfig.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfig.java
@@ -102,6 +102,11 @@ public interface JsonXMLConfig {
             return false;
         }
 
+        @Override
+        public boolean isWriteNullForEmptyElements() {
+            return true;
+        }
+
     };
 
     /**
@@ -196,5 +201,13 @@ public interface JsonXMLConfig {
     public String getCustomReplaceSequence();
 
     public boolean isReadWriteXmlNil();
+
+    /**
+     * Used in XML->JSON conversion. Decides whether to set null
+     * or "" for an empty XML element without nil attribute
+     *
+     * @return true if null is written, false if "" is written
+     */
+    public boolean isWriteNullForEmptyElements();
 
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfigBuilder.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfigBuilder.java
@@ -179,4 +179,15 @@ public class JsonXMLConfigBuilder {
         return this;
     }
 
+    /**
+     * Set writeNullForEmptyElement property and return receiver.
+     *
+     * @param writeNullForEmptyElements true if writing null, false if writing ""
+     * @return this
+     */
+    public JsonXMLConfigBuilder writeNullForEmptyElement(boolean writeNullForEmptyElements){
+        config.setWriteNullForEmptyElement(writeNullForEmptyElements);
+        return this;
+    }
+
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfigImpl.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLConfigImpl.java
@@ -34,10 +34,11 @@ public class JsonXMLConfigImpl implements JsonXMLConfig, Cloneable {
     private char namespaceSeparator = JsonXMLConfig.DEFAULT.getNamespaceSeparator();
 
     private boolean repairingNamespaces = JsonXMLConfig.DEFAULT.isRepairingNamespaces();
-    private String customRegex =JsonXMLConfig.DEFAULT.getCustomRegex();
-    private String customReplaceRegex =JsonXMLConfig.DEFAULT.getCustomReplaceRegex();
-    private String customReplaceSequence =JsonXMLConfig.DEFAULT.getCustomReplaceSequence();
+    private String customRegex = JsonXMLConfig.DEFAULT.getCustomRegex();
+    private String customReplaceRegex = JsonXMLConfig.DEFAULT.getCustomReplaceRegex();
+    private String customReplaceSequence = JsonXMLConfig.DEFAULT.getCustomReplaceSequence();
     private boolean readWriteXmlNil = JsonXMLConfig.DEFAULT.isReadWriteXmlNil();
+    private boolean writeNullForEmptyElement = JsonXMLConfig.DEFAULT.isWriteNullForEmptyElements();
 
     @Override
     protected JsonXMLConfigImpl clone() {
@@ -125,8 +126,8 @@ public class JsonXMLConfigImpl implements JsonXMLConfig, Cloneable {
         return customRegex;
     }
 
-    public void setCustomRegex(String customRegex){
-        this.customRegex =customRegex;
+    public void setCustomRegex(String customRegex) {
+        this.customRegex = customRegex;
     }
 
     @Override
@@ -151,9 +152,18 @@ public class JsonXMLConfigImpl implements JsonXMLConfig, Cloneable {
         this.readWriteXmlNil = readWriteXmlNil;
     }
 
+    public void setWriteNullForEmptyElement(boolean writeNullForEmptyElement) {
+        this.writeNullForEmptyElement = writeNullForEmptyElement;
+    }
+
     @Override
     public boolean isReadWriteXmlNil() {
         return readWriteXmlNil;
+    }
+
+    @Override
+    public boolean isWriteNullForEmptyElements() {
+        return writeNullForEmptyElement;
     }
 
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLOutputFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLOutputFactory.java
@@ -126,6 +126,7 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
     private String customReplaceRegex;
     private String customReplaceSequence;
     private boolean xmlNilReadWriteEnabled;
+    private boolean xmlWriteNullForEmptyElement;
 
     public JsonXMLOutputFactory() throws FactoryConfigurationError {
         this(JsonXMLConfig.DEFAULT);
@@ -152,6 +153,7 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
         this.customReplaceRegex = config.getCustomReplaceRegex();
         this.customReplaceSequence = config.getCustomReplaceSequence();
         this.xmlNilReadWriteEnabled = config.isReadWriteXmlNil();
+        this.xmlWriteNullForEmptyElement = config.isWriteNullForEmptyElements();
 
 		/*
          * initialize standard properties
@@ -192,7 +194,8 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
         boolean repairNamespaces = Boolean.TRUE.equals(getProperty(IS_REPAIRING_NAMESPACES));
         try {
             return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)),
-                    repairNamespaces, multiplePI, namespaceSeparator, namespaceDeclarations, xmlNilReadWriteEnabled);
+                    repairNamespaces, multiplePI, namespaceSeparator, namespaceDeclarations, xmlNilReadWriteEnabled,
+                    xmlWriteNullForEmptyElement);
         } catch (IOException e) {
             throw new XMLStreamException(e);
         }
@@ -203,7 +206,8 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
         boolean repairNamespaces = Boolean.TRUE.equals(getProperty(IS_REPAIRING_NAMESPACES));
         try {
             return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)),
-                    repairNamespaces, multiplePI, namespaceSeparator, namespaceDeclarations, xmlNilReadWriteEnabled);
+                    repairNamespaces, multiplePI, namespaceSeparator, namespaceDeclarations, xmlNilReadWriteEnabled,
+                    xmlWriteNullForEmptyElement);
         } catch (IOException e) {
             throw new XMLStreamException(e);
         }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLStreamWriter.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/json/JsonXMLStreamWriter.java
@@ -112,6 +112,7 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
     private final char namespaceSeparator;
     private final boolean namespaceDeclarations;
     private final boolean xmlNilReadWriteEnabled;
+    private final boolean xmlWriteNullForEmptyElement;
 
     private boolean documentArray = false;
 
@@ -122,6 +123,7 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
      * @param multiplePI            whether to consume <code>&lt;xml-multiple?&gt;</code> PIs to trigger array start
      * @param namespaceSeparator    namespace prefix separator
      * @param namespaceDeclarations whether to write namespace declarations
+     * @param repairNamespaces      repair Namespaces
      */
     public JsonXMLStreamWriter(JsonStreamTarget target, boolean repairNamespaces, boolean multiplePI, char namespaceSeparator, boolean namespaceDeclarations) {
         super(new ScopeInfo(), repairNamespaces);
@@ -131,7 +133,8 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
         this.namespaceDeclarations = namespaceDeclarations;
         this.autoEndArray = true;
         this.skipSpace = true;
-        xmlNilReadWriteEnabled = false;
+        this.xmlNilReadWriteEnabled = false;
+        this.xmlWriteNullForEmptyElement = true;
     }
 
     /**
@@ -142,9 +145,11 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
      * @param namespaceSeparator    namespace prefix separator
      * @param namespaceDeclarations whether to write namespace declarations
      * @param xmlNilReadWriteEnabled    Supports reading and writing of XML Nil elements as defined by http://www.w3.org/TR/xmlschema-1/#xsi_nil when the XML/JSON inputs contains nil/null values.
+     * @param repairNamespaces      repair Namespaces
+     * @param xmlWriteNullForEmptyElement   write null or "" for XML empty elements without nil attribute
      */
     public JsonXMLStreamWriter(JsonStreamTarget target, boolean repairNamespaces, boolean multiplePI, char namespaceSeparator, boolean namespaceDeclarations,
-                               boolean xmlNilReadWriteEnabled) {
+                               boolean xmlNilReadWriteEnabled, boolean xmlWriteNullForEmptyElement) {
         super(new ScopeInfo(), repairNamespaces);
         this.target = target;
         this.multiplePI = multiplePI;
@@ -153,6 +158,7 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
         this.autoEndArray = true;
         this.skipSpace = true;
         this.xmlNilReadWriteEnabled = xmlNilReadWriteEnabled;
+        this.xmlWriteNullForEmptyElement = xmlWriteNullForEmptyElement;
     }
 
     private String getFieldName(String prefix, String localName) {
@@ -223,10 +229,10 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
             if (getScope().getInfo().startObjectWritten) {
                 target.endObject();
             } else if (!getScope().getInfo().hasData()) {
-                if (xmlNilReadWriteEnabled) {
-                    target.value("");
-                } else {
+                if (xmlWriteNullForEmptyElement) {
                     target.value(null);
+                } else {
+                    target.value("");
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose
When converting XML payloads to JSON, the behavior as of now is as follows.
1. `<element />`  = `{"element":null}`
2. `<element nil=true />` = `{"element":{"@nil":"true"}}

If we set the Synapse property `synapse.commons.enableXmlNilReadWrite` to true, the behavior changes to the following.
1. `<element />`  = `{"element":""}`
2. `<element nil=true />` = `{"element":null}

The issue here is setting `synapse.commons.enableXmlNilReadWrite` to true or false shouldn't affect how empty XML elements without `nil` attribute is converted. That is a separate concern itself. 

## Goals
This PR adds the following new property to determine whether to transform empty XML elements without `nil` attribute to `null` or `""` string when converting to JSON.

```
synapse.commons.enableXmlNullForEmptyElement
```

The default value of this property is `true`. i.e. by default, empty XML elements without `nil` attribute will be converted to `null`.

## Approach
The following matrix shows the behaviors involved when using this property with the already existing one `synapse.commons.enableXmlNilReadWrite`, that determines the behavior for empty XML elements with `nil` attribute.
1. The column in blue is the default state where no property is exclusively set. The new property synapse.commons.enableXmlNullForEmptyElement is defaulted to `true` to avoid changing the existing behavior. 
2. The cells in red are the instances where the behavior changes from the existing ones. The value in grey shows the behavior before the fix, and the one in red is the behavior after the fix.
3. The third row is when the `nil` attribute is involved and remains unchanged by the value in the newly introduced property synapse.commons.enableXmlNullForEmptyElement.
![image](https://user-images.githubusercontent.com/505989/32239446-91c3a6d0-be90-11e7-8174-d07d44be2ad7.png)

This change only affects XML->JSON, and not JSON->XML path which has already documented behavior of converting `null` and `""` strings to `<element></element>`. 

## User stories
Conversion of an empty XML element without `nil` attribute set to `true` or `false`, to JSON.

## Release note
Fixed conversion of empty XML element without nil attribute to by default "".

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Existing tests cover the scenarios addressed by this property.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Included in Goals and Approach sections

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04
JDK 1.8.0_77
 
## Learning
N/A