### PR TITLE
Fix for ESBJAVA-4886

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
@@ -696,7 +696,7 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
         getAspectConfiguration().setUniqueId(cloneId);
         if (endpointKey != null) {
             String childId = StatisticIdentityGenerator.getIdReferencingComponent(endpointKey, ComponentType.ENDPOINT, holder);
-            StatisticIdentityGenerator.reportingEndEvent(childId, ComponentType.SEQUENCE, holder);
+            StatisticIdentityGenerator.reportingEndEvent(childId, ComponentType.ENDPOINT, holder);
         } else if (endpoint != null) {
             endpoint.setComponentStatisticsId(holder);
         }


### PR DESCRIPTION
## Purpose
> This PR fixes the issue of throwing empty stack exception when analytics is enabled in a proxy which has callout mediator with an endpointKey.
This resolves ESBJAVA-4886

## Goals
> Fixed empty stack exception

## Approach
> While going through the code it was identified that an invalid component getting removed from the stack led to this error. After changing the correct component type at the time of calling EndEvent solved the issue.

  