### PR TITLE
Fix for ESBJAVA-4499

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorProperty.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorProperty.java
@@ -24,7 +24,7 @@ import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.util.MediatorPropertyUtils;
 
 import javax.xml.namespace.QName;
 import java.util.HashMap;
@@ -74,6 +74,7 @@ public class MediatorProperty {
             org.apache.axis2.context.MessageContext axis2MessageCtx =
                     axis2smc.getAxis2MessageContext();
             axis2MessageCtx.setProperty(name, result);
+            MediatorPropertyUtils.handleSpecialProperties(name, result, axis2MessageCtx);
         } else if (XMLConfigConstants.SCOPE_CLIENT.equals(scope)) {
             //Setting property into the  Axis2 Message Context client options
             Axis2MessageContext axis2smc = (Axis2MessageContext) synCtx;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -33,6 +33,7 @@ import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.util.JavaUtils;
 import org.apache.http.protocol.HTTP;
+import org.apache.synapse.util.MediatorPropertyUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -135,7 +136,7 @@ public class PropertyMediator extends AbstractMediator {
                 org.apache.axis2.context.MessageContext axis2MessageCtx =
                         axis2smc.getAxis2MessageContext();
                 axis2MessageCtx.setProperty(name, resultValue);
-                handleSpecialProperties(resultValue, axis2MessageCtx);
+                MediatorPropertyUtils.handleSpecialProperties(name, resultValue, axis2MessageCtx);
 
             } else if (XMLConfigConstants.SCOPE_CLIENT.equals(scope)
                     && synCtx instanceof Axis2MessageContext) {
@@ -456,20 +457,6 @@ public class PropertyMediator extends AbstractMediator {
         }
         return contentAware;
     }
-
-    private void handleSpecialProperties(Object resultValue,
-                                         org.apache.axis2.context.MessageContext axis2MessageCtx) {
-		if (org.apache.axis2.Constants.Configuration.MESSAGE_TYPE.equals(name)) {
-			axis2MessageCtx.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, resultValue);
-			Object o = axis2MessageCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-			Map _headers = (Map) o;
-			if (_headers != null) {
-				_headers.remove(HTTP.CONTENT_TYPE);
-				_headers.put(HTTP.CONTENT_TYPE, resultValue);
-			}
-		}
-    }
-
 
     private OMElement buildOMElement(String xml) {
         // intentionally building the resulting OMElement. See ESBJAVA-3478.

--- a/modules/core/src/main/java/org/apache/synapse/util/MediatorPropertyUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/MediatorPropertyUtils.java
@@ -1,20 +1,19 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.synapse.util;
 

--- a/modules/core/src/main/java/org/apache/synapse/util/MediatorPropertyUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/MediatorPropertyUtils.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.synapse.util;
+
+import org.apache.http.protocol.HTTP;
+
+import java.util.Map;
+
+/*
+ *  This class contains the util methods with respect to mediator properties
+ */
+public class MediatorPropertyUtils {
+
+    /**
+     * This method removes the current content-type header value from the Axis2 message context and
+     * set the given value.
+     * @param propertyName Message type property
+     * @param resultValue Value to be set
+     * @param axis2MessageCtx Axis2 message context
+     */
+    public static void handleSpecialProperties(String propertyName, Object resultValue,
+                                               org.apache.axis2.context.MessageContext axis2MessageCtx) {
+        if (org.apache.axis2.Constants.Configuration.MESSAGE_TYPE.equals(propertyName)) {
+            axis2MessageCtx.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, resultValue);
+            Map headers = (Map) axis2MessageCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+            if (headers != null) {
+                headers.remove(HTTP.CONTENT_TYPE);
+                headers.put(HTTP.CONTENT_TYPE, resultValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> If the "messageType" property is defined inside the endpoint template it does not take effect. The reason is "messageType" property is not handled in the mediator property class.

## Goals
> Resolves ESBJAVA-4499

## Approach
> Reused the same property handling method that is being used in the Property Mediator to handle the properties that are coming under mediator properties.

## Automation tests
 - Unit tests 
   > Added a unit test to check whether the transport header gets replaced by new value.
