### PR TITLE
Fix for ESBJAVA-5004

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/mediators/builtin/ValidateMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/builtin/ValidateMediatorTest.java
@@ -177,10 +177,10 @@ public class ValidateMediatorTest extends TestCase {
         validate.addChild(testMediator);
         validate.mediate(synCtx);
         if (expectFail) {
-            assertTrue("Expected ValidateMediator to trigger fail sequence",
+            assertTrue("Expected ValidateMediator to trigger on-fail sequence",
                     onFailInvoked.intValue() == 1);
         } else {
-            assertTrue("ValidateMediator unexpectedly triggered fail sequence",
+            assertTrue("ValidateMediator unexpectedly triggered on-fail sequence",
                     onFailInvoked.intValue() == 0);
         }
     }
@@ -252,6 +252,28 @@ public class ValidateMediatorTest extends TestCase {
                 .setBodyFromString(IN_VALID_ENVELOPE).build();
 
         // test validate mediator, with static enveope
+        test(validate, synCtx, true);
+    }
+
+    /**
+     * This method tests the mediator when an invalid source xpath is given.
+     * Test gets passed if mediator invokes on-fail sequence.
+     * @throws Exception
+     */
+    public void testValidateMediatorInvalidSource() throws Exception {
+        // create a validate mediator
+        ValidateMediator validate = new ValidateMediator();
+
+        // set the schema url, invalid source xpath and any name spaces
+        validate.setSchemaKeys(createKeyListFromStaticKey("xsd-key-1"));
+        validate.setSource(createXPath("//m0:CheckPriceRequest/m0:price"));
+
+        MessageContext synCtx = new TestMessageContextBuilder()
+                .setRequireAxis2MessageContext(true)
+                .addFileEntry("xsd-key-1", "./../../repository/conf/sample/resources/validate/validate.xsd")
+                .setBodyFromString(VALID_ENVELOPE).build();
+
+        // test validate mediator, with static envelope
         test(validate, synCtx, true);
     }
 
@@ -345,6 +367,29 @@ public class ValidateMediatorTest extends TestCase {
                 .setJsonBodyFromString(INVALID_JSON_MESSAGE1).build();
 
         // test validate mediator, with static enveope
+        test(validate, synCtx, true);
+    }
+
+    /**
+     * This method tests the mediator when an invalid source json-path is given.
+     * Test gets passed if mediator invokes on-fail sequence.
+     * @throws Exception
+     */
+    public void testValidateMediatorJSONSchemaWithInvalidSourceValidCase() throws Exception {
+        // create a validate mediator
+        ValidateMediator validate = new ValidateMediator();
+
+        // set the schema url, source json-path and any name spaces
+        validate.setSchemaKeys(createKeyListFromStaticKey("JSON-key"));
+        // set invalid json-path
+        validate.setSource(createJSONPath("$.msg.get"));
+
+        MessageContext synCtx = new TestMessageContextBuilder()
+                .setRequireAxis2MessageContext(true)
+                .addFileEntry("JSON-key", "./../../repository/conf/sample/resources/validate/StockQuoteSchema.json")
+                .setJsonBodyFromString(VALID_JSON_MESSAGE1).build();
+
+        // test validate mediator, with static envelope
         test(validate, synCtx, true);
     }
 


### PR DESCRIPTION
## Purpose
> When a source element is given as an XPath expression to the validate mediator and if it is not available in the request body, validate mediator throws an axis fault. This exception is handled by the defined fault sequence rather than considering it as a validation error.

## Goals
> Resolves ESBJAVA-5004

## Approach
> Previously, when the source element is given and if it is not accessible from the request body, logic was written to throw a synapse exception and handle it inside the validate mediator by forwarding to fault sequence of the validate mediator. Now this fix catches that synapse exception and invokes the on-fail sequence since it is a validation error.

## Automation tests
 - Unit tests 
   > Added a test case to test with an invalid source XPath
   > Added a test case to test with an invalid source JsonPath