### PR TITLE
Add Unit tests for passthru.config package

### DIFF
--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/BaseConfigurationTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/BaseConfigurationTest.java
@@ -1,0 +1,142 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.apache.synapse.transport.passthru.config;
+
+import junit.framework.Assert;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.description.Parameter;
+import org.apache.axis2.description.TransportInDescription;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.base.threads.WorkerPool;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.params.HttpParams;
+import org.apache.http.params.HttpProtocolParams;
+import org.apache.synapse.transport.http.conn.Scheme;
+import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
+import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
+import org.apache.synapse.transport.passthru.util.PassThroughTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for BaseConfiguration.
+ */
+public class BaseConfigurationTest {
+
+    private static final int DEFAULT_WORKER_POOL_SIZE_CORE = 40;
+    private static final int DEFAULT_IO_BUFFER_SIZE = 8 * 1024;
+    private static final String HOST = "127.0.0.1";
+    private static final int PORT = 8285;
+    private PassThroughConfiguration conf = PassThroughTestUtils.getPassThroughConfiguration();
+    private static TransportInDescription transportInDescription = new TransportInDescription("http");
+    private ConfigurationContext cfgCtx = null;
+    private Scheme scheme = null;
+    private BaseConfiguration baseConfiguration = null;
+    private PassThroughTransportMetricsCollector metrics = null;
+
+    @Before
+    public void setUp() throws Exception {
+        Parameter portParam = new Parameter("port", PORT);
+        portParam.setParameterElement(
+                AXIOMUtil.stringToOM("<parameter name=\"port\" locked=\"false\">" + PORT + "</parameter>"));
+        Parameter hostParam = new Parameter("hostname", HOST);
+        transportInDescription.addParameter(portParam);
+        transportInDescription.addParameter(hostParam);
+        cfgCtx = new ConfigurationContext(new AxisConfiguration());
+        cfgCtx.setServicePath("services");
+        cfgCtx.setContextRoot("/");
+        scheme = new Scheme(transportInDescription.getName(), PORT, false);
+        metrics = new PassThroughTransportMetricsCollector(true, scheme.getName());
+        baseConfiguration = new SourceConfiguration(cfgCtx, transportInDescription,
+                scheme, PassThroughTestUtils.getWorkerPool(conf), metrics);
+        baseConfiguration.build();
+    }
+
+    @Test
+    public void testBuild() throws Exception {
+        Assert.assertNotNull("Building base configuration isn't successful.", baseConfiguration);
+        Assert.assertNotNull("Worker pool hasn't been initialized.", baseConfiguration.getWorkerPool());
+        Assert.assertNotSame("Worker thread count hasn't been taken from passthru-http.properties file",
+                conf.getWorkerPoolCoreSize(), DEFAULT_WORKER_POOL_SIZE_CORE);
+
+    }
+
+    @Test
+    public void testGetWorkerPool() throws Exception {
+        Assert.assertNotNull("Worker pool hasn't been initialized.", baseConfiguration.getWorkerPool());
+    }
+
+    @Test
+    public void testGetIOBufferSize() throws Exception {
+        Assert.assertNotNull("IO Buffer hasn't been initialized.", baseConfiguration.getIOBufferSize());
+        Assert.assertNotSame("IO buffer size hasn't been taken from passthru-http.properties file",
+                conf.getIOBufferSize(), DEFAULT_IO_BUFFER_SIZE);
+    }
+
+    @Test
+    public void testGetConfigurationContext() throws Exception {
+        Assert.assertNotNull("Configuration context hasn't been initialized.",
+                baseConfiguration.getConfigurationContext());
+    }
+
+    @Test
+    public void testBuildHttpParams() throws Exception {
+        HttpParams httpParams = baseConfiguration.buildHttpParams();
+        Assert.assertNotNull("HTTP Parameters hasn't been initialized.", httpParams);
+        String originServer = (String) httpParams.getParameter(HttpProtocolParams.ORIGIN_SERVER);
+        Assert.assertEquals("Origin Server isn't correct.", "WSO2-PassThrough-HTTP", originServer);
+    }
+
+    @Test
+    public void testBuildIOReactorConfig() throws Exception {
+        IOReactorConfig config = baseConfiguration.buildIOReactorConfig();
+        int expectedIOThreadCount = Runtime.getRuntime().availableProcessors();
+        Assert.assertNotNull("I/O Reactor hasn't been initialized.", config);
+        Assert.assertEquals("I/O reactor thread count isn't correct.",
+                expectedIOThreadCount, config.getIoThreadCount());
+    }
+
+    @Test
+    public void testGetBufferFactory() throws Exception {
+        Assert.assertNotNull("BufferFactor is null.", baseConfiguration.getBufferFactory());
+        Assert.assertTrue("Buffer isn't an instance of ControlledByteBuffer.",
+                baseConfiguration.getBufferFactory().getBuffer() instanceof ControlledByteBuffer);
+    }
+
+    @Test
+    public void testGetMetrics() throws Exception {
+        Assert.assertNotNull("Metrics hasn't been initialized.", baseConfiguration.getMetrics());
+    }
+
+    @Test
+    public void testBuildwithDefaultWorkerPool() throws Exception {
+        baseConfiguration = new SourceConfiguration(cfgCtx, transportInDescription, scheme, null, metrics);
+        baseConfiguration.build();
+        Assert.assertNotNull("Building base configuration isn't successful.", baseConfiguration);
+        Assert.assertNotNull("Worker pool hasn't been initialized.", baseConfiguration.getWorkerPool());
+    }
+
+    @Test
+    public void testDefaultWorkerPool() throws Exception {
+        WorkerPool workerPool = baseConfiguration.getWorkerPool(0, 0, 0, 0, null, null);
+        Assert.assertNotNull("Worker pool hasn't been initialized.", workerPool);
+    }
+
+}

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/SourceConfigurationTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/SourceConfigurationTest.java
@@ -1,0 +1,242 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.apache.synapse.transport.passthru.config;
+
+import junit.framework.Assert;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.description.Parameter;
+import org.apache.axis2.description.TransportInDescription;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.base.threads.WorkerPool;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.params.HttpParams;
+import org.apache.http.params.HttpProtocolParams;
+import org.apache.synapse.transport.http.conn.Scheme;
+import org.apache.synapse.transport.passthru.HttpGetRequestProcessor;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
+import org.apache.synapse.transport.passthru.util.PassThroughTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for SourceConfiguration.
+ */
+public class SourceConfigurationTest {
+
+    private static final int DEFAULT_WORKER_POOL_SIZE_CORE = 40;
+    private static final String HOST = "127.0.0.1";
+    private static final int PORT = 8285;
+    private PassThroughConfiguration passThroughConfiguration = PassThroughTestUtils.getPassThroughConfiguration();
+    private static TransportInDescription transportInDescription = new TransportInDescription("http");
+    private static final String HTTP_GET_PROCESSOR =
+            "org.apache.synapse.transport.passthru.api.PassThroughNHttpGetProcessor";
+    private static final String INVALID_HTTP_GET_PROCESSOR = "org.apache.synapse.transport.InvalidClass";
+    private static final String INCORRECT_HTTP_GET_PROCESSOR =
+            "org.apache.synapse.transport.nhttp.DefaultHttpGetProcessor";
+    private static final String WSDLPREFIX = "http://apachehost:" + PORT + "/somepath";
+    private ConfigurationContext cfgCtx = null;
+    private Scheme scheme = null;
+    private SourceConfiguration sourceConfiguration = null;
+    private PassThroughTransportMetricsCollector metrics = null;
+
+    @Before
+    public void setUp() throws Exception {
+        Parameter portParam = new Parameter("port", PORT);
+        portParam.setParameterElement(
+                AXIOMUtil.stringToOM("<parameter name=\"port\" locked=\"false\">" + PORT + "</parameter>"));
+        Parameter hostParam = new Parameter("hostname", HOST);
+        transportInDescription.addParameter(portParam);
+        transportInDescription.addParameter(hostParam);
+        cfgCtx = new ConfigurationContext(new AxisConfiguration());
+        cfgCtx.setServicePath("services");
+        cfgCtx.setContextRoot("/");
+        scheme = new Scheme(transportInDescription.getName(), PORT, false);
+        metrics = new PassThroughTransportMetricsCollector(true, scheme.getName());
+        sourceConfiguration = new SourceConfiguration(cfgCtx, transportInDescription,
+                scheme, PassThroughTestUtils.getWorkerPool(passThroughConfiguration), metrics);
+        sourceConfiguration.build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Parameter wsdlPrefix = transportInDescription.getParameter("WSDLEPRPrefix");
+        Parameter httpGetProcessor = transportInDescription.getParameter("httpGetProcessor");
+        if (wsdlPrefix != null) {
+            transportInDescription.removeParameter(wsdlPrefix);
+        }
+        if (httpGetProcessor != null) {
+            transportInDescription.removeParameter(httpGetProcessor);
+        }
+    }
+
+    @Test
+    public void testBuild() throws Exception {
+        Assert.assertNotNull("Building base configuration isn't successful.", sourceConfiguration);
+        Assert.assertNotNull("Worker pool hasn't been initialized.", sourceConfiguration.getWorkerPool());
+        Assert.assertNotSame("Worker thread count hasn't been taken from passthru-http.properties file",
+                passThroughConfiguration.getWorkerPoolCoreSize(), DEFAULT_WORKER_POOL_SIZE_CORE);
+    }
+
+    @Test
+    public void testGetHttpParams() throws Exception {
+        HttpParams httpParams = sourceConfiguration.getHttpParams();
+        Assert.assertNotNull("HTTP Parameters are null.", httpParams);
+        String originServer = (String) httpParams.getParameter(HttpProtocolParams.ORIGIN_SERVER);
+        Assert.assertEquals("Origin Server isn't correct.", "WSO2-PassThrough-HTTP", originServer);
+
+    }
+
+    @Test
+    public void testGetIOReactorConfig() throws Exception {
+        IOReactorConfig config = sourceConfiguration.getIOReactorConfig();
+        int expectedIOThreadCount = Runtime.getRuntime().availableProcessors();
+        Assert.assertNotNull("I/O Reactor hasn't been initialized.", config);
+        Assert.assertEquals("I/O reactor thread count isn't correct.",
+                expectedIOThreadCount, config.getIoThreadCount());
+    }
+
+    @Test
+    public void testGetHttpProcessor() throws Exception {
+        Assert.assertNotNull("HttpProcessor hasn't been initialized.", sourceConfiguration.getHttpProcessor());
+    }
+
+    @Test
+    public void testGetResponseFactory() throws Exception {
+        Assert.assertNotNull("ResponseFactory hasn't been initialized.", sourceConfiguration.getResponseFactory());
+    }
+
+    @Test
+    public void testGetHostname() throws Exception {
+        String hostName = sourceConfiguration.getHostname();
+        Assert.assertNotNull("Host hasn't been initialized.", hostName);
+        Assert.assertEquals("Host name doesn't match with : " + HOST, HOST, hostName);
+    }
+
+    @Test
+    public void testGetPort() throws Exception {
+        int port = sourceConfiguration.getPort();
+        Assert.assertNotNull("Host hasn't been initialized.", port);
+        Assert.assertEquals("Port doesn't match with : " + PORT, PORT, port);
+    }
+
+    @Test
+    public void testGetSourceConnections() throws Exception {
+        Assert.assertNotNull("Source Connections hasn't been initialized.", sourceConfiguration.getSourceConnections());
+    }
+
+    @Test
+    public void testGetInDescription() throws Exception {
+        Assert.assertNotNull("ResponseFactory hasn't been initialized.", sourceConfiguration.getInDescription());
+    }
+
+    @Test
+    public void testGetScheme() throws Exception {
+        Scheme scheme = sourceConfiguration.getScheme();
+        String expectedSchemeName = transportInDescription.getName();
+        Assert.assertNotNull("ResponseFactory hasn't been initialized.", scheme);
+        Assert.assertEquals("Scheme doesn't match with : " + expectedSchemeName, expectedSchemeName, scheme.getName());
+    }
+
+    @Test
+    public void testGetServiceEPRPrefix() throws Exception {
+        String serviceEPPrefix = sourceConfiguration.getServiceEPRPrefix();
+        Assert.assertNotNull("Service EPR prefix hasn't been initialized.", serviceEPPrefix);
+        Assert.assertEquals("Service Endpoint prefix isn't correct.",
+                scheme.getName() + "://" + HOST + "/services/", serviceEPPrefix);
+    }
+
+    @Test
+    public void testGetServiceEPWithWSDLPrefix() throws Exception {
+        Parameter wsdlPrefix = new Parameter("WSDLEPRPrefix", WSDLPREFIX);
+        wsdlPrefix.setParameterElement(AXIOMUtil.stringToOM(
+                "<parameter name=\"WSDLEPRPrefix\" locked=\"false\">" + WSDLPREFIX + "</parameter>"));
+        transportInDescription.addParameter(wsdlPrefix);
+        sourceConfiguration.build();
+        String serviceEPPrefix = sourceConfiguration.getServiceEPRPrefix();
+        Assert.assertNotNull("Service EPR prefix hasn't been initialized.", serviceEPPrefix);
+        Assert.assertEquals("Service Endpoint with WDSLPrefix isn't correct.", WSDLPREFIX +
+                "/services/", serviceEPPrefix);
+    }
+
+    @Test
+    public void testGetCustomEPRPrefix() throws Exception {
+        Assert.assertNotNull("Custom EPR prefix hasn't been initialized.", sourceConfiguration.getCustomEPRPrefix());
+    }
+
+    @Test
+    public void testGetHttpGetRequestProcessor() throws Exception {
+        Parameter httpGetProcessor = new Parameter("httpGetProcessor", HTTP_GET_PROCESSOR);
+        httpGetProcessor.setParameterElement(AXIOMUtil.stringToOM("" +
+                "<parameter name=\"httpGetProcessor\" locked=\"false\">" + HTTP_GET_PROCESSOR + "</parameter>"));
+        transportInDescription.addParameter(httpGetProcessor);
+        sourceConfiguration.build();
+        HttpGetRequestProcessor httpGetRequestProcessor = sourceConfiguration.getHttpGetRequestProcessor();
+        Assert.assertNotNull("httpGetProcessor hasn't been initialized.", httpGetRequestProcessor);
+        Assert.assertEquals("Service Endpoint with WDSLPrefix isn't correct.",
+                httpGetRequestProcessor.getClass().getName(), HTTP_GET_PROCESSOR);
+    }
+
+    @Test
+    public void testFaultGetHttpGetRequestProcessor() {
+        Parameter httpGetProcessor = new Parameter("httpGetProcessor", INCORRECT_HTTP_GET_PROCESSOR);
+        try {
+            httpGetProcessor.setParameterElement(AXIOMUtil.stringToOM(
+                    "<parameter name=\"httpGetProcessor\" locked=\"false\">" +
+                            INCORRECT_HTTP_GET_PROCESSOR + "</parameter>"));
+            transportInDescription.addParameter(httpGetProcessor);
+            sourceConfiguration.build();
+        } catch (Exception ex) {
+            Assert.assertNotNull("Error message is null", ex.getMessage());
+            Assert.assertTrue("", ex.getMessage().contains("Error creating WSDL processor"));
+        }
+    }
+
+    @Test
+    public void testInvalidGetHttpGetRequestProcessor() {
+        Parameter httpGetProcessor = new Parameter("httpGetProcessor", INVALID_HTTP_GET_PROCESSOR);
+        try {
+            httpGetProcessor.setParameterElement(AXIOMUtil.stringToOM(
+                    "<parameter name=\"httpGetProcessor\" locked=\"false\">" +
+                            INVALID_HTTP_GET_PROCESSOR + "</parameter>"));
+            transportInDescription.addParameter(httpGetProcessor);
+            sourceConfiguration.build();
+        } catch (Exception ex) {
+            Assert.assertNotNull("Error message is null", ex.getMessage());
+            Assert.assertTrue("", ex.getMessage().contains("Error creating WSDL processor"));
+        }
+    }
+
+    @Test
+    public void testGetBooleanValue() throws Exception {
+        boolean enableAdvancedForS2SView = sourceConfiguration.getBooleanValue(
+                PassThroughConstants.SYNAPSE_PASSTHROUGH_S2SLATENCY_ADVANCE_VIEW, false);
+        Assert.assertFalse(PassThroughConstants.SYNAPSE_PASSTHROUGH_S2SLATENCY_ADVANCE_VIEW + " is enabled",
+                enableAdvancedForS2SView);
+    }
+
+    @Test
+    public void testSourceConfiguration() throws Exception {
+        WorkerPool workerPool = PassThroughTestUtils.getWorkerPool(passThroughConfiguration);
+        SourceConfiguration sourceConfiguration = new SourceConfiguration(workerPool, metrics);
+        Assert.assertNotNull("SourceConfiguration is null", sourceConfiguration);
+    }
+
+}

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/TargetConfigurationTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/config/TargetConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.apache.synapse.transport.passthru.config;
+
+import junit.framework.Assert;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.base.threads.NativeWorkerPool;
+import org.apache.axis2.transport.base.threads.WorkerPool;
+import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
+import org.apache.synapse.transport.passthru.util.PassThroughTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Test class for TargetConfiguration.
+ */
+public class TargetConfigurationTest {
+
+    private static final String PASS_THROUGH_TRANSPORT_WORKER_POOL = "PASS_THROUGH_TRANSPORT_WORKER_POOL";
+    private PassThroughConfiguration passThroughConfiguration = PassThroughTestUtils.getPassThroughConfiguration();
+    private TargetConfiguration targetConfiguration = null;
+
+    @Before
+    public void setUp() throws Exception {
+        ConfigurationContext configurationContext = new ConfigurationContext(new AxisConfiguration());
+        WorkerPool workerPool = new NativeWorkerPool(3, 4, 5, 5, "name", "id");
+        configurationContext.setProperty(PASS_THROUGH_TRANSPORT_WORKER_POOL, workerPool);
+        PassThroughTransportMetricsCollector metrics = new PassThroughTransportMetricsCollector(true, "testScheme");
+        targetConfiguration = new TargetConfiguration(configurationContext, null, workerPool, metrics, null);
+        targetConfiguration.build();
+    }
+
+    @Test
+    public void testBuild() throws Exception {
+        Assert.assertNotNull("Building base configuration isn't successful.", targetConfiguration);
+    }
+
+    @Test
+    public void testGetPreserveHttpHeaders() throws Exception {
+        List<String> preserveHttpHeaders = targetConfiguration.getPreserveHttpHeaders();
+        Assert.assertNotNull("Preserve Headers lis is null.", preserveHttpHeaders);
+        Assert.assertTrue("No header has been preserved.", preserveHttpHeaders.size() > 0);
+    }
+
+}

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/util/PassThroughTestUtils.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/util/PassThroughTestUtils.java
@@ -1,0 +1,60 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.apache.synapse.transport.passthru.util;
+
+import org.apache.axis2.transport.base.threads.WorkerPool;
+import org.apache.axis2.transport.base.threads.WorkerPoolFactory;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
+
+import java.io.File;
+
+/**
+ * Provides utility methods for PassTrough Transport tests.
+ */
+public class PassThroughTestUtils {
+
+    private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
+    private static final String PASSTHROUGH_THREAD_ID = "PassThroughMessageProcessor";
+    private static final String PASSTHROUGH_RESOURCE_PATH = File.separator + "src" + File.separator + "test" +
+            File.separator + "resources" + File.separator + "org.apache.synapse.transport.ptt.conf" + File.separator;
+
+    /**
+     * Creates a PassThroughConfiguration instance with provided passthru-http.properties
+     *
+     * @return PassThroughConfiguration instance
+     */
+    public static PassThroughConfiguration getPassThroughConfiguration() {
+        String testConfLocation = System.getProperty("user.dir") + PASSTHROUGH_RESOURCE_PATH;
+        System.setProperty(PassThroughConstants.CONF_LOCATION, testConfLocation);
+        return PassThroughConfiguration.getInstance();
+    }
+
+    /**
+     * Creates a workerpool from Passthrough configurations
+     *
+     * @param conf Passthrough Configuration
+     * @return Worker Pool
+     */
+    public static WorkerPool getWorkerPool(PassThroughConfiguration conf) {
+        return WorkerPoolFactory.getWorkerPool(conf.getWorkerPoolCoreSize(), conf.getWorkerPoolMaxSize(),
+                conf.getWorkerThreadKeepaliveSec(), conf.getWorkerPoolQueueLen(),
+                PASSTHROUGH_THREAD_GROUP, PASSTHROUGH_THREAD_ID);
+    }
+
+}

