### PR TITLE
Fix #1709 

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -197,7 +197,7 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
      */
     private void scanFileOrDirectory(final PollTableEntry entry, String fileURI) {
         if (log.isDebugEnabled()) {
-            log.debug("Polling: " + fileURI);
+            log.debug("Polling: " + VFSUtils.maskURLPassword(fileURI));
         }
         if (entry.isClusterAware()) {
             boolean leader = true;
@@ -243,7 +243,7 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
 
         //TODO : Trying to make the correct URL out of the malformed one.
         if(fileURI.contains("vfs:")){
-            fileURI=fileURI.substring(fileURI.indexOf("vfs:")+4);
+            fileURI = fileURI.substring(fileURI.indexOf("vfs:") + 4);
         }
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
 ## Purpose
> Currently, when debug logs are enabled for synapse, password in the FTP URL is logged in the debug log file. With this fix, the FTP server password in the URL is masked when logging.
## Goals
> Fix issue #1006 

## Approach
Used password masking utility function VFSUtils.maskURLPassword to mask the password. 