### PR TITLE
Change log level to WARN for non existing json element evaluations

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -122,7 +122,7 @@ public class SynapseJsonPath extends SynapsePath {
         } catch (IOException e) {
             handleException("Error evaluating JSON Path <" + jsonPath.getPath() + ">", e);
         } catch (Exception e) { // catch invalid json paths that do not match with the existing JSON payload.
-            log.error("#stringValueOf. Error evaluating JSON Path <" + jsonPath.getPath() + ">. Returning empty result. Error>>> " + e.getLocalizedMessage());
+            log.warn("#stringValueOf. Error evaluating JSON Path <" + jsonPath.getPath() + ">. Returning empty result. Error>>> " + e.getLocalizedMessage());
             return "";
         }
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
> When users use json eval function following ERROR will print in the log when the particular element is not available in the json payload. IMO It should be a warning. 

2017-12-14 00:01:30,666 WSO2_ESB ERROR SynapseJsonPath:125 - #stringValueOf. Error evaluating JSON Path <************>. Returning empty result. Error>>> invalid path

