### PR TITLE
Fix clear method of DatasourceMBeanRepository

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DatasourceMBeanRepository.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DatasourceMBeanRepository.java
@@ -77,8 +77,16 @@ public class DatasourceMBeanRepository implements MBeanRepository {
     public void removeMBean(String name) {
 
         dataSourcesMBeans.remove(name);
-        MBeanRegistrar.getInstance().unRegisterMBean(
-                MBEAN_CATEGORY_DATABASE_CONNECTION_POOL, name);
+        unregisterMBean(name);
+    }
+
+    /**
+     * Unregisters an MBean related to datasources without removing it from the datasource MBean map.
+     *
+     * @param name the name of the datasource Mbean to be unregistered.
+     */
+    private void unregisterMBean(String name) {
+        MBeanRegistrar.getInstance().unRegisterMBean(MBEAN_CATEGORY_DATABASE_CONNECTION_POOL, name);
     }
 
     public void clear() {
@@ -87,7 +95,7 @@ public class DatasourceMBeanRepository implements MBeanRepository {
             log.info("UnRegistering DBPool MBeans");
             for (DBPoolView dbPoolView : dataSourcesMBeans.values()) {
                 if (dbPoolView != null) {
-                    removeMBean(dbPoolView.getName());
+                    unregisterMBean(dbPoolView.getName());
                 }
             }
             dataSourcesMBeans.clear();


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-ei/issues/1302

## Goals
Avoid occurence of ConcurrentModificationException at the invocation of the method, DatasourceMBeanRepository.clear()

## Approach
Introduced new method 'unregisterMBean' to DatasourceMBeanRepository to be called when all the clearing the datasource, which only unregisters the MBeans without removing them from the 'dataSourcesMBeans' map.

## User stories
N/A, this is a bug fix for an exception that occurs.

## Release note
N/A, this is a bug fix for an exception that occurs.

## Documentation
N/A, this is a bug fix for an exception that occurs.

## Training
N/A, this is a bug fix for an exception that occurs.

## Certification
N/A, this is a bug fix for an exception that occurs.

## Marketing
N/A, this is a bug fix for an exception that occurs.

## Automation tests
 - Unit tests 
   DataSourceRepositoryManagerTest.testClear()

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A, this is a bug fix for an exception that occurs.

## Related PRs
N/A, this is a bug fix for an exception that occurs.

## Migrations (if applicable)
N/A, this is a bug fix for an exception that occurs.

## Test environment
java version "1.8.0_131"
 
## Learning
N/A, this is a bug fix for an exception that occurs.