### PR TITLE
[EI1381] Avoid closing xml tag after reading value

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/base/AbstractXMLStreamReader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/staxon/core/base/AbstractXMLStreamReader.java
@@ -352,7 +352,6 @@ public abstract class AbstractXMLStreamReader<T> implements XMLStreamReader {
      */
     protected void readData(String text, Object data, int type) throws XMLStreamException {
         if (hasData(type)) {
-            ensureStartTagClosed();
             queue.add(new Event(type, scope, text, data));
         } else {
             throw new XMLStreamException("Unexpected event type " + getEventName(), locationProvider);


### PR DESCRIPTION
## Purpose
Avoid closing xml tag after reading value since the closing tag is processed specifically intepreting the JSON end tag.

Fixes: https://github.com/wso2/product-ei/issues/1381

## Automation tests
 - Unit tests - PENDING
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Learning
> Staxon JSON -> XML conversion convention. https://github.com/beckchr/staxon/wiki/Mapping-Convention