### PR TITLE
Shutdown the thread pool started in PassThroughHttpListener

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -424,6 +424,7 @@ public class PassThroughHttpListener implements TransportListener {
                 passThroughListeningIOReactorManager.shutdownIOReactor(operatingPort);
             }
             serviceTracker.stop();
+            handler.stop();
         } catch (IOException e) {
             handleException("Error shutting down " + namePrefix + " listening IO reactor", e);
         } catch (InterruptedException e) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -600,7 +600,8 @@ public class SourceHandler implements NHttpServerEventHandler {
             if (sourceConfiguration.getWorkerPool() != null) {
                 sourceConfiguration.getWorkerPool().shutdown(1000);
             }
-        } catch (InterruptedException ignore) {
+        } catch (InterruptedException e) {
+            log.warn("Error while shutting down worker thread pool. " + e.getMessage());
         }
     }
     

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -589,7 +589,20 @@ public class SourceHandler implements NHttpServerEventHandler {
             handleException("IO error submiting response : " + e.getMessage(), e, conn);
         }
     }
-    
+    /**
+     * Shutting down the thread pools.
+     */
+    public void stop() {
+        latencyView.destroy();
+        s2sLatencyView.destroy();
+        threadingView.destroy();
+        try {
+            if (sourceConfiguration.getWorkerPool() != null) {
+                sourceConfiguration.getWorkerPool().shutdown(1000);
+            }
+        } catch (InterruptedException ignore) {
+        }
+    }
     
     // ----------- utility methods -----------
 


### PR DESCRIPTION
## Purpose
> PassThroughHttpListener creates three thread pools and does not shutdown them on the stop.
This will shutdown the thread pools when the listener stop.