### PR TITLE
Fix EI-1329 mutipart/form-data issue

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -45,6 +45,7 @@ import org.apache.synapse.transport.nhttp.util.MessageFormatterDecoratorFactory;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 import org.apache.synapse.transport.passthru.util.PassThroughTransportUtils;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.apache.synapse.transport.passthru.util.TargetRequestFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayOutputStream;
@@ -182,9 +183,17 @@ public class TargetRequest {
 			Map _headers = (Map) o;
 			String trpContentType = (String) _headers.get(HTTP.CONTENT_TYPE);
 			if (trpContentType != null && !trpContentType.equals("")) {
-				if (!trpContentType.contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED)) {
+				if (!TargetRequestFactory.isMultipartContent(trpContentType)) {
 					addHeader(HTTP.CONTENT_TYPE, trpContentType);
 				}
+                //If the boundary is already set in the message context, the header specified in the message context
+                // should be added.
+                // Addresses both ESBJAVA-3182 and EI-1329
+                else {
+                    if (trpContentType.contains("boundary=")) {
+                        addHeader(HTTP.CONTENT_TYPE, trpContentType);
+                    }
+                }
 
 			}
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
@@ -252,10 +252,9 @@ public class TargetRequestFactory {
      * @param contentType
      * @return true for multipart content types
      */
-    private static boolean isMultipartContent(String contentType) {
-        // Identifying whether the content-type is multipart or not
-        if (contentType.contains(HTTPConstants.MEDIA_TYPE_MULTIPART_FORM_DATA) || contentType.contains(HTTPConstants
-                .HEADER_ACCEPT_MULTIPART_RELATED)) {
+    public static boolean isMultipartContent(String contentType) {
+        if (contentType.contains(HTTPConstants.MEDIA_TYPE_MULTIPART_FORM_DATA)
+            || contentType.contains(HTTPConstants.HEADER_ACCEPT_MULTIPART_RELATED)) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-ei/issues/1329

## Goals
Fix boundary value not being added when the content type, multipart/form-data is used.

## Approach
https://github.com/wso2/wso2-synapse/pull/104 allows Content-type header which was set by the formatter to be overwritten by what's in the message context as a solution for https://wso2.org/jira/browse/ESBJAVA-3182. Reverted it and fixed as appropriate where the content-type will be overwritten by what's in the context only if the message context contains a boundary value.

## User stories
n/a, this is a bug fix

## Release note
n/a, this is a bug fix

## Documentation
n/a, this is a bug fix

## Training
n/a, this is a bug fix

## Certification
n/a, this is a bug fix

## Marketing
n/a, this is a bug fix

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
n/a, this is a bug fix

## Related PRs
n/a, this is a bug fix

## Migrations (if applicable)
n/a, this is a bug fix

## Test environment
1.8.0_131
 
## Learning
n/a, this is a bug fix