--- a/modules/transports/core/nhttp/src/test/resources/org.apache.synapse.transport.ptt.conf/passthru-http.properties
+++ b/modules/transports/core/nhttp/src/test/resources/org.apache.synapse.transport.ptt.conf/passthru-http.properties
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## This file contains the configuration parameters used by the Pass-through HTTP transport
+
+## Pass-through HTTP transport specific tuning parameters
+http.socket.timeout=180000
+
+worker_pool_size_core=400
+worker_pool_size_max=500
+#worker_thread_keepalive_sec=60
+#worker_pool_queue_length=-1
+#io_threads_per_reactor=2
+io_buffer_size=16384
+#http.max.connection.per.host.port=32767
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true
+
+## Other parameters
+#http.user.agent.preserve=false
+#http.server.preserve=true
+http.headers.preserve=Content-Type
+#http.connection.disable.keepalive=false
+rest.dispatcher.service=__MultitenantDispatcherService
+# URI configurations that determine if it requires custom rest dispatcher
+rest_uri_api_regex=\\w+://.+:\\d+/t/.*|\\w+://.+\\w+/t/.*|^(/t/).*
+rest_uri_proxy_regex=\\w+://.+:\\d+/services/t/.*|\\w+://.+\\w+/services/t/.*|^(/services/t/).*
+
+# Message size validation based on the message size in bytes.
+#message.size.validation.enabled=true
+#valid.max.message.size.in.bytes=81920


### PR DESCRIPTION
This is to add test cases for org.apache.synapse.transport.passthru.config package.

## Purpose
This is to add test cases for org.apache.synapse.transport.passthru.config package.

## Goals
Cover the transport use cases from unit tests.

## Automation tests
 - Unit tests 
Code coverage information
org.apache.synapse.transport.passthru.config - coverage increased from 69% to 83%

## Test environment
JDK 1.8
 