### PR TITLE
Fix for ESBJAVA-4443

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -128,6 +128,15 @@ public final class SynapseConstants {
     public final static String SOAP11_CONTENT_TYPE  = "text/xml";
     /** Content-type of soap12 request **/
     public final static String SOAP12_CONTENT_TYPE  = "application/soap+xml";
+    
+    /**
+     * Content-Type of XML request
+     */
+    public static final String XML_CONTENT_TYPE = "application/xml";
+    /**
+     * Content-Type property of Axis2MessageContext
+     */
+    public static final String AXIS2_PROPERTY_CONTENT_TYPE = "ContentType";
 
     /** Parameter names in the axis2.xml that can be used to configure the synapse */
     public static final class Axis2Param {

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
@@ -29,6 +29,8 @@ import org.apache.axiom.om.impl.llom.OMDocumentImpl;
 import org.apache.axiom.om.impl.llom.OMElementImpl;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.axiom.om.impl.llom.util.AXIOMUtil;
+import org.apache.axiom.soap.SOAP11Constants;
+import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.impl.dom.factory.DOMSOAPFactory;
 import org.apache.commons.logging.Log;
@@ -40,7 +42,9 @@ import org.apache.synapse.config.xml.OMElementUtils;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.apache.synapse.util.streaming_xpath.StreamingXPATH;
 import org.apache.synapse.util.streaming_xpath.compiler.exception.StreamingXPATHCompilerException;
 import org.apache.synapse.util.streaming_xpath.custom.components.ParserComponent;
@@ -368,7 +372,15 @@ public class SynapseXPath extends SynapsePath {
                             ((Axis2MessageContext) synCtx).getEnvelope().getBody().getFirstElement() == null)) {
                 try {
                     axis2MC = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-                    inputStream = getMessageInputStreamPT(axis2MC);
+                    String contentType = (String) axis2MC.getProperty(SynapseConstants.AXIS2_PROPERTY_CONTENT_TYPE);
+                    if (!isStreamingXpathSupportedContentType(contentType) &&
+                            !Boolean.TRUE.equals(PassThroughConstants.MESSAGE_BUILDER_INVOKED)) {
+                        RelayUtils.buildMessage(axis2MC);
+                    } else {
+                        inputStream = getMessageInputStreamPT(axis2MC);
+                    }
+                } catch (XMLStreamException e) {
+                    handleException("Error occurred while building the message from the message context", e);
                 } catch (IOException e) {
                     log.error("Error occurred while obtaining input stream from the message context", e);
                 }
@@ -642,6 +654,19 @@ public class SynapseXPath extends SynapsePath {
         OMFactory doomFactory = DOOMAbstractFactory.getOMFactory();
         StAXOMBuilder doomBuilder = new StAXOMBuilder(doomFactory, llomReader);
         return doomBuilder.getDocumentElement();
+    }
+
+    /**
+     * Checks whether Streaming Xpath supported Content-Type
+     *
+     * @param contentType Content-Type string
+     * @return true if Content-Type is Streaming Xpath supported.
+     */
+    private boolean isStreamingXpathSupportedContentType(String contentType) {
+        return contentType != null &&
+                (contentType.indexOf(SOAP11Constants.SOAP_11_CONTENT_TYPE) != -1 ||
+                        contentType.indexOf(SOAP12Constants.SOAP_12_CONTENT_TYPE) != -1 ||
+                        contentType.indexOf(SynapseConstants.XML_CONTENT_TYPE) != -1);
     }
 
 //    private InputStream getMessageInputStreamBR(MessageContext context) throws IOException {


### PR DESCRIPTION
When the synapse.streaming.xpath.enabled is set to true, Synapse always trying to build the message as XML. We only need to build the message as XML if the Content-Type is Streaming Xpath support one. Related JIRA : https://wso2.org/jira/browse/ESBJAVA-4538

## Purpose
Build the request messages in a correct manner when the synapse.streaming.xpath.enabled is set to true. By default Synapse always trying to build the message as XML.

## Approach
Check whether content-type of the request is streaming XPath supported one or not and engage correct builders accordingly.
