### PR TITLE
Refactor JMS message forwarding processor and JMS Message store code

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/ManagedLifecycle.java
+++ b/modules/core/src/main/java/org/apache/synapse/ManagedLifecycle.java
@@ -20,6 +20,9 @@
 package org.apache.synapse;
 
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.message.StoreForwardException;
+
+import javax.jms.JMSException;
 
 /**
  * This interface defines all the managed stateful parts of Synapse
@@ -33,11 +36,11 @@ public interface ManagedLifecycle {
      *
      * @param se SynapseEnvironment to be used for initialization
      */
-    public void init(SynapseEnvironment se);
+     void init(SynapseEnvironment se);
 
     /**
      * This method should implement the destroying of the
      * implemented parts of the configuration.
      */
-    public void destroy();
+     void destroy();
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/StoreForwardException.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/StoreForwardException.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.synapse.message;
+
+/**
+ * Checked exception for Message Store / Processor related packages
+ */
+public class StoreForwardException extends Exception {
+
+    /**
+     * Constructor for StoreForwardException
+     *
+     * @param message message in exception
+     */
+    public StoreForwardException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor for StoreForwardException
+     *
+     * @param message   the detail message (which is saved for later retrieval
+     *                  by the {@link #getMessage()} method).
+     * @param throwable the cause (which is saved for later retrieval by the
+     *                  {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                  permitted, and indicates that the cause is nonexistent or
+     *                  unknown.)
+     */
+    public StoreForwardException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessorConstants.java
@@ -63,4 +63,19 @@ public final class MessageProcessorConstants {
      */
     public static final int INITIAL_EXECUTION_DELAY = 2000;
 
+    /**
+     * Constant to define maximum number of connection attempts to store
+     */
+    public static final String MAX_STORE_CONNECT_ATTEMPTS = "max.store.connection.attempts";
+
+    /**
+     * Constant to define connection retry interval to associated message store
+     */
+    public static final String STORE_CONNECTION_RETRY_INTERVAL = "store.connection.retry.interval";
+
+    /**
+     * Constant to identify an issue with connecting to store
+     */
+    public static final String STORE_CONNECTION_ERROR = "STORE_CONNECTION_ERROR";
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingProcessorConstants.java
@@ -76,4 +76,9 @@ public final class ForwardingProcessorConstants {
      * used for forward in case of scheduled message processor deactivation
      */
     public static final String DEACTIVATE_SEQUENCE = "message.processor.deactivate.sequence";
+
+    /**
+     * Message store to keep un-processable messages of message processor
+     */
+    public static final String FAIL_MESSAGES_STORE = "message.processor.failMessagesStore";
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -29,7 +29,6 @@ import org.apache.axiom.om.OMException;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.util.ElementHelper;
 import org.apache.axiom.soap.SOAP11Constants;
-import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.SOAPHeaderBlock;
 import org.apache.axis2.description.Parameter;
@@ -49,10 +48,12 @@ import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.message.MessageConsumer;
+import org.apache.synapse.message.StoreForwardException;
 import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.processor.MessageProcessorConstants;
 import org.apache.synapse.message.processor.impl.ScheduledMessageProcessor;
 import org.apache.synapse.message.senders.blocking.BlockingMsgSender;
+import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.task.Task;
 import org.apache.synapse.util.MessageHelper;
 
@@ -60,10 +61,9 @@ import org.apache.synapse.util.MessageHelper;
  * This task is responsible for forwarding a request to a given endpoint. This
  * is based on a blocking implementation and can send only one message at a
  * time. Also this supports Throttling and reliable messaging.
- * 
  */
 public class ForwardingService implements Task, ManagedLifecycle {
-    private static final Log log = LogFactory.getLog(ForwardingService.class);
+	private static final Log log = LogFactory.getLog(ForwardingService.class);
 
 	// The consumer that is associated with the particular message store
 	private MessageConsumer messageConsumer;
@@ -71,8 +71,8 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	// Owner of the this job
 	private MessageProcessor messageProcessor;
 
-    // This is the client which sends messages to the end point
-    private BlockingMsgSender sender;
+	// This is the client which sends messages to the end point
+	private BlockingMsgSender sender;
 
 	/*
 	 * Interval between two retries to the client. This only come to affect only
@@ -89,7 +89,12 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	// Sequence to invoke in a message processor deactivation
 	private String deactivateSeq = null;
 
-    private String targetEndpoint = null;
+	private String targetEndpoint = null;
+
+	/**
+	 * Message store to keep failing messages
+	 */
+	private MessageStore failMessageStore = null;
 
 	/*
 	 * The cron expression under which the message processor runs.
@@ -117,13 +122,24 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	private int maxDeliverAttempts = 4;
 	private int attemptCount = 0;
 
-    private boolean isThrottling = true;
+	/*
+	 * Number of connection attempts to store before shutting down the processor.
+	 * -1 value to indicate that retry needs to happen forever.
+	 */
+	private int maxConnectionAttemptsToStore = -1;
 
-    /**
-     * Throttling-interval is the forwarding interval when cron scheduling is enabled.
-     */
-    private long throttlingInterval = -1;
-    
+	/*
+	 * Time (in milliseconds) between two attempts to connect to the store
+	 */
+	private int storeConnectionAttemptDelay = 1000;
+
+	private boolean isThrottling = true;
+
+	/**
+	 * Throttling-interval is the forwarding interval when cron scheduling is enabled.
+	 */
+	private long throttlingInterval = -1;
+
 	// Message Queue polling interval value.
 	private long interval;
 
@@ -132,25 +148,26 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	 * the message processor after maximum number of delivery
 	 */
 	private boolean isMaxDeliveryAttemptDropEnabled = false;
-    
+
 	private SynapseEnvironment synapseEnvironment;
 
 	private boolean initialized = false;
 
-    /**
-     * Specifies whether the service should be started as deactivated or not
-     */
-    private boolean isDeactivatedAtStartup= false;
+	/**
+	 * Specifies whether the service should be started as deactivated or not
+	 */
+	private boolean isDeactivatedAtStartup = false;
 
-    /**
-     * Specifies whether we should consider the response of the message in determining the success of message forwarding
-     */
-    private boolean isResponseValidationNotRequired = false;
-    
-    Pattern httpPattern = Pattern.compile("^(http|https|hl7):");
-	
+	/**
+	 * Specifies whether we should consider the response of the message in determining the success of message
+	 * forwarding
+	 */
+	private boolean isResponseValidationNotRequired = false;
+
+	Pattern httpPattern = Pattern.compile("^(http|https|hl7):");
+
 	public ForwardingService(MessageProcessor messageProcessor, BlockingMsgSender sender,
-	                         SynapseEnvironment synapseEnvironment, long threshouldInterval) {
+							 SynapseEnvironment synapseEnvironment, long threshouldInterval) {
 		this.messageProcessor = messageProcessor;
 		this.sender = sender;
 		this.synapseEnvironment = synapseEnvironment;
@@ -158,46 +175,52 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		this.interval = threshouldInterval;
 	}
 
-    public ForwardingService(MessageProcessor messageProcessor, BlockingMsgSender sender,
-                             SynapseEnvironment synapseEnvironment, long threshouldInterval,
-                             boolean isDeactivatedAtStartup ) {
-        this.messageProcessor = messageProcessor;
-        this.sender = sender;
-        this.synapseEnvironment = synapseEnvironment;
-        this.interval = threshouldInterval;
-        this.isDeactivatedAtStartup = isDeactivatedAtStartup;
-    }
+	public ForwardingService(MessageProcessor messageProcessor, BlockingMsgSender sender,
+							 SynapseEnvironment synapseEnvironment, long thresholdInterval,
+							 boolean isDeactivatedAtStartup) {
+		this.messageProcessor = messageProcessor;
+		this.sender = sender;
+		this.synapseEnvironment = synapseEnvironment;
+		this.interval = thresholdInterval;
+		this.isDeactivatedAtStartup = isDeactivatedAtStartup;
+	}
 
-    /**
+	/**
 	 * Starts the execution of this task which grabs a message from the message
 	 * queue and dispatch it to a given endpoint.
 	 */
 	public void execute() {
 		final long startTime = new Date().getTime();
 
-        if(isDeactivatedAtStartup){
-            //This delay is required until tasks are paused from ScheduledMessageProcessor since message processor is
-            // inactive
-            try {
-                TimeUnit.MILLISECONDS.sleep(MessageProcessorConstants.INITIAL_EXECUTION_DELAY);
-            } catch (InterruptedException exception) {
-                log.warn("Initial delay interrupted when Forwarding service started as inactive ", exception);
-            }
-            isDeactivatedAtStartup = false;
-        }
+		if (isDeactivatedAtStartup) {
+			//This delay is required until tasks are paused from ScheduledMessageProcessor since message processor is
+			// inactive
+			try {
+				TimeUnit.MILLISECONDS.sleep(MessageProcessorConstants.INITIAL_EXECUTION_DELAY);
+			} catch (InterruptedException exception) {
+				log.warn("Initial delay interrupted when Forwarding service started as inactive ", exception);
+			}
+			isDeactivatedAtStartup = false;
+		}
 		/*
 		 * Initialize only if it is NOT already done. This will make sure that
 		 * the initialization is done only once.
 		 */
 		if (!initialized) {
-			this.init(synapseEnvironment);
+			try {
+				this.init(synapseEnvironment);
+			} catch (SynapseException e) {
+				log.fatal("Deactivating the message processor [" + this.messageProcessor.getName()
+						+ "] due to initialization issue", e);
+				deactivateMessageProcessor(null);
+			}
 		}
 		do {
 			resetService();
 			MessageContext messageContext = null;
 			try {
 				if (!this.messageProcessor.isDeactivated()) {
-					messageContext = fetch(messageConsumer);
+					messageContext = fetch();
 					if (messageContext != null) {
 
 						Set proSet = messageContext.getPropertyKeySet();
@@ -213,8 +236,8 @@ public class ForwardingService implements Task, ManagedLifecycle {
 						// either the connection is broken or there are no new
 						// massages.
 						if (log.isDebugEnabled()) {
-							log.debug("No messages were received for message processor [" +
-							          messageProcessor.getName() + "]");
+							log.debug("No messages were received for message processor ["
+									+ messageProcessor.getName() + "]");
 						}
 
 						// this means we have consumed all the messages
@@ -241,14 +264,14 @@ public class ForwardingService implements Task, ManagedLifecycle {
 				 * case and yet if it comes this
 				 * we have to shutdown the processor
 				 */
-				log.fatal("Deactivating the message processor [" + this.messageProcessor.getName() +
-				          "]", e);
+				log.fatal("Deactivating the message processor [" + this.messageProcessor.getName()
+						+ "]", e);
 				deactivateMessageProcessor(messageContext);
 			}
 
 			if (log.isDebugEnabled()) {
-				log.debug("Exiting the iteration of message processor [" +
-				          this.messageProcessor.getName() + "]");
+				log.debug("Exiting the iteration of message processor ["
+						+ this.messageProcessor.getName() + "]");
 			}
 			/*
 			 * This code wrote handle scenarios in which cron expressions are
@@ -262,80 +285,78 @@ public class ForwardingService implements Task, ManagedLifecycle {
 					log.debug("Current Thread was interrupted while it is sleeping.");
 				}
 			}
-            /*
-             * If the interval is less than 1000 ms, then the scheduling is done
-             * using the while loop since ntask rejects any intervals whose
-             * value is less then 1000 ms. Cron expressions are handled above so
-             * we need to skip it here. Otherwise the cron expression is kept
-             * sleeping twice as the forwarding interval.
-             */
-            if (interval > 0 && interval < MessageProcessorConstants.THRESHOULD_INTERVAL &&
-                !isRunningUnderCronExpression()) {
-                try {
-                    Thread.sleep(interval);
-                } catch (InterruptedException e) {
-                    log.debug("Current Thread was interrupted while it is sleeping.");
-                }
-            }
-            /*
-             * Gives the control back to Quartz scheduler. This needs to be done
-             * only if the interval value is less than the Threshould interval
-             * value of 1000 ms, where the scheduling is done outside of Quartz
-             * via the while loop. Otherwise the schedular will get blocked.
-             * For cron expressions with interval < 1000ms this scenario is not
-             * applicable hence skipping it here. For cron expressions, all the
-             * messages in the queue at the moment are sent to the backend. If
-             * you give control back to the Quartz that behavior can not be
-             * achieved, only a portion of the messages will get dispatched
-             * while other messages will remain in the queue.
-             */
-            if (isThrottling && new Date().getTime() - startTime > 1000 &&
-                !isRunningUnderCronExpression()) {
-                break;
-            }
+
+			/*
+			 * If the interval is less than 1000 ms, then the scheduling is done
+			 * using the while loop since ntask rejects any intervals whose
+			 * value is less then 1000 ms. Cron expressions are handled above so
+			 * we need to skip it here. Otherwise the cron expression is kept
+			 * sleeping twice as the forwarding interval.
+			 */
+			if (interval > 0 && interval < MessageProcessorConstants.THRESHOULD_INTERVAL &&
+					!isRunningUnderCronExpression()) {
+				try {
+					Thread.sleep(interval);
+				} catch (InterruptedException e) {
+					log.debug("Current Thread was interrupted while it is sleeping.");
+				}
+			}
+
+			/*
+			 * Gives the control back to Quartz scheduler. This needs to be done
+			 * only if the interval value is less than the Threshould interval
+			 * value of 1000 ms, where the scheduling is done outside of Quartz
+			 * via the while loop. Otherwise the schedular will get blocked.
+			 * For cron expressions with interval < 1000ms this scenario is not
+			 * applicable hence skipping it here. For cron expressions, all the
+			 * messages in the queue at the moment are sent to the backend. If
+			 * you give control back to the Quartz that behavior can not be
+			 * achieved, only a portion of the messages will get dispatched
+			 * while other messages will remain in the queue.
+			 */
+			if (isThrottling && new Date().getTime() - startTime > 1000 &&
+					!isRunningUnderCronExpression()) {
+				break;
+			}
 		} while ((isThrottling || isRunningUnderCronExpression()) && !isTerminated);
 
 		if (log.isDebugEnabled()) {
-			log.debug("Exiting service thread of message processor [" +
-			          this.messageProcessor.getName() + "]");
+			log.debug("Exiting service thread of message processor ["
+					+ this.messageProcessor.getName() + "]");
 		}
 	}
 
-    /**
-     * Helper method to get a value of a parameters in the AxisConfiguration
-     *
-     * @param axisConfiguration AxisConfiguration instance
-     * @param paramKey The name / key of the parameter
-     * @return The value of the parameter
-     */
-    private static String getAxis2ParameterValue(AxisConfiguration axisConfiguration,
-                                                 String paramKey) {
-        Parameter parameter = axisConfiguration.getParameter(paramKey);
-        if (parameter == null) {
-            return null;
-        }
-        Object value = parameter.getValue();
-        if (value != null && value instanceof String) {
-            return (String) parameter.getValue();
-        } else {
-            return null;
-        }
-    }
-
-	public void init(SynapseEnvironment se) {
+	public void init(SynapseEnvironment se) throws SynapseException {
 		// Setting up the JMS consumer here.
-		setMessageConsumer();
+		try {
+			setMessageConsumer();
+		} catch (StoreForwardException e) {
+			throw new SynapseException("Error while initializing consumer " + messageProcessor.getName(), e);
+		}
 
 		// Defaults to -1.
 		Map<String, Object> parametersMap = messageProcessor.getParameters();
 		if (parametersMap.get(MessageProcessorConstants.MAX_DELIVER_ATTEMPTS) != null) {
 			maxDeliverAttempts =
-			                     Integer.parseInt((String) parametersMap.get(MessageProcessorConstants.MAX_DELIVER_ATTEMPTS));
+					Integer.parseInt((String) parametersMap.get(MessageProcessorConstants.MAX_DELIVER_ATTEMPTS));
 		}
 
 		if (parametersMap.get(MessageProcessorConstants.RETRY_INTERVAL) != null) {
 			retryInterval =
-			                Integer.parseInt((String) parametersMap.get(MessageProcessorConstants.RETRY_INTERVAL));
+					Integer.parseInt((String) parametersMap.get(MessageProcessorConstants.RETRY_INTERVAL));
+		}
+
+		String maxConnectionAttemptsToStore =
+				(String) parametersMap.get(MessageProcessorConstants.MAX_STORE_CONNECT_ATTEMPTS);
+		String storeConnectionAttemptDelay =
+				(String) parametersMap.get(MessageProcessorConstants.STORE_CONNECTION_RETRY_INTERVAL);
+
+		if (null != maxConnectionAttemptsToStore) {
+			this.maxConnectionAttemptsToStore = Integer.parseInt(maxConnectionAttemptsToStore);
+		}
+
+		if (null != storeConnectionAttemptDelay) {
+			this.storeConnectionAttemptDelay = Integer.parseInt(storeConnectionAttemptDelay);
 		}
 
 		replySeq = (String) parametersMap.get(ForwardingProcessorConstants.REPLY_SEQUENCE);
@@ -346,31 +367,36 @@ public class ForwardingService implements Task, ManagedLifecycle {
 
 		targetEndpoint = (String) parametersMap.get(ForwardingProcessorConstants.TARGET_ENDPOINT);
 
+		String failMessageStoreName = (String) parametersMap.get(ForwardingProcessorConstants.FAIL_MESSAGES_STORE);
+		if (null != failMessageStoreName && !failMessageStoreName.isEmpty()) {
+			failMessageStore = se.createMessageContext().getConfiguration().getMessageStore(failMessageStoreName);
+		}
+
 		// Default value should be true.
 		if (parametersMap.get(ForwardingProcessorConstants.THROTTLE) != null) {
 			isThrottling =
-			               Boolean.parseBoolean((String) parametersMap.get(ForwardingProcessorConstants.THROTTLE));
+					Boolean.parseBoolean((String) parametersMap.get(ForwardingProcessorConstants.THROTTLE));
 		}
-		
+
 		if (parametersMap.get(ForwardingProcessorConstants.CRON_EXPRESSION) != null) {
 			cronExpression =
-			                 String.valueOf(parametersMap.get(ForwardingProcessorConstants.CRON_EXPRESSION));
+					String.valueOf(parametersMap.get(ForwardingProcessorConstants.CRON_EXPRESSION));
 		}
 
 		// Default Value should be -1.
 		if (cronExpression != null &&
-		    parametersMap.get(ForwardingProcessorConstants.THROTTLE_INTERVAL) != null) {
+				parametersMap.get(ForwardingProcessorConstants.THROTTLE_INTERVAL) != null) {
 			throttlingInterval =
-			                     Long.parseLong((String) parametersMap.get(ForwardingProcessorConstants.THROTTLE_INTERVAL));
+					Long.parseLong((String) parametersMap.get(ForwardingProcessorConstants.THROTTLE_INTERVAL));
 		}
 
 		nonRetryStatusCodes =
-		                      (String[]) parametersMap.get(ForwardingProcessorConstants.NON_RETRY_STATUS_CODES);
+				(String[]) parametersMap.get(ForwardingProcessorConstants.NON_RETRY_STATUS_CODES);
 
 		// Default to FALSE.
 		if (parametersMap.get(ForwardingProcessorConstants.MAX_DELIVERY_DROP) != null &&
-		    parametersMap.get(ForwardingProcessorConstants.MAX_DELIVERY_DROP).toString()
-		                 .equals("Enabled") && maxDeliverAttempts > 0) {
+				parametersMap.get(ForwardingProcessorConstants.MAX_DELIVERY_DROP).toString()
+						.equals("Enabled") && maxDeliverAttempts > 0) {
 			isMaxDeliveryAttemptDropEnabled = true;
 		}
 
@@ -383,223 +409,108 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		 */
 		initialized = true;
 	}
-    
-    private Set<Integer> getNonRetryStatusCodes() {
-        Set<Integer>nonRetryCodes = new HashSet<Integer>();
-        if (nonRetryStatusCodes != null) {
-            for (String code : nonRetryStatusCodes) {
-                try {
-                    int codeI = Integer.parseInt(code.trim());
-                    nonRetryCodes.add(codeI);
-                } catch (NumberFormatException e) {
-                } // ignore the invalid status code
-            }
-        }
-         return nonRetryCodes;
-    }
-    
-	/**
-	 * Receives the next message from the message store.
-	 * 
-	 * @param msgConsumer
-	 *            message consumer
-	 * @return {@link MessageContext} of the last message received from the
-	 *         store.
-	 */
-	public MessageContext fetch(MessageConsumer msgConsumer) {
-		return messageConsumer.receive();
+
+	private Set<Integer> getNonRetryStatusCodes() {
+		Set<Integer> nonRetryCodes = new HashSet<Integer>();
+		if (nonRetryStatusCodes != null) {
+			for (String code : nonRetryStatusCodes) {
+				try {
+					int codeI = Integer.parseInt(code.trim());
+					nonRetryCodes.add(codeI);
+				} catch (NumberFormatException e) {
+				} // ignore the invalid status code
+			}
+		}
+		return nonRetryCodes;
 	}
 
 	/**
-	 * Sends the mesage to a given endpoint.
-	 * 
-	 * @param messageContext
-	 *            synapse {@link MessageContext} to be sent
-     */
-    public void dispatch(MessageContext messageContext) {
-        if (log.isDebugEnabled()) {
-			log.debug("Sending the message to client with message processor [" +
-			          messageProcessor.getName() + "]");
+	 * Receives the next message from the message store. On a connection issue
+	 * to store, retry will happen in this method
+	 *
+	 * @return {@link MessageContext} of the last message received from the
+	 * store.
+	 * @throws StoreForwardException on an issue fetching a message from store. Here
+	 *                               all connections to internal store will be closed. Also all connections
+	 *                               made by consumer to poll messages will be closed
+	 */
+	public MessageContext fetch() throws StoreForwardException {
+
+		MessageContext fetchedMessage = null;
+
+		for (int connAttempt = 0;
+			 connAttempt < maxConnectionAttemptsToStore || maxConnectionAttemptsToStore == -1;
+			 connAttempt++) {
+			try {
+				fetchedMessage = messageConsumer.receive();
+				break;
+			} catch (SynapseException e) {
+				/*used message in the exception to keep Interface MessageConsumer unchanged.
+				  If it is a connection exception retry, otherwise throw  as it is
+				*/
+				if (e.getLocalizedMessage().contains(MessageProcessorConstants.STORE_CONNECTION_ERROR)) {
+					try {
+						//on last try to connect throw the exception
+						if (connAttempt == maxConnectionAttemptsToStore - 1) {
+							throw new SynapseException("Error while connecting to message store "
+									+ messageProcessor.getName(), e);
+						}
+						Thread.sleep(storeConnectionAttemptDelay);
+					} catch (InterruptedException e1) {
+						//ignore
+					}
+				} else {
+					throw new SynapseException("Error while fetching message from " + messageProcessor.getName(), e);
+				}
+			}
 		}
 
-		// The below code is just for keeping the backward compatibility with
-		// the old code.
+		return fetchedMessage;
+	}
+
+	/**
+	 * Sends the message to a given endpoint.
+	 *
+	 * @param messageContext synapse {@link MessageContext} to be sent
+	 */
+	public void dispatch(MessageContext messageContext) {
+		if (log.isDebugEnabled()) {
+			log.debug("Sending the message to client with message processor ["
+					+ messageProcessor.getName() + "]");
+		}
+
+		// The below code is just for keeping the backward compatibility with the old code.
 		if (targetEndpoint == null) {
 			targetEndpoint =
-			                 (String) messageContext.getProperty(ForwardingProcessorConstants.TARGET_ENDPOINT);
+					(String) messageContext.getProperty(ForwardingProcessorConstants.TARGET_ENDPOINT);
 		}
 
-		MessageContext outCtx = null;
-		SOAPEnvelope originalEnvelop = messageContext.getEnvelope();
-
 		if (targetEndpoint != null) {
-			Endpoint ep = messageContext.getEndpoint(targetEndpoint);
-			if (ep == null) {
+			Endpoint endpoint = messageContext.getEndpoint(targetEndpoint);
+			if (endpoint == null) {
 				log.error("Endpoint does not exists. Deactivating the message processor");
 				deactivateMessageProcessor(messageContext);
 				return;
 			}
-			AbstractEndpoint abstractEndpoint = (AbstractEndpoint) ep;
+			AbstractEndpoint abstractEndpoint = (AbstractEndpoint) endpoint;
 			EndpointDefinition endpointDefinition = abstractEndpoint.getDefinition();
-			String endpointReferenceValue = null;
-	        if (endpointDefinition.getAddress() != null) {
-		        endpointReferenceValue = endpointDefinition.getAddress();
-		        isResponseValidationNotRequired = !isResponseValidationRequiredEndpoint(endpointReferenceValue);
-	        }
+			String endpointReferenceValue;
+			if (endpointDefinition.getAddress() != null) {
+				endpointReferenceValue = endpointDefinition.getAddress();
+				//we only validate response for certain protocols (i.e HTTP/HTTPS)
+				isResponseValidationNotRequired = !isResponseValidationRequiredEndpoint(endpointReferenceValue);
+			}
 			try {
 				// Send message to the client
 				while (!isSuccessful && !isTerminated) {
-					try {
-						// For each retry we need to have a fresh copy of the
-						// actual message. otherwise retry may not
-						// work as expected.
-						messageContext.setEnvelope(MessageHelper.cloneSOAPEnvelope(originalEnvelop));
-                        setSoapHeaderBlock(messageContext);
-						OMElement firstChild = null; //
-						org.apache.axis2.context.MessageContext origAxis2Ctx =
-						                                                       ((Axis2MessageContext) messageContext).getAxis2MessageContext();
-						if (JsonUtil.hasAJsonPayload(origAxis2Ctx)) {
-							firstChild = origAxis2Ctx.getEnvelope().getBody().getFirstElement();
-						} // Had to do this because
-						  // MessageHelper#cloneSOAPEnvelope does not clone
-						  // OMSourcedElemImpl correctly.
-						if (JsonUtil.hasAJsonPayload(firstChild)) { //
-							OMElement clonedFirstElement =
-							                               messageContext.getEnvelope().getBody()
-							                                             .getFirstElement();
-							if (clonedFirstElement != null) {
-								clonedFirstElement.detach();
-								messageContext.getEnvelope().getBody().addChild(firstChild);
-							}
-						}// Had to do this because
-						 // MessageHelper#cloneSOAPEnvelope does not clone
-						 // OMSourcedElemImpl correctly.
-						origAxis2Ctx.setProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES,
-						                         getNonRetryStatusCodes());
-
-						if (messageConsumer != null && messageConsumer.isAlive()) {
-							outCtx = sender.send(ep, messageContext);
-						}
-
-                        if (isResponseValidationNotRequired) {
-                            /*
-                             * There is no status codes to deal with JMS eps. So
-                             * merely set it as a success if there's no any
-                             * exceptions.
-                             */
-                            isSuccessful = true;
-                        } else {
-                            String responseSc =
-                                                ((String) ((Axis2MessageContext) messageContext).getAxis2MessageContext()
-                                                                                                .getProperty(SynapseConstants.HTTP_SC));
-							// Some events where response code is null (i.e. sender socket timeout
-							// when there is no response from endpoint)
-							int sc;
-							try {
-								sc = Integer.parseInt(responseSc.trim());
-								isSuccessful =
-										getHTTPStatusCodeFamily(sc).equals(
-												HTTPStatusCodeFamily.SUCCESSFUL) ||
-												isNonRetryErrorCode(responseSc);
-							} catch (NumberFormatException nfe) {
-								isSuccessful = false;
-							}
-                        }
-					} catch (Exception e) {
-                        // this means send has failed due to some reason so we
-                        // have to retry it
-                        /*
-                         * If an exception is thrown in a JMS scenario then we
-                         * have to consider it as a failure.
-                         */
-                        if (isResponseValidationNotRequired) {
-                            isSuccessful = false;
-						} else if (outCtx != null && "true".equals(outCtx.getProperty(
-								ForwardingProcessorConstants.BLOCKING_SENDER_ERROR))) {
-							isSuccessful = false;
-						} else {
-                            if (e instanceof SynapseException) {
-                                String responseSc =
-                                                    ((String) ((Axis2MessageContext) messageContext).getAxis2MessageContext()
-                                                                                                    .getProperty(SynapseConstants.HTTP_SC));
-								// We can come to this exception where sender has
-								// not responded, in which case there is no SC - we can't guarantee
-								// if send was successful or not in such cases other than those
-								// handled above.
-								int sc;
-								try {
-									sc = Integer.parseInt(responseSc.trim());
-									isSuccessful =
-											getHTTPStatusCodeFamily(sc).equals(
-													HTTPStatusCodeFamily.SUCCESSFUL) ||
-													isNonRetryErrorCode(responseSc);
-								} catch (NumberFormatException nfe) {
-									isSuccessful = false;
-								}
-                            }
-                        }
-						if (!isSuccessful) {
-							log.error("BlockingMessageSender of message processor [" +
-							          this.messageProcessor.getName() +
-							          "] failed to send message to the endpoint");
-							// Some Error has occurred while having out only
-							// operation. Try to send the to fault sequence,
-							// since
-							// outCtx is null passing the messageContext
-							sendThroughFaultSeq(messageContext);
-						}
-					}
-
-                    if (outCtx != null) {
-                        if (isSuccessful) {
-                            sendThroughReplySeq(outCtx);
-                            messageConsumer.ack();
-                            attemptCount = 0;
-                            isSuccessful = true;
-                            if (log.isDebugEnabled()) {
-                                log.debug("Successfully sent the message to endpoint [" +
-                                          ep.getName() + "]" + " with message processor [" +
-                                          messageProcessor.getName() + "]");
-                            }
-                        } else {
-                            // This means some error has occurred so
-                            // must try to send down the fault sequence.
-                            log.error("BlockingMessageSender of message processor [" +
-                                      this.messageProcessor.getName() +
-                                      "] failed to send message to the endpoint");
-                            sendThroughFaultSeq(outCtx);
-                        }
-                    } else {
-                        if (isSuccessful) {
-                            // This Means we have invoked an out only operation
-                            // remove the message and reset the count
-                            messageConsumer.ack();
-                            attemptCount = 0;
-                            isSuccessful = true;
-
-                            if (log.isDebugEnabled()) {
-                                log.debug("Successfully sent the message to endpoint [" +
-                                          ep.getName() + "]" + " with message processor [" +
-                                          messageProcessor.getName() + "]");
-                            }
-
-                        } else {
-                            // This means some error has occurred.
-                            log.error("BlockingMessageSender of message processor [" +
-                                      this.messageProcessor.getName() +
-                                      "] failed to send message to the endpoint");
-                        }
-                    }
-					
+					tryToDispatchToEndpoint(messageContext, endpoint);
 					if (!isSuccessful) {
-						// Then we have to retry sending the message to the
-						// client.
 						prepareToRetry(messageContext);
-					} 
+					}
 				}
 			} catch (Exception e) {
 				log.error("Message processor [" + messageProcessor.getName() +
-				          "] failed to send the message to" + " client", e);
+						"] failed to send the message to" + " client", e);
 			}
 		} else {
 			/*
@@ -609,32 +520,208 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			 * this by implementing a target inferring
 			 * mechanism.
 			 */
-
-			log.error("Neither targetEndpoint defined in the MessageProcessor configuration nor " +
-			          "Property " + ForwardingProcessorConstants.TARGET_ENDPOINT +
-			          " is found in the message context, hence deactivating the MessageProcessor");
+			log.error("Neither targetEndpoint defined in the MessageProcessor configuration nor "
+					+ "Property " + ForwardingProcessorConstants.TARGET_ENDPOINT
+					+ " is found in the message context, hence deactivating the MessageProcessor");
 			deactivateMessageProcessor(messageContext);
 		}
-		return;
+	}
+
+	/**
+	 * Try to dispatch message to the given endpoint
+	 *
+	 * @param messageToDispatch MessageContext containing message to forward
+	 * @param endpoint                endpoint to forward message to
+	 */
+	private void tryToDispatchToEndpoint(MessageContext messageToDispatch, Endpoint endpoint) {
+
+		isSuccessful = false;
+		MessageContext outCtx = null;
+
+		try {
+			// For each retry we need to have a fresh copy of the original message
+			messageToDispatch.setEnvelope(MessageHelper.cloneSOAPEnvelope(messageToDispatch.getEnvelope()));
+			setSoapHeaderBlock(messageToDispatch);
+			updateAxis2MessageContext(messageToDispatch);
+
+			if (messageConsumer != null && messageConsumer.isAlive()) {
+				outCtx = sender.send(endpoint, messageToDispatch);
+			}
+
+			/*
+			 * Validation as message is forwarded successfully depends on
+			 * 1. is message forwarding validation is required
+			 * 2. is there a outCtx
+			 * 3. has some error happened inside blocking sender
+			 * 4. HTTP_SC code is in success family or configured to consider as a success
+			 * 5. Some exception has happened during message forwarding
+			 */
+
+			//For Protocols like JMS etc no need of validating response
+			if (isResponseValidationNotRequired) {
+				isSuccessful = true;
+				onForwardSuccess(endpoint);
+			}
+
+			//there is no response
+			if (!isResponseValidationNotRequired && outCtx == null) {
+				isSuccessful = true;
+				onForwardSuccess(endpoint);
+			}
+
+			//there is a response (In message context) but failed to send with no exception thrown
+			if (!isResponseValidationNotRequired && outCtx != null
+					&& "true".equals(outCtx.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
+				log.error("Blocking Sender Error " + outCtx.getProperty(SynapseConstants.ERROR_EXCEPTION));
+				isSuccessful = false;
+				onForwardFailure();
+				//invoke fault sequence of MP
+				sendThroughFaultSeq(outCtx);
+				return;
+			}
+
+			//there is a response so check on status codes
+			if (!isResponseValidationNotRequired && outCtx != null && validateResponse(outCtx)) {
+				isSuccessful = true;
+				sendThroughReplySeq(outCtx);
+				onForwardSuccess(endpoint);
+			}
+
+		} catch (Exception e) {
+
+			log.error("[ " + messageProcessor.getName() + " ] Error while forwarding message to endpoint "
+					+ targetEndpoint + ".", e);
+
+			/*
+			 * TODO: need to validate the requirement for below checks. Ideally on any error forwarding should
+			 * be considered as a failure. Keeping them for backward compatibility
+			 */
+
+			if (!isResponseValidationNotRequired && outCtx != null && e instanceof SynapseException &&
+					validateResponse(outCtx)) {
+				isSuccessful = true;
+				onForwardSuccess(endpoint);
+			}
+
+			if (!isResponseValidationNotRequired && outCtx != null && "true".equals(outCtx.getProperty(
+					ForwardingProcessorConstants.BLOCKING_SENDER_ERROR))) {
+				log.error("Blocking Sender Error " + outCtx.getProperty(SynapseConstants.ERROR_EXCEPTION));
+				isSuccessful = false;
+				onForwardFailure();
+				//invoke fault sequence of MP
+				sendThroughFaultSeq(outCtx);
+			}
+
+			if (!isResponseValidationNotRequired && outCtx != null && validateResponse(outCtx)) {
+				isSuccessful = false;
+				onForwardFailure();
+				//invoke fault sequence of MP
+				sendThroughFaultSeq(outCtx);
+			}
+		}
+	}
+
+	/**
+	 * Steps after successfully forwarding the message to backend
+	 * @param endpoint
+	 */
+	private void onForwardSuccess(Endpoint endpoint) {
+		messageConsumer.ack();
+		attemptCount = 0;
+		isSuccessful = true;
+
+		if (log.isDebugEnabled()) {
+			log.debug("Successfully forwarded the message to endpoint ["
+					+ endpoint.getName() + "]" + " with message processor ["
+					+ messageProcessor.getName() + "].");
+		}
+	}
+
+	/**
+	 * Steps after failure to forward the message to the BE (service level or connection level)
+	 */
+	private void onForwardFailure() {
+		log.error("BlockingMessageSender of message processor ["
+				+ this.messageProcessor.getName()
+				+ "] failed to forward message to endpoint " + messageProcessor.getTargetEndpoint());
+	}
+
+	/**
+	 * Validate if response can be considered as a successful Back-end invocation
+	 *
+	 * @param responseMessage MessageContext of response
+	 * @return true if it is a successful invocation
+	 */
+	private boolean validateResponse(MessageContext responseMessage) {
+		boolean isSuccessful;
+		String responseSc = ((Axis2MessageContext) responseMessage).
+				getAxis2MessageContext().getProperty(SynapseConstants.HTTP_SC).toString();
+		// Some events where response code is null (i.e. sender socket timeout
+		// when there is no response from endpoint)
+		int sc = 0;
+		try {
+			sc = Integer.parseInt(responseSc.trim());
+			isSuccessful = getHTTPStatusCodeFamily(sc).equals(
+					HTTPStatusCodeFamily.SUCCESSFUL) ||
+					isNonRetryErrorCode(responseSc);
+		} catch (NumberFormatException nfe) {
+			isSuccessful = false;
+		}
+		if (!isSuccessful) {
+			String statusCode = " ";
+			if (sc != 0) {
+				statusCode = Integer.toString(sc);
+			}
+			log.info("Message processor [" + this.messageProcessor.getName() + "] received a response with HTTP_SC: "
+					+ statusCode + " from backend " + targetEndpoint + ". Message forwarding failed.");
+		}
+		return isSuccessful;
+	}
+
+	/**
+	 * Update Axis2MessageContext before dispatching message
+	 *
+	 * @param messageToDispatch message to be forwarded
+	 */
+	private void updateAxis2MessageContext(MessageContext messageToDispatch) {
+		OMElement firstChild = null; //
+		org.apache.axis2.context.MessageContext origAxis2Ctx =
+				((Axis2MessageContext) messageToDispatch).getAxis2MessageContext();
+		if (JsonUtil.hasAJsonPayload(origAxis2Ctx)) {
+			firstChild = origAxis2Ctx.getEnvelope().getBody().getFirstElement();
+		}
+		// Had to do this because
+		// MessageHelper#cloneSOAPEnvelope does not clone
+		// OMSourcedElemImpl correctly.
+		if (JsonUtil.hasAJsonPayload(firstChild)) { //
+			OMElement clonedFirstElement = messageToDispatch.
+					getEnvelope().getBody().getFirstElement();
+			if (clonedFirstElement != null) {
+				clonedFirstElement.detach();
+				messageToDispatch.getEnvelope().getBody().addChild(firstChild);
+			}
+		}
+
+		origAxis2Ctx.setProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES,
+				getNonRetryStatusCodes());
 	}
 
 	/**
 	 * Sending the out message through the fault sequence.
-	 * 
-	 * @param msgCtx
-	 *            Synapse {@link MessageContext} to be sent through the fault
-     *            sequence.
-     */
-    public void sendThroughFaultSeq(MessageContext msgCtx) {
+	 *
+	 * @param msgCtx Synapse {@link MessageContext} to be sent through the fault
+	 *               sequence.
+	 */
+	public void sendThroughFaultSeq(MessageContext msgCtx) {
 		if (faultSeq == null) {
 			log.warn("Failed to send the message through the fault sequence. Sequence name does not Exist.");
-            return;
-        }
-        Mediator mediator = msgCtx.getSequence(faultSeq);
+			return;
+		}
+		Mediator mediator = msgCtx.getSequence(faultSeq);
 
-        if (mediator == null) {
+		if (mediator == null) {
 			log.warn("Failed to send the message through the fault sequence. Sequence [" +
-			         faultSeq + "] does not Exist.");
+					faultSeq + "] does not Exist.");
 			return;
 		}
 
@@ -654,8 +741,8 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		}
 		Mediator mediator = msgCtx.getSequence(deactivateSeq);
 		if (mediator == null) {
-			log.warn("Failed to send the message through the deactivate sequence. Sequence [" +
-			         deactivateSeq + "] does not Exist.");
+			log.warn("Failed to send the message through the deactivate sequence. Sequence ["
+					+ deactivateSeq + "] does not Exist.");
 			return;
 		}
 		mediator.mediate(msgCtx);
@@ -663,15 +750,15 @@ public class ForwardingService implements Task, ManagedLifecycle {
 
 	/**
 	 * Sending the out message through the reply sequence.
-	 * 
-	 * @param outCtx
-	 *            Synapse out {@link MessageContext} to be sent through the
-	 *            reply sequence.
+	 *
+	 * @param outCtx Synapse out {@link MessageContext} to be sent through the
+	 *               reply sequence.
 	 */
 	public void sendThroughReplySeq(MessageContext outCtx) {
 		if (replySeq == null) {
 			deactivateMessageProcessor(outCtx);
-			log.error("Failed to send the out message. Reply sequence does not Exist. Deactivated the message processor");
+			log.error("Failed to send the out message. Reply sequence does not Exist. "
+					+ "Deactivated the message processor.");
 			return;
 		}
 		Mediator mediator = outCtx.getSequence(replySeq);
@@ -679,7 +766,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		if (mediator == null) {
 			deactivateMessageProcessor(outCtx);
 			log.error("Failed to send the out message. Reply sequence [" + replySeq +
-			          "] does not exist. Deactivated the message processor");
+					"] does not exist. Deactivated the message processor.");
 			return;
 		}
 
@@ -698,13 +785,13 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			// Thread.currentThread().interrupt();
 
 			if (log.isDebugEnabled()) {
-				log.debug("Successfully terminated job of message processor [" +
-				          messageProcessor.getName() + "]");
+				log.debug("Successfully terminated job of message processor ["
+						+ messageProcessor.getName() + "]");
 			}
 			return true;
 		} catch (Exception e) {
-			log.error("Failed to terminate the job of message processor [" +
-			          messageProcessor.getName() + "]");
+			log.error("Failed to terminate the job of message processor ["
+					+ messageProcessor.getName() + "]");
 			return false;
 		}
 	}
@@ -716,27 +803,27 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	 */
 	private void checkAndDeactivateProcessor(MessageContext msgCtx) {
 		if (maxDeliverAttempts > 0) {
-            this.attemptCount++;
-            if (attemptCount >= maxDeliverAttempts) {
+			this.attemptCount++;
+			if (attemptCount >= maxDeliverAttempts) {
 
-                if (this.isMaxDeliveryAttemptDropEnabled) {
-                    dropMessageAndContinueMessageProcessor();
-                    if (log.isDebugEnabled()) {
-                        log.debug("Message processor [" + messageProcessor.getName() +
-                                "] Dropped the failed message and continue due to reach of max attempts");
-                    }
-                } else {
-	                terminate();
-	                deactivateMessageProcessor(msgCtx);
+				if (this.isMaxDeliveryAttemptDropEnabled) {
+					dropMessageAndContinueMessageProcessor();
+					log.warn("Message processor [" + messageProcessor.getName()
+							+ "] failed to forward message " + maxDeliverAttempts + " times. Drop message and "
+							+ "continue.");
+				} else if (null != failMessageStore) {
+					storeMessageToBackupStoreAndContinue(msgCtx, failMessageStore);
+				} else {
+					terminate();
+					deactivateMessageProcessor(msgCtx);
+					log.warn("Message processor [" + messageProcessor.getName()
+							+ "] failed to forward message " + maxDeliverAttempts + " times. Deactivating message "
+							+ "processor.");
+				}
 
-                    if (log.isDebugEnabled()) {
-                        log.debug("Message processor [" + messageProcessor.getName() +
-                                "] stopped due to reach of max attempts");
-                    }
-                }
-            }
-        }
-    }
+			}
+		}
+	}
 
 
 	/*
@@ -761,18 +848,20 @@ public class ForwardingService implements Task, ManagedLifecycle {
 	}
 
 	private void deactivateMessageProcessor(MessageContext messageContext) {
-		sendThroughDeactivateSeq(messageContext);
+		if (null != messageContext) {
+			sendThroughDeactivateSeq(messageContext);
+		}
 		this.messageProcessor.deactivate();
 	}
 
-    private void resetService() {
-        isSuccessful = false;
-        attemptCount = 0;
-    }
+	private void resetService() {
+		isSuccessful = false;
+		attemptCount = 0;
+	}
 
-    private boolean isNonRetryErrorCode(final String responseHttpSc) {
-        boolean isNonRetryErrCode = false;
-		if(nonRetryStatusCodes != null) {
+	private boolean isNonRetryErrorCode(final String responseHttpSc) {
+		boolean isNonRetryErrCode = false;
+		if (nonRetryStatusCodes != null) {
 			for (String nonretrySc : nonRetryStatusCodes) {
 				if (nonretrySc.trim().contains(responseHttpSc.trim())) {
 					isNonRetryErrCode = true;
@@ -780,41 +869,81 @@ public class ForwardingService implements Task, ManagedLifecycle {
 				}
 			}
 		}
-        return isNonRetryErrCode;
-    }
+		return isNonRetryErrCode;
+	}
 
 	private boolean isRunningUnderCronExpression() {
 		return (cronExpression != null) && (throttlingInterval > -1);
 	}
 
+	/**
+	 * Acknowledge current message and reset message processor for next message
+	 */
 	private void dropMessageAndContinueMessageProcessor() {
 		messageConsumer.ack();
 		attemptCount = 0;
 		isSuccessful = true;
-		log.info("Removed failed message and continue the message processor [" +
-		         this.messageProcessor.getName() + "]");
 	}
-    
-	private boolean setMessageConsumer() {
+
+	/**
+	 * Store message failed to process by message
+	 * processor to backup message store and continue.
+	 * If backup is not successful, message processor will be deactivated
+	 */
+	private void storeMessageToBackupStoreAndContinue(MessageContext forwardFailedMessage, MessageStore messageStore) {
+
+		if (null == messageStore) {
+			log.error("Message processor [" + messageProcessor.getName()
+					+ "] failed to forward message " + maxDeliverAttempts + " times. Cannot find fail-messages-store "
+					+ "to backup. Hence deactivating message processor.");
+			deactivateMessageProcessor(forwardFailedMessage);
+			return;
+		}
+
+		boolean produceStatus = messageStore.getProducer().storeMessage(forwardFailedMessage);
+
+		if (produceStatus) {
+			messageConsumer.ack();
+			attemptCount = 0;
+			isSuccessful = true;
+			log.info("Message processor [" + messageProcessor.getName()
+					+ "] failed to forward message " + maxDeliverAttempts
+					+ " times. Moved failed message to fail-messages-store and continue");
+		} else {
+			log.error("Message processor [" + messageProcessor.getName()
+					+ "] failed to forward message " + maxDeliverAttempts
+					+ " times but failed to store message "
+					+ "in fail-messages-store and continue. Hence deactivating message processor.");
+			deactivateMessageProcessor(forwardFailedMessage);
+		}
+	}
+
+	/**
+	 * Set message consumer of associated store
+	 * and set to the message processor
+	 *
+	 * @throws StoreForwardException on an issue initializing the consumer if not done
+	 */
+	private void setMessageConsumer() throws StoreForwardException {
 		final String messageStore = messageProcessor.getMessageStoreName();
 		messageConsumer =
-		                  synapseEnvironment.getSynapseConfiguration()
-		                                    .getMessageStore(messageStore).getConsumer();
+				synapseEnvironment.getSynapseConfiguration()
+						.getMessageStore(messageStore).getConsumer();
 		
         /*
-         * If Message Processor is deactivated via Advanced params, then we need
+		 * If Message Processor is deactivated via Advanced params, then we need
          * to cleanup the JMS consumers here. Ideally a deactivated MP should
          * not have any active JMS consumers.
          */
-        if (!((ScheduledMessageProcessor) messageProcessor).getIsActivatedParamValue()) {
-            messageConsumer.cleanup();
-        }
+		if (!((ScheduledMessageProcessor) messageProcessor).getIsActivatedParamValue()) {
+			messageConsumer.cleanup();
+		}
 		/*
 		 * Make sure to set the same message consumer in the message processor
 		 * since it is used by life-cycle management methods. Specially by the
 		 * deactivate method to cleanup the connection before the deactivation.
 		 */
-		return messageProcessor.setMessageConsumer(messageConsumer);
+		messageProcessor.setMessageConsumer(messageConsumer);
 
 	}
 
@@ -832,43 +961,41 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		terminate();
 
 	}
-    
-    private boolean isResponseValidationRequiredEndpoint(String epAddress) {
-        Matcher match = httpPattern.matcher(epAddress);
-        return match.find();
-    }
 
-    /**
-     * + * Used to determine the family of HTTP status codes to which the given
-     * code
-     * + * belongs.
-     * + *
-     * + * @param statusCode - The HTTP status code
-     * +
-     */
-    private HTTPStatusCodeFamily getHTTPStatusCodeFamily(int statusCode) {
-        switch (statusCode / 100) {
-            case 1:
-                return HTTPStatusCodeFamily.INFORMATIONAL;
-            case 2:
-                return HTTPStatusCodeFamily.SUCCESSFUL;
-            case 3:
-                return HTTPStatusCodeFamily.REDIRECTION;
-            case 4:
-                return HTTPStatusCodeFamily.CLIENT_ERROR;
-            case 5:
-                return HTTPStatusCodeFamily.SERVER_ERROR;
-            default:
-                return HTTPStatusCodeFamily.OTHER;
-        }
-    }
+	private boolean isResponseValidationRequiredEndpoint(String epAddress) {
+		Matcher match = httpPattern.matcher(epAddress);
+		return match.find();
+	}
 
-    /**
-     * The set of HTTP status code families.
-     */
-    private enum HTTPStatusCodeFamily {
-        INFORMATIONAL, SUCCESSFUL, REDIRECTION, CLIENT_ERROR, SERVER_ERROR, OTHER
-    }
+	/**
+	 * Used to determine the family of HTTP status codes to which the given
+	 * code
+	 * @param statusCode The HTTP status code
+	 * @return HTTPStatusCodeFamily
+	 */
+	private HTTPStatusCodeFamily getHTTPStatusCodeFamily(int statusCode) {
+		switch (statusCode / 100) {
+			case 1:
+				return HTTPStatusCodeFamily.INFORMATIONAL;
+			case 2:
+				return HTTPStatusCodeFamily.SUCCESSFUL;
+			case 3:
+				return HTTPStatusCodeFamily.REDIRECTION;
+			case 4:
+				return HTTPStatusCodeFamily.CLIENT_ERROR;
+			case 5:
+				return HTTPStatusCodeFamily.SERVER_ERROR;
+			default:
+				return HTTPStatusCodeFamily.OTHER;
+		}
+	}
+
+	/**
+	 * The set of HTTP status code families.
+	 */
+	private enum HTTPStatusCodeFamily {
+		INFORMATIONAL, SUCCESSFUL, REDIRECTION, CLIENT_ERROR, SERVER_ERROR, OTHER
+	}
 
 	private void setSoapHeaderBlock(MessageContext synCtx) {
 		// Send the SOAP Header Blocks to support WS-Addressing

--- a/modules/core/src/main/java/org/apache/synapse/message/store/MessageStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/MessageStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
@@ -22,6 +22,7 @@ import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.Nameable;
 import org.apache.synapse.SynapseArtifact;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.message.MessageConsumer;
 import org.apache.synapse.message.MessageProducer;
 
@@ -30,67 +31,72 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 public interface MessageStore extends ManagedLifecycle, Nameable, SynapseArtifact {
+
     /**
      * Returns a Message Producer for this message store. <br/>
-     * @return  A non-null message producer that can produce messages to this message store.
+     *
+     * @return A non-null message producer that can produce messages to this message store.
      */
-    MessageProducer getProducer();
+    MessageProducer getProducer() throws SynapseException;
 
     /**
      * Returns a Message Consumer for this message store. <br/>
+     *
      * @return A non-null message consumer that can read messages from this message store.<br/>
      */
-    MessageConsumer getConsumer();
+    MessageConsumer getConsumer() throws SynapseException;
 
     /**
      * set the implementation specific parameters
+     *
      * @param parameters A map of parameters or null
      */
-    public void setParameters(Map<String,Object> parameters);
+    void setParameters(Map<String, Object> parameters);
 
     /**
      * get the implementation specific parameters of the Message store
+     *
      * @return a properties map
      */
-    public Map<String,Object> getParameters();
+    Map<String, Object> getParameters();
 
     /**
      * Set the name of the file that the Message store is configured
      *
      * @param filename Name of the file where this artifact is defined
      */
-    public void setFileName(String filename);
+    void setFileName(String filename);
 
     /**
      * get the file name that the message store is configured
      *
      * @return Name of the file where this artifact is defined
      */
-    public String getFileName();
+    String getFileName();
 
     /**
      * Returns the type of this message store. <br/>
      * The type of a message store can be one of following types, <br/>
      * {@link Constants#JMS_MS}, {@link Constants#INMEMORY_MS},
      * or {@link Constants#JDBC_MS}
+     *
      * @return Type of the message store.
      */
-    public int getType();
+    int getType();
 
     /**
      * Retrieves and removes the first Message in this store.
      * Message ordering will depend on the underlying implementation
      *
      * @return first message context in the store
-     * @throws java.util.NoSuchElementException
-     *          if store is empty
+     * @throws java.util.NoSuchElementException if store is empty
      */
-    public MessageContext remove() throws NoSuchElementException;
+    MessageContext remove() throws NoSuchElementException;
 
     /**
      * Delete all the Messages in the Message Store
      */
-    public void clear();
+    void clear();
 
     /**
      * Delete and return the MessageContext with given Message id
@@ -98,14 +104,14 @@ public interface MessageStore extends ManagedLifecycle, Nameable, SynapseArtifac
      * @param messageID message id of the Message
      * @return MessageContext instance
      */
-    public MessageContext remove(String messageID);
+    MessageContext remove(String messageID);
 
     /**
      * Returns the number of Messages  in this store.
      *
      * @return the number of Messages in this Store
      */
-    public int size();
+    int size();
 
     /**
      * Return the Message in given index position
@@ -114,14 +120,14 @@ public interface MessageStore extends ManagedLifecycle, Nameable, SynapseArtifac
      * @param index position of the message
      * @return Message in given index position
      */
-    public MessageContext get(int index);
+    MessageContext get(int index);
 
     /**
      * Get the All messages in the Message store without removing them from the queue
      *
      * @return List of all Messages
      */
-    public List<MessageContext> getAll();
+    List<MessageContext> getAll();
 
     /**
      * Get the Message with the given ID from the Message store without removing it
@@ -129,29 +135,33 @@ public interface MessageStore extends ManagedLifecycle, Nameable, SynapseArtifac
      * @param messageId A message ID string
      * @return Message with given ID
      */
-    public MessageContext get(String messageId);
+    MessageContext get(String messageId);
 
     /**
      * Whether the message store edited through the management console
-     * @return
+     *
+     * @return true if Message Store config is locally edited
      */
-    public boolean isEdited();
+    boolean isEdited();
 
     /**
      * Set whether the message store edited through the management console
-     * @param isEdited
+     *
+     * @param isEdited true if Message Store config is locally edited
      */
-    public void setIsEdited(boolean isEdited);
+    void setIsEdited(boolean isEdited);
 
     /**
      * Get the name of the artifact container from which the message store deployed
-     * @return
+     *
+     * @return Name of artifact container
      */
-    public String getArtifactContainerName();
+    String getArtifactContainerName();
 
     /**
      * Set the name of the artifact container from which the message store deployed
-     * @param artifactContainerName
+     *
+     * @param artifactContainerName name of artifact container
      */
-    public void setArtifactContainerName(String artifactContainerName);
+    void setArtifactContainerName(String artifactContainerName);
 }

--- a/modules/tasks/src/main/java/org/apache/synapse/task/Task.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/Task.java
@@ -25,5 +25,5 @@ public interface Task {
     /**
      * Execute method will be invoked by the QuartzJOb.
      */
-    public void execute();
+    void execute();
 }


### PR DESCRIPTION
## Purpose

Fixes below issues:

1. https://github.com/wso2/product-ei/issues/1667
2. https://github.com/wso2/product-ei/issues/1668
3. https://github.com/wso2/product-ei/issues/1676
4. https://github.com/wso2/product-ei/issues/1682
5. https://github.com/wso2/product-ei/issues/1677

## Goals

This PR introduces two new features. 

1. https://github.com/wso2/product-ei/issues/1677

 **publish poison message to a different queue and continue** 

Publish the failing message to a different queue, acknowledge the original message and continue the message processor to the next message.

2. https://github.com/wso2/product-ei/issues/1667

**Deactivate message processor after trying to connect to JMS provider a specified number of times with specified delay between each try.** 

## User stories

1. Message processor is configured for reliable delivery. It consumes messages one after the other and if cannot process, will deactivate itself. No more messages are processed until a admin logs into the system, correct the problem (or move that particular message from considered queue to a different queue) and activate the message processor manually again. 

For some systems, this can introduce a critical situation as whole message flow stops from there onwards. New feature will prevent that issue. Message will be forwarded to a different queue (or any type of message store) and processing will be continued. Admin can configure a message processor to address them when system is at low peak and attend to them specifically. 

2. There are situations where JMS provider (Broker) can go offline/crash. Then message processor should try to connect periodically a several times before giving up. User should be able to configure how it should retry and when to give up. 


## Release note

.1 Feature: Forwarding Message processor (JMS) is able to forward the failing message to a different message store and continue to next message. 

2. Feature:  Forwarding Message processor (JMS) is able to configure to reconnect to JMS provider a several times with specified interval between each try before deactivating message processor. 

## Documentation

1. 

JMS Message forwarding processor has following new configuration parameter

A new parameter is introduced to forwarding message processor called "fail.messages.store" where any message store already configured can be pointed.

i.e
`<parameter name="message.processor.failMessagesStore">BackupMessageStore</parameter>`

**Behaviour is:**
If this parameter is present, message will be forwarded to that store when failed, and message processor will continue to the next message. If some issue happened when forwarding the message to the new store, message processor will get deactivated. 

If parameter  <parameter name="max.delivery.drop">Enabled</parameter> is configured, even if message.processor.failMessagesStore parameter is there, precedence will be given to former. That means message will be dropped and message processor will continue to the next message. 

If parameter message.processor.failMessagesStore is not present, message processor will disable itself after trying to forward the message to endpoint given number of times. 

2. 

Following two new parameters are introduced to message processor configuration with specified default values

<max.store.connection.attempts> = -1 = infinite
<store.connection.retry.interval> = 1000 ms

**Behaviour is**

Upon a broker crash/disconnect, message processor will retry to connect <max.store.connection.attempts> number of attempts. Each attempt will have <store.connection.retry.interval> interval in milliseconds. If it still cannot connect message processor will get deactivated. 

This affects to a running message processor as well as at deployment/start up.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
Not needed

## Test environment
Java 8, MAC OS EL Capitan
 
## Learning
> N/A