### PR TITLE
Fix the Inconsistent behaviour with streaming.xpath

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapsePropertiesLoader.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapsePropertiesLoader.java
@@ -95,4 +95,25 @@ public class SynapsePropertiesLoader {
     public static String getPropertyValue(String key, String defaultValue) {
         return MiscellaneousUtil.getProperty(loadSynapseProperties(), key, defaultValue);
     }
+
+    /**
+     * Get the boolean value of the property from the synapse properties.
+     *
+     * @param name name of the config property
+     * @param def  default value to return if the property is not set
+     * @return the value of the property to be used
+     */
+    public static Boolean getBooleanProperty(String name, Boolean def) {
+        String val = MiscellaneousUtil.getProperty(loadSynapseProperties(), name, String.valueOf(def));
+        if (val == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Parameter : " + name + " is not defined in the synapse.properties file.");
+            }
+            return def;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("synapse.properties parameter : " + name + " = " + val);
+        }
+        return Boolean.valueOf(val);
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
@@ -26,10 +26,12 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
@@ -58,6 +60,12 @@ public abstract class AbstractListMediator extends AbstractMediator
 
     private boolean sequenceContentAware = false;
 
+    /**
+     * Whether Streaming Xpath is enabled in synapse.properties file.
+     */
+    private static boolean isStreamXpathEnabled = SynapsePropertiesLoader.
+            getBooleanProperty(SynapseConstants.STREAMING_XPATH_PROCESSING, Boolean.FALSE);
+
     public boolean mediate(MessageContext synCtx) {
         return  mediate(synCtx,0);
     }
@@ -81,7 +89,7 @@ public abstract class AbstractListMediator extends AbstractMediator
                 // ensure correct trace state after each invocation of a mediator
                 Mediator mediator = mediators.get(i);
 
-                if (sequenceContentAware && mediator.isContentAware() &&
+                if (sequenceContentAware && (mediator.isContentAware() || isStreamXpathEnabled) &&
                         (!Boolean.TRUE.equals(synCtx.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED)))) {
                     buildMessage(synCtx, synLog);
                 }


### PR DESCRIPTION
When synapse.streaming.xpath.enabled is configured to true in the synapse.properties file, ContentAwareness of the Xpath expressions will become false. This introduces inconsistent behavior of mediations flows when synapse.streaming.xpath.enabled property enabled. This will fix: https://wso2.org/jira/browse/ESBJAVA-4443

## Purpose
Fix the inconsistent behavior of mediations flows when synapse.streaming.xpath.enabled property is configured to true in the synapse.properties file.

## Approach
Check the content-awareness of the sequence within the AbstractList mediator and build the message if the sequence is content-aware and synapse.streaming.xpath.enabled is configured to true in the synapse.properties file.