### PR TITLE
Refactor ConcurrencyThrottlingUtils class

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/ConcurrencyThrottlingUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/ConcurrencyThrottlingUtils.java
@@ -47,10 +47,10 @@ public class ConcurrencyThrottlingUtils {
         if (isConcurrencyThrottleEnabled != null && isConcurrencyThrottleEnabled) {
             ConcurrentAccessController concurrentAccessController = (ConcurrentAccessController) synCtx
                     .getProperty(SynapseConstants.SYNAPSE_CONCURRENT_ACCESS_CONTROLLER);
+            int available = concurrentAccessController.incrementAndGet();
+            int concurrentLimit = concurrentAccessController.getLimit();
             if (log.isDebugEnabled()) {
-                int available = concurrentAccessController.incrementAndGet();
-                int concurrentLimit = concurrentAccessController.getLimit();
-                log.debug("Concurrency Throttle : Connection returned" + " :: " + +available + " of available of"
+                log.debug("Concurrency Throttle : Connection returned" + " :: " + available + " of available of"
                         + concurrentLimit + " connections");
             }
             ConcurrentAccessReplicator concurrentAccessReplicator = (ConcurrentAccessReplicator) synCtx


### PR DESCRIPTION
## Purpose
>This will move a codeblock out-of the debug log

## Goals
> Cannot move the code inside debug log since its incrementing throttling parameter

## Related PRs
> [https://github.com/wso2/wso2-synapse/pull/991](https://github.com/wso2/wso2-synapse/pull/991)

  
  