### PR TITLE
Add unit tests for SynapseImportFactory, SynapseImportSerializer and MediatorPropertySerializer

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorPropertySerializerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorPropertySerializerTest.java
@@ -1,0 +1,99 @@
+/*
+*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.mediators.MediatorProperty;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for MediatorPropertySerializer.
+ */
+public class MediatorPropertySerializerTest {
+
+    private final String XML = "<property xmlns:ns2=\"http://org.apache.synapse/xsd\" > </property>\n";
+    private final String NAME = "testName";
+    private final String VALUE = "testValue";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Test SerializeMediatorProperties for correct insertion of properties.
+     *
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testSerializeMediatorProperties() throws XMLStreamException {
+        OMElement element = AXIOMUtil.stringToOM(XML);
+        List<MediatorProperty> propertyList = new ArrayList<>();
+        MediatorProperty property = new MediatorProperty();
+        property.setName(NAME);
+        property.setValue(VALUE);
+        propertyList.add(property);
+        MediatorPropertySerializer.serializeMediatorProperties(element, propertyList);
+        OMElement firstElement = element.getFirstElement();
+        Assert.assertEquals("name of property must be added as an attribute", NAME,
+                firstElement.getAttribute(new QName("name")).getAttributeValue());
+        Assert.assertEquals("value of property must be added as an attribute", VALUE,
+                firstElement.getAttribute(new QName("value")).getAttributeValue());
+    }
+
+    /**
+     * Test SerializeMediatorProperties for a property without name.
+     *
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testSerializeWithoutPropertyName() throws XMLStreamException {
+        OMElement element = AXIOMUtil.stringToOM(XML);
+        List<MediatorProperty> propertyList = new ArrayList<>();
+        MediatorProperty property = new MediatorProperty();
+        propertyList.add(property);
+        thrown.expect(SynapseException.class);
+        thrown.expectMessage("Mediator property name missing");
+        MediatorPropertySerializer.serializeMediatorProperties(element, propertyList);
+    }
+
+    /**
+     * Test SerializeMediatorProperties for a property without value.
+     *
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testSerializeWithoutPropertyValue() throws XMLStreamException {
+        OMElement element = AXIOMUtil.stringToOM(XML);
+        List<MediatorProperty> propertyList = new ArrayList<>();
+        MediatorProperty property = new MediatorProperty();
+        property.setName(NAME);
+        propertyList.add(property);
+        thrown.expect(SynapseException.class);
+        thrown.expectMessage("Mediator property must have a literal value or be an expression");
+        MediatorPropertySerializer.serializeMediatorProperties(element, propertyList);
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseImportFactoryTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseImportFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.libraries.imports.SynapseImport;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Properties;
+
+/**
+ * Unit tests for SynapseImportFactory class.
+ */
+public class SynapseImportFactoryTest {
+
+    private final String XML1 = "<property xmlns:ns2=\"http://org.apache.synapse/xsd\"> </property>\n";
+    private final String XML2 = "<property xmlns:ns2=\"http://org.apache.synapse/xsd\" " +
+            "name=\"testName\"> </property>\n";
+    private final String XML3 = "<property xmlns:ns2=\"http://org.apache.synapse/xsd\" " +
+            "name=\"testName\" package=\"testPackage\"> </property>\n";
+    private final String XML4 = "<property xmlns:ns2=\"http://org.apache.synapse/xsd\" " +
+            "name=\"testName\" package=\"testPackage\" status=\"enabled\"> </property>\n";
+
+    /**
+     * Test CreateImport method using different XML formats.
+     * @throws XMLStreamException
+     */
+    @Test
+    public void testCreateImport() throws XMLStreamException {
+        Properties properties = new Properties();
+        OMElement element = AXIOMUtil.stringToOM(XML1);
+        try {
+            SynapseImportFactory.createImport(element,properties);
+            Assert.fail("execution successful where exception is expected");
+        } catch (Exception ex) {
+            Assert.assertEquals("asserting exception class",SynapseException.class,ex.getClass());
+            Assert.assertEquals("asserting exception message",
+                    "Synapse Import Target Library name is not specified",ex.getMessage());
+        }
+        element = AXIOMUtil.stringToOM(XML2);
+        try {
+            SynapseImportFactory.createImport(element,properties);
+            Assert.fail("execution successful where exception is expected");
+        } catch (Exception ex) {
+            Assert.assertEquals("asserting exception class",SynapseException.class,ex.getClass());
+            Assert.assertEquals("asserting exception message",
+                    "Synapse Import Target Library package is not specified",ex.getMessage());
+        }
+        element = AXIOMUtil.stringToOM(XML3);
+        SynapseImport synapseImport = SynapseImportFactory.createImport(element,properties);
+        Assert.assertFalse("status should be false when status data not provided",synapseImport.isStatus());
+        element = AXIOMUtil.stringToOM(XML4);
+        synapseImport = SynapseImportFactory.createImport(element,properties);
+        Assert.assertTrue("status should be enabled as specified in XML",synapseImport.isStatus());
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseImportSerializerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseImportSerializerTest.java
@@ -1,0 +1,104 @@
+/*
+*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.libraries.imports.SynapseImport;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Unit tests for SynapseImportSerializer class.
+ */
+public class SynapseImportSerializerTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Test serializeImport method with null value.
+     */
+    @Test
+    public void testSerializeImportNUll() {
+        thrown.expect(SynapseException.class);
+        thrown.expectMessage("Unsupported Synapse Import passed in for serialization");
+        SynapseImportSerializer.serializeImport(null);
+    }
+
+    /**
+     * Test serializeImport with incomplete synapseImport.
+     */
+    @Test
+    public void testSerializeImportNoLibName() {
+        SynapseImport synapseImport = new SynapseImport();
+        thrown.expect(SynapseException.class);
+        thrown.expectMessage("Invalid Synapse Import. Target Library name is required");
+        SynapseImportSerializer.serializeImport(synapseImport);
+    }
+
+    /**
+     * Test serializeImport with incomplete synapseImport.
+     */
+    @Test
+    public void testSerializeImportNoLibPackage() {
+        SynapseImport synapseImport = new SynapseImport();
+        synapseImport.setLibName("testLibName");
+        thrown.expect(SynapseException.class);
+        thrown.expectMessage("Invalid Synapse Import. Target Library package is required");
+        SynapseImportSerializer.serializeImport(synapseImport);
+    }
+
+    /**
+     * Test SerializeImport with valid synapseImport, status disabled.
+     */
+    @Test
+    public void testSerializeImportDisabled() {
+        SynapseImport synapseImport = new SynapseImport();
+        synapseImport.setLibName("testLibName");
+        synapseImport.setLibPackage("testVersion");
+        OMElement element = SynapseImportSerializer.serializeImport(synapseImport);
+        Assert.assertEquals("asserting OMElement name", "import", element.getLocalName());
+        OMAttribute temp = element.getAttribute(new QName("name"));
+        Assert.assertEquals("asserting name attribute", "testLibName", temp.getAttributeValue());
+        temp = element.getAttribute(new QName("package"));
+        Assert.assertEquals("asserting package attribute", "testVersion", temp.getAttributeValue());
+        temp = element.getAttribute(new QName("status"));
+        Assert.assertEquals("asserting status attribute", "disabled", temp.getAttributeValue());
+    }
+
+    /**
+     * Test SerializeImport with valid synapseImport, status enabled.
+     */
+    @Test
+    public void testSerializeImportEnabled() {
+        SynapseImport synapseImport = new SynapseImport();
+        synapseImport.setStatus(true);
+        synapseImport.setLibName("testLibName");
+        synapseImport.setLibPackage("testVersion");
+        OMElement element = SynapseImportSerializer.serializeImport(synapseImport);
+        OMAttribute temp = element.getAttribute(new QName("status"));
+        Assert.assertEquals("asserting stats attribute", "enabled", temp.getAttributeValue());
+    }
+}


### PR DESCRIPTION
## Purpose
> Add unit tests for SynapseImportFactory, SynapseImportSerializer and MediatorPropertySerializer classes

## Goals
> Improve test coverage

## Automation tests
 - Unit tests 
   > 85% | 81% | 77%

## Test environment
> JDK8, Ubuntu 16.04