### PR TITLE
Fix wso2/product-ei/#1664

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -410,7 +410,8 @@ public class ScriptMediator extends AbstractMediator {
                     jsonObject = this.jsEngine.eval('(' + scriptWithJsonParser + ')');
                 }
             } catch (ScriptException e) {
-                throw new SynapseException("Invalid JSON payload", e);
+                throw new ScriptException("Invalid JSON payload", e.getFileName(), e.getLineNumber(),
+                        e.getColumnNumber());
             }
         } else if (jsonString != null) {
             String jsonPayload = jsonParser.parse(jsonString).toString();


### PR DESCRIPTION
Throws a ScriptException In processJSONPayload method when trying
to parse a JSON payload and it fails, rather than
throwing a SynapseException.

Fixes: https://github.com/wso2/product-ei/issues/1664

## Purpose
> Resolves: https://github.com/wso2/product-ei/issues/1664

## Goals
> Throws a ScriptException In processJSONPayload method when trying
to parse a JSON payload and it fails

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes