### PR TITLE
[EI-1451] Avoid converting already existing SOAPHeaderBlock elements.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -31,6 +31,7 @@ import org.apache.axiom.om.util.ElementHelper;
 import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.apache.axis2.description.Parameter;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.axis2.transport.http.HTTPConstants;
@@ -878,10 +879,13 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			while (iHeader.hasNext()) {
 				try {
 					Object element = iHeader.next();
-					if (element instanceof OMElement) {
+					// If the element is already a SOAPHeaderBlock, we do not need to convert it. Doing so will incur
+					// a removal of the element based on OMAbstractIterator, and sets the
+					// OMSourcedElementImpl.datasource to null, causing an NPE when serializing in future.
+					if (element instanceof  OMElement && !(element instanceof SOAPHeaderBlock)) {
 						newHeaderNodes.add(ElementHelper.toSOAPHeaderBlock((OMElement) element, fac));
+						iHeader.remove();
 					}
-					iHeader.remove();
 				} catch (OMException e) {
 					log.error("Unable to convert to SoapHeader Block", e);
 				} catch (Exception e) {


### PR DESCRIPTION
## Purpose
> If the element is already a SOAPHeaderBlock, we do not need to convert it.
Doing so will incur a removal of the element based on OMAbstractIterator, and sets the OMSourcedElementImpl.datasource to null, causing an NPE when serializing in future.

Fixes : https://github.com/wso2/product-ei/issues/1451

## Automation tests
 - Integration tests
   > In progress

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes