### PR TITLE
Fix EI-1329

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -186,15 +186,6 @@ public class TargetRequest {
 				if (!TargetRequestFactory.isMultipartContent(trpContentType)) {
 					addHeader(HTTP.CONTENT_TYPE, trpContentType);
 				}
-                //If the boundary is already set in the message context, the header specified in the message context
-                // should be added.
-                // Addresses both ESBJAVA-3182 and EI-1329
-                else {
-                    if (trpContentType.contains("boundary=")) {
-                        addHeader(HTTP.CONTENT_TYPE, trpContentType);
-                    }
-                }
-
 			}
 
 		}


### PR DESCRIPTION
## Purpose
Resolves: https://github.com/wso2/product-ei/issues/1329

## Goals
The boundary value set in the content-type should be the one set by the formatter regardless of what's set in the transport header.

## Approach
Removes the boundary value being replaced by what's set in the transport header since it results in an inconsistency between the boundary set in the content type header and the boundary that separates
the sub parts.