### PR TITLE
Fix wso2/product-ei/issues/1719

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -19,7 +19,6 @@
 
 package org.apache.synapse.core.axis2;
 
-import org.apache.axiom.om.OMException;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.addressing.AddressingConstants;
@@ -32,7 +31,6 @@ import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.util.CallbackReceiver;
 import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.nio.NHttpServerConnection;
@@ -40,7 +38,6 @@ import org.apache.synapse.ContinuationState;
 import org.apache.synapse.FaultHandler;
 import org.apache.synapse.ServerContextInformation;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.flow.statistics.collectors.CallbackStatisticCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
@@ -56,12 +53,11 @@ import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
-import org.apache.synapse.util.ResponseAcceptEncodingProcessor;
 import org.apache.synapse.util.ConcurrencyThrottlingUtils;
+import org.apache.synapse.util.ResponseAcceptEncodingProcessor;
 
 import java.util.Stack;
 import java.util.Timer;
-import java.util.regex.Pattern;
 
 /**
  * This is the message receiver that receives the responses for outgoing messages sent out
@@ -279,14 +275,13 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
                     log.debug("[Failed Request Message ID : " + messageID + "]" +
                             " [New to be Retried Request Message ID : " +
                             synapseOutMsgCtx.getMessageID() + "]");
-                }  
-                
-                int errorCode = (Integer)response.getProperty(SynapseConstants.ERROR_CODE);
+                }
 
+                int errorCode = (Integer)response.getProperty(SynapseConstants.ERROR_CODE);
                 //If a timeout has occured and the timeout action of the callback is to discard the message
-                if(errorCode == SynapseConstants.NHTTP_CONNECTION_TIMEOUT &&
-                   callback.getTimeOutAction() == SynapseConstants.DISCARD){
-                        //Do not execute any fault sequences. Discard message
+                if (errorCode == SynapseConstants.NHTTP_CONNECTION_TIMEOUT && callback.getTimeOutAction()
+                        == SynapseConstants.DISCARD) {
+                    //Do not execute any fault sequences. Discard message
                         if(log.isWarnEnabled()){
                             log.warn("Synapse timed out for the request with Message ID : " + messageID +
                                       ". Ignoring fault handlers since the timeout action is DISCARD");

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
@@ -137,7 +137,7 @@ public class TimeoutHandler extends TimerTask {
                             toRemove.add(key);
                         }
 
-                        if (callback.getTimeOutAction() == SynapseConstants.DISCARD_AND_FAULT) {
+                        if (callback.getTimeOutAction() != SynapseConstants.NONE) {
 
                             // activate the fault sequence of the current sequence mediator
                             MessageContext msgContext = callback.getSynapseOutMsgCtx();

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -526,8 +526,13 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
      * @param synCtx the message at hand
      */
     public void onFault(MessageContext synCtx) {
-        logSetter();
-        invokeNextFaultHandler(synCtx);
+        EndpointDefinition endpointDefinition = getDefinition();
+        if (endpointDefinition != null && endpointDefinition.getTimeoutAction() == SynapseConstants.DISCARD) {
+            log.info("Ignoring fault handlers since the timeout action is set to DISCARD");
+        } else {
+            logSetter();
+            invokeNextFaultHandler(synCtx);
+        }
     }
 
     /**


### PR DESCRIPTION
In EndPoint error handling scenarios when we define the “responseAction” as “discard” the endpoint will not be get suspended whether the “retriesBeforeSuspension” count exceeded or not.
This has been fixed by changing the logic to execute the onFault method of AbstractEndpoint wheteher the timeOutAction defined as Discard or Fault and deciding whether to invoke the fault
sequence or not in the onFault method of AbstractEndpoint.

Fixes: https://github.com/wso2/product-ei/issues/1719

## Purpose
In EndPoint error handling scenarios when we define the “responseAction” as “discard” the endpoint will not be get suspended whether the “retriesBeforeSuspension” count exceeded.

But the expected behavior of “Timeout” state is that , endpoint will continue to attempt to receive messages until one message succeeds or the maximum retry setting has been reached. If the maximum is reached at which point the endpoint is marked as "Suspended."

## Goals
 This has been fixed by changing the logic to execute the onFault method of AbstractEndpoint wheteher the timeOutAction defined as Discard or Fault and deciding whether to invoke the fault
sequence or not in the onFault method of AbstractEndpoint.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

