### PR TITLE
Fix the issue of VFS proxy with startOnLoad="false" becomes active after server restart.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -882,8 +882,10 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
 
             AxisService as = axisConfig.getServiceForActivation(this.getName());
             //If an active AxisService is found
-            if (as != null && as.isActive()) {
-                as.setActive(false);
+            if (as != null) {
+                if (as.isActive()) {
+                    as.setActive(false);
+                }
                 axisConfig.notifyObservers(new AxisEvent(AxisEvent.SERVICE_STOP, as), as);
             }
             this.setRunning(false);

--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -97,7 +97,7 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                 log.info("ProxyService named '" + proxy.getName()
                         + "' has been deployed from file : " + filePath);
 
-                if (!proxy.isStartOnLoad()) {
+                if (!proxy.isStartOnLoad() || !axisService.isActive()) {
                     proxy.stop(getSynapseConfiguration());
                     log.info("ProxyService named '" + proxy.getName()
                              + "' has been stopped as startOnLoad parameter is set to false");


### PR DESCRIPTION
## Purpose
> Fix the issue of VFS proxy with startOnLoad="false" becomes active after server restart.
Fixes : https://github.com/wso2/product-ei/issues/1439
https://github.com/wso2/product-ei/issues/1465
