### PR TITLE
Add unit tests for StatisticDataCollectionHelper, EJBMediator, XMLToTemplateMapper classes

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/util/StatisticDataCollectionHelperTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/util/StatisticDataCollectionHelperTest.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.aspects.flow.statistics.util;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.aspects.flow.statistics.data.raw.StatisticDataUnit;
+import org.apache.synapse.config.Entry;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.TestUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Unit tests for StatisticDataCollectionHelper class.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RuntimeStatisticCollector.class)
+public class StatisticDataCollectionHelperTest {
+
+    private static Axis2MessageContext messageContext;
+    private static Axis2MessageContext messageContextOld;
+    private static Axis2MessageContext messageContextNew;
+
+    /**
+     * Initializing message context.
+     *
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void initialize() throws Exception {
+        String samplePayload = "<test>value</test>";
+        Map<String, Entry> properties = new HashMap<>();
+        messageContext = TestUtils.getAxis2MessageContext(samplePayload, properties);
+        messageContextOld = TestUtils.getAxis2MessageContext(samplePayload, properties);
+        messageContextNew = TestUtils.getAxis2MessageContext(samplePayload, properties);
+    }
+
+    /**
+     * Test getStatisticTraceId method by validating returned string.
+     */
+    @Test
+    public void testGetStatisticTraceId() {
+        //inserting text value here to distinguish from numeric values later appended
+        String id = "testId";
+        messageContext.setProperty(StatisticsConstants.FLOW_STATISTICS_ID, id);
+        String traceId = StatisticDataCollectionHelper.getStatisticTraceId(messageContext);
+        Assert.assertTrue("should return concatenation of id and timestamp",traceId.contains(id));
+    }
+
+    /**
+     * Test getFlowPosition method for start and increment.
+     */
+    @Test
+    public void testGetFlowPosition() {
+        int currentIndex = StatisticDataCollectionHelper.getFlowPosition(messageContext);
+        Assert.assertEquals("index should start from 0", 0, currentIndex);
+        Assert.assertNotNull("indexing object must be set by the method", messageContext.getProperty
+                (StatisticsConstants.MEDIATION_FLOW_STATISTICS_INDEXING_OBJECT));
+        currentIndex = StatisticDataCollectionHelper.getFlowPosition(messageContext);
+        Assert.assertEquals("index should be incremented to 1", 1, currentIndex);
+    }
+
+    /**
+     * Test getParentFlowPosition method for default and inserted parent ids.
+     */
+    @Test
+    public void testGetParentFlowPosition() {
+        int position = StatisticDataCollectionHelper.getParentFlowPosition(messageContext, 0);
+        Assert.assertNotNull("should set a new parent index property",
+                messageContext.getProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_INDEX));
+        Assert.assertEquals("should return the default parent index",
+                StatisticsConstants.DEFAULT_PARENT_INDEX, position);
+        messageContext.setProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_INDEX, 1);
+        Assert.assertEquals("should return the inserted value to the parent index property",
+                1, StatisticDataCollectionHelper.getParentFlowPosition(messageContext, 0));
+    }
+
+    /**
+     * Test getParentList method by validating parent id list.
+     */
+    @Test
+    public void testGetParentList() {
+        Assert.assertNull("should return null since no list added",
+                StatisticDataCollectionHelper.getParentList(messageContext));
+        List<Integer> parentList = Arrays.asList(1, 2, 3);
+        messageContext.setProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_LIST, parentList);
+        Assert.assertEquals("should return the added parentList",
+                parentList, StatisticDataCollectionHelper.getParentList(messageContext));
+    }
+
+    /**
+     * Test isOutOnlyFlow method for true and false cases.
+     */
+    @Test
+    public void testIsOutOnlyFlow() {
+        messageContext.setProperty(SynapseConstants.OUT_ONLY, "true");
+        Assert.assertTrue("should return true", StatisticDataCollectionHelper.isOutOnlyFlow(messageContext));
+        messageContext.setProperty(SynapseConstants.OUT_ONLY, "false");
+        Assert.assertFalse("should return false", StatisticDataCollectionHelper.isOutOnlyFlow(messageContext));
+    }
+
+    /**
+     * Test collectAggregatedParents method by validating aggregated parent IDs.
+     */
+    @Test
+    public void testCollectAggregatedParents() {
+        PowerMockito.mockStatic(RuntimeStatisticCollector.class);
+        PowerMockito.when(RuntimeStatisticCollector.isStatisticsEnabled()).thenReturn(true);
+        PowerMockito.when(RuntimeStatisticCollector.shouldReportStatistic(any(MessageContext.class))).thenReturn(true);
+        messageContextOld.setProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_INDEX, 1);
+        messageContextNew.setProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_INDEX, 2);
+        List<MessageContext> messageList = new ArrayList<>();
+        messageList.add(messageContextOld);
+        StatisticDataCollectionHelper.collectAggregatedParents(messageList, messageContextNew);
+        List<Integer> parentList = Arrays.asList(1);
+        Assert.assertEquals("should return all the parent indices in message list", parentList, messageContextNew
+                .getProperty(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_LIST));
+    }
+
+    /**
+     * Test collectData method by validating dataUnit.
+     */
+    @Test
+    public void testCollectData() {
+        PowerMockito.mockStatic(RuntimeStatisticCollector.class);
+        PowerMockito.when(RuntimeStatisticCollector.isCollectingPayloads()).thenReturn(true);
+        PowerMockito.when(RuntimeStatisticCollector.isCollectingProperties()).thenReturn(true);
+        StatisticDataUnit dataUnit = new StatisticDataUnit();
+        StatisticDataCollectionHelper.collectData(messageContext, true, true, dataUnit);
+        Assert.assertNotNull("context properties should be inserted", dataUnit.getContextPropertyMap());
+        Assert.assertNotNull("transport properties should be inserted", dataUnit.getTransportPropertyMap());
+        Assert.assertNotNull("payload should be inserted", dataUnit.getPayload());
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/XMLToTemplateMapperTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/XMLToTemplateMapperTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.synapse.endpoints.Template;
+import org.apache.synapse.mediators.template.TemplateMediator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Properties;
+
+/**
+ * Unit tests for XMLToTemplateMapper class.
+ */
+public class XMLToTemplateMapperTest {
+
+    private XMLToTemplateMapper mapper = new XMLToTemplateMapper();
+    private Properties properties = new Properties();
+    private final String NAME = "HelloWordLogger";
+
+    /**
+     * Test getObjectFromOMNode by parsing a XML with sequence tag.
+     *
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testGetObjectFromOMNodeSequence() throws XMLStreamException {
+        String input = "<template xmlns=\"http://ws.apache.org/ns/synapse\" name=\"" + NAME + "\">\n" +
+                "   <sequence>\n" +
+                "      <log level=\"full\">\n" +
+                "         <property xmlns:ns2=\"http://org.apache.synapse/xsd\" name=\"message\" " +
+                "expression=\"$func:message\"></property>\n" +
+                "      </log>\n" +
+                "   </sequence>\n" +
+                "</template>";
+        OMElement element = AXIOMUtil.stringToOM(input);
+        TemplateMediator templateMediator = (TemplateMediator) mapper.getObjectFromOMNode(element, properties);
+        Assert.assertEquals("name should be parsed into the element", NAME, templateMediator.getName());
+    }
+
+    /**
+     * Test getObjectFromOMNode by parsing a XML with endpoint tag.
+     *
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testGetObjectFromOMNodeEndpoint() throws XMLStreamException {
+        String input = "<template xmlns=\"http://ws.apache.org/ns/synapse\" name=\"HelloWordLogger\">\n" +
+                "<endpoint>\n" +
+                "         <address uri=\"http://localhost:9000/services/SimpleStockQuoteService\"/>\n" +
+                "      </endpoint>" +
+                "</template>";
+        OMElement element = AXIOMUtil.stringToOM(input);
+        Template template = (Template) mapper.getObjectFromOMNode(element, properties);
+        Assert.assertEquals("name should be parsed into the template", NAME, template.getName());
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/mediators/bean/Enterprise/EJBMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/bean/Enterprise/EJBMediatorTest.java
@@ -60,9 +60,6 @@ public class EJBMediatorTest {
     private static EJBMediator ejbMediator = new EJBMediator();
     private static EnterpriseBeanstalk beanstalk;
 
-    @Rule
-    public static ExpectedException thrown = ExpectedException.none();
-
     /**
      * Initializing EJBMediator and Mediating a messageContext
      */
@@ -74,6 +71,7 @@ public class EJBMediatorTest {
         Mockito.when(synapseEnvironment.getServerContextInformation()).thenReturn(contextInformation);
         try {
             ejbMediator.init(synapseEnvironment);
+            Assert.fail("executed successfully when exception is expected");
         } catch (Exception ex) {
             Assert.assertEquals("assert exception class", SynapseException.class, ex.getClass());
             Assert.assertEquals("assert exception message",
@@ -84,6 +82,7 @@ public class EJBMediatorTest {
         contextInformation.addProperty(EnterpriseBeanstalkConstants.BEANSTALK_MANAGER_PROP_NAME, beanstalkManager);
         try {
             ejbMediator.init(synapseEnvironment);
+            Assert.fail("executed successfully when exception is expected");
         } catch (Exception ex) {
             Assert.assertEquals("assert exception class", SynapseException.class, ex.getClass());
             Assert.assertEquals("assert exception message", "Initialization failed. '"

--- a/modules/core/src/test/java/org/apache/synapse/mediators/bean/Enterprise/EJBMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/bean/Enterprise/EJBMediatorTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.mediators.bean.Enterprise;
+
+import org.apache.synapse.ServerConfigurationInformation;
+import org.apache.synapse.ServerContextInformation;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.commons.beanstalk.enterprise.EnterpriseBeanstalk;
+import org.apache.synapse.commons.beanstalk.enterprise.EnterpriseBeanstalkConstants;
+import org.apache.synapse.commons.beanstalk.enterprise.EnterpriseBeanstalkManager;
+import org.apache.synapse.config.Entry;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.TestUtils;
+import org.apache.synapse.mediators.Value;
+import org.apache.synapse.mediators.bean.BeanUtils;
+import org.apache.synapse.mediators.bean.enterprise.EJBMediator;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Unit tests for EJBMediator class.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BeanUtils.class, EnterpriseBeanstalk.class})
+public class EJBMediatorTest {
+
+    private static final String BEANSTALK_NAME = "testBeansTalk";
+    private static final String CLASS_NAME = "testClassName";
+    private static final String JNDI_NAME = "testJndiName";
+    private static final String VALUE = "testValue";
+    private static EJBMediator ejbMediator = new EJBMediator();
+    private static EnterpriseBeanstalk beanstalk;
+
+    @Rule
+    public static ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Initializing EJBMediator and Mediating a messageContext
+     */
+    @Test
+    public void testInitAndMediate() throws Exception {
+        SynapseEnvironment synapseEnvironment = Mockito.mock(SynapseEnvironment.class);
+        ServerConfigurationInformation configurationInformation = new ServerConfigurationInformation();
+        ServerContextInformation contextInformation = new ServerContextInformation(configurationInformation);
+        Mockito.when(synapseEnvironment.getServerContextInformation()).thenReturn(contextInformation);
+        try {
+            ejbMediator.init(synapseEnvironment);
+        } catch (Exception ex) {
+            Assert.assertEquals("assert exception class", SynapseException.class, ex.getClass());
+            Assert.assertEquals("assert exception message",
+                    "Initialization failed. BeanstalkManager not found.", ex.getMessage());
+        }
+        ejbMediator.setBeanstalkName(BEANSTALK_NAME);
+        EnterpriseBeanstalkManager beanstalkManager = Mockito.mock(EnterpriseBeanstalkManager.class);
+        contextInformation.addProperty(EnterpriseBeanstalkConstants.BEANSTALK_MANAGER_PROP_NAME, beanstalkManager);
+        try {
+            ejbMediator.init(synapseEnvironment);
+        } catch (Exception ex) {
+            Assert.assertEquals("assert exception class", SynapseException.class, ex.getClass());
+            Assert.assertEquals("assert exception message", "Initialization failed. '"
+                    + BEANSTALK_NAME + "' " + "beanstalk not found.", ex.getMessage());
+        }
+        beanstalk = PowerMockito.mock(EnterpriseBeanstalk.class);
+        Value beanId = new Value(VALUE);
+        ejbMediator.setBeanId(beanId);
+        Object obj = new Object();
+        PowerMockito.when(beanstalk.getEnterpriseBean(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(obj);
+        PowerMockito.when(beanstalkManager.getBeanstalk(BEANSTALK_NAME)).thenReturn(beanstalk);
+        PowerMockito.mockStatic(BeanUtils.class);
+        PowerMockito.when(BeanUtils.invokeInstanceMethod(any(Object.class), any(Method.class), any(Object[].class)))
+                .thenReturn(new Object());
+        ejbMediator.init(synapseEnvironment);
+        String samplePayload = "<test>value</test>";
+        Map<String, Entry> properties = new HashMap<>();
+        Axis2MessageContext messageContext = TestUtils.getAxis2MessageContext(samplePayload, properties);
+        ejbMediator.setClassName(CLASS_NAME);
+        ejbMediator.setJndiName(JNDI_NAME);
+        Assert.assertTrue("mediation must be successful", ejbMediator.mediate(messageContext));
+    }
+}


### PR DESCRIPTION
## Purpose
> Add unit tests for StatisticDataCollectionHelper class

## Goals
> Improve unit test coverage 

## Automation tests
 - Unit tests 
   > 98% | 48% | 86%


## Test environment
> JDK 8 ,  Ubuntu 16.04 