### PR TITLE
Fix NPE in message processor when message body is empty

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/commons/MessageConverter.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/commons/MessageConverter.java
@@ -358,7 +358,9 @@ public final class MessageConverter {
             response.getFirstElement().detach();
         }
 
-        soapEnvelope.getBody().addChild(response.getFirstElement().getFirstElement());
+        if (response.getFirstElement().getFirstElement() != null) {
+            soapEnvelope.getBody().addChild(response.getFirstElement().getFirstElement());
+        }
 
         return soapEnvelope;
     }


### PR DESCRIPTION
## Purpose
>This is the fix for the issue https://github.com/wso2/product-ei/issues/1449
When a message without SOAP body is stored in a JDBC store and processed by a message processor, a Null Pointer Exception is thrown at the message converting end.

