### PR TITLE
Change error to debug jsonpath for nonexisting element

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -30,7 +30,8 @@ import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.jaxen.JaxenException;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class SynapseJsonPath extends SynapsePath {
 
@@ -122,7 +123,10 @@ public class SynapseJsonPath extends SynapsePath {
         } catch (IOException e) {
             handleException("Error evaluating JSON Path <" + jsonPath.getPath() + ">", e);
         } catch (Exception e) { // catch invalid json paths that do not match with the existing JSON payload.
-            log.warn("#stringValueOf. Error evaluating JSON Path <" + jsonPath.getPath() + ">. Returning empty result. Error>>> " + e.getLocalizedMessage());
+            if (log.isDebugEnabled()) {
+                log.debug("#stringValueOf. Error evaluating JSON Path <" + jsonPath.getPath()
+                        + ">. Returning empty result. Error>>> " + e.getLocalizedMessage());
+            }
             return "";
         }
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
> Change error log to debug since an InvalidPathException is thrown when jsonPath points to nonexisting json element.
> And quering nonexisting JSON element is valid use-case and jsonPath validation should happen at JsonPath.compile(jsonPathExpression);

## Goals
> Fix: https://github.com/wso2/product-ei/issues/1718

## Approach
> Change error log to debug log