### PR TITLE
Improve performance of Script Mediator

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -403,8 +403,12 @@ public class ScriptMediator extends AbstractMediator {
         if (JsonUtil.hasAJsonPayload(messageContext)) {
             try {
                 String jsonPayload = JsonUtil.jsonPayloadToString(messageContext);
-                String scriptWithJsonParser = "JSON.parse(JSON.stringify(" + jsonPayload + "))";
-                jsonObject = this.jsEngine.eval('(' + scriptWithJsonParser + ')');
+                if (NASHORN_JAVA_SCRIPT.equals(language)) {
+                    jsonObject = jsonSerializer.callMember("parse", jsonPayload);
+                } else {
+                    String scriptWithJsonParser = "JSON.parse(JSON.stringify(" + jsonPayload + "))";
+                    jsonObject = this.jsEngine.eval('(' + scriptWithJsonParser + ')');
+                }
             } catch (ScriptException e) {
                 throw new SynapseException("Invalid JSON payload", e);
             }


### PR DESCRIPTION
Parse the  JSON object by using jsonSerializer object already evaluated
rather than using the JavaScript engine's eval method,
When processing the JSON payload in Script Mediator.

## Purpose
> Fix https://github.com/wso2/product-ei/issues/1656

## Goals
> Parse the  JSON object by using jsonSerializer object already evaluated
rather than using the JavaScript engine's eval method


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
