### PR TITLE
Fix for scheduling inbound task at delete and shutdown

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
@@ -26,8 +26,13 @@ import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.*;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.Startup;
+import org.apache.synapse.SynapseArtifact;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.flow.statistics.store.CompletedStructureStore;
 import org.apache.synapse.carbonext.TenantInfoConfigProvider;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
@@ -1447,10 +1452,12 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
         }
 
         //destroy inbound endpoint
-		for (InboundEndpoint endpoint : getInboundEndpoints()) {
-			endpoint.destroy();
-		}         
-        
+        for (InboundEndpoint endpoint : getInboundEndpoints()) {
+            // This path trigger from server shutdown hook. So we don't want to remove scheduled inbound tasks
+            // from registry. Only un-deployment should remove task from registry. Ref product-ei#1206
+            endpoint.destroy(false);
+        }
+
         // destroy the managed endpoints
         for (Endpoint endpoint : getDefinedEndpoints().values()) {
             endpoint.destroy();

--- a/modules/core/src/main/java/org/apache/synapse/inbound/InboundEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/inbound/InboundEndpoint.java
@@ -140,11 +140,33 @@ public class InboundEndpoint implements AspectConfigurable, ManagedLifecycle {
         return inboundProcessorParams;
     }
 
-    public void destroy() {
+    /**
+     * Remove inbound endpoints.
+     * <p>
+     * This was introduced as a fix for product-ei#1206.
+     *
+     * @param removeTask Whether to remove scheduled task or not.
+     */
+    public void destroy(boolean removeTask) {
         log.info("Destroying Inbound Endpoint: " + getName());
         if (inboundRequestProcessor != null) {
-            inboundRequestProcessor.destroy();
+            try {
+                if (inboundRequestProcessor instanceof InboundTaskProcessor) {
+                    ((InboundTaskProcessor) inboundRequestProcessor).destroy(removeTask);
+                } else {
+                    inboundRequestProcessor.destroy();
+                }
+            } catch (Exception e) {
+                log.error("Unable to destroy Inbound endpoint", e);
+            }
         }
+    }
+
+    /**
+     * Remove inbound endpoints.
+     */
+    public void destroy() {
+        destroy(true);
     }
 
     public String getName() {

--- a/modules/core/src/main/java/org/apache/synapse/inbound/InboundTaskProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/inbound/InboundTaskProcessor.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.inbound;
+
+/**
+ * Interface to be implemented at the task inbound endpoint to distinguish task/no-task inbound endpoints
+ */
+public interface InboundTaskProcessor {
+
+    void destroy(boolean removeTask);
+
+}


### PR DESCRIPTION
## Purpose
Fix the issue of deleting registry task at cluster node shutdown with hazelcast.shutdownhook.enabled=false.

## Goals
Fixed: https://github.com/wso2/product-ei/issues/1206

## Approach
As the approach, we introduced a new parameter to differentiate shutdown and delete scenarios, and delete the registry task only at inbound endpoint delete. Inbound task at registry will remain at the shutdown scenario.

## Release note
will be released with 6.2.0

## Documentation
https://docs.wso2.com/display/EI611/Clustered+Deployment

## Related PRs
https://github.com/wso2/carbon-mediation/pull/908
