### PR TITLE
Fix for ESBJAVA-3517

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/Value.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/Value.java
@@ -151,6 +151,27 @@ public class Value {
         }
     }
 
+    /**
+     * Resolve the object defined in the Value
+     *
+     * @param synCtx Message Context
+     * @return Object defined in the Value
+     */
+    public Object resolveObject(MessageContext synCtx) {
+        if (keyValue != null) {
+            return keyValue;
+        } else if (expression != null) {
+            try {
+                return expression.selectSingleNode(synCtx);
+            } catch (JaxenException e) {
+                handleException("Failed to evaluate the XPath expression: " + expression, e);
+            }
+        } else {
+            handleException("Unable to resolve the object: " + toString());
+        }
+        return null;
+    }
+
     private Object getObjectValue(MessageContext synCtx) {
         try {
             Object result = expression.selectSingleNode(synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
@@ -18,6 +18,10 @@
  */
 package org.apache.synapse.mediators.template;
 
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMDocument;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMText;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.eip.EIPUtils;
@@ -88,7 +92,7 @@ public class TemplateContext {
                 	}
                     return expression.getExpression();
                 } else {
-                    return expression.evaluateValue(synCtx);
+                    return resolveExpressionValue(synCtx, expression);
                 }
             } else if (expression.getKeyValue() != null) {
                 return expression.evaluateValue(synCtx);
@@ -97,6 +101,19 @@ public class TemplateContext {
         return null;
     }
 
+    private Object resolveExpressionValue(MessageContext synCtx, Value expression) {
+
+        Object result = expression.resolveObject(synCtx);
+
+        // Extract string values from axiom objects which has only texts
+        if (result instanceof OMText) {
+            return ((OMText) result).getText();
+        } else if (result instanceof OMAttribute) {
+            return ((OMAttribute) result).getAttributeValue();
+        } else {
+            return result;
+        }
+    }
 
     private void removeProperty(MessageContext synCtxt, String deletedMapping) {
         //Removing property from the  Synapse Context


### PR DESCRIPTION
## Purpose
In the call-template mediator configuration assume that we have a parameter which has an expression which access a message context property. Currently only String type properties are supported.
If we have OM type property as follows it gets converted to String while fetching the value at the sequence template.
We need to avoid conversion to string to support object type properties.

## Goals
Avoid OMElement conversion to string, to support object type properties in Call Template mediator parameters.

## Approach
Stop string conversion for OMElements. 

## User stories
## Release note
## Documentation
## Training
## Certification
## Marketing
## Automation tests
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8

## Learning