### PR TITLE
set port number greater than 2000

### DIFF
--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/utils/http/server/SimpleHttpServer.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/utils/http/server/SimpleHttpServer.java
@@ -76,8 +76,10 @@ public class SimpleHttpServer implements HttpServer {
      * @return a port number.
      */
     private int selectAvailablePort() {
-        int port = new Random().nextInt(9999);
-        port = Math.abs(port);
+        //port must be greater than 1024
+        int port = new Random().nextInt(7000);
+        port = Math.abs(port) + 2000;
+
         if (TCPUtils.isPortOpen(port, "localhost")) {
             return selectAvailablePort();
         }


### PR DESCRIPTION
## Purpose
> set port number to be greater than 2000 to avoid permission denied 