### PR TITLE
Fix handling POST request without Content-Type

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -212,4 +212,9 @@ public class PassThroughConstants {
 
     public static final String MESSAGE_SIZE_VALIDATION_SUM = "MESSAGE_SIZE_VALIDATION_SUM";
     public static final String SOURCE_CONNECTION_DROPPED = "SOURCE_CONNECTION_DROPPED";
+
+    /**
+     * Denotes application/octet-stream content-type
+     */
+    public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -183,10 +183,15 @@ public class ServerWorker implements Runnable {
 	 */
 	public SOAPEnvelope handleRESTUrlPost(String contentTypeHdr) throws FactoryConfigurationError {
 	    SOAPEnvelope soapEnvelope = null;
-	    String contentType = contentTypeHdr!=null?TransportUtils.getContentType(contentTypeHdr, msgContext):null;
-	    if (contentType == null || "".equals(contentType) || HTTPConstants.MEDIA_TYPE_X_WWW_FORM.equals(contentType)) {
-	        contentType = contentTypeHdr != null ? contentTypeHdr:HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
-	        msgContext.setTo(new EndpointReference(request.getRequest().getRequestLine().getUri()));
+        String contentType = contentTypeHdr != null ? TransportUtils.getContentType(contentTypeHdr, msgContext) : null;
+        // When POST request doesn't contain a Content-Type,
+        // recipient should consider it as application/octet-stream (rfc2616)
+        if (contentType == null || contentType.isEmpty()) {
+            contentType = PassThroughConstants.APPLICATION_OCTET_STREAM;
+        }
+        if (HTTPConstants.MEDIA_TYPE_X_WWW_FORM.equals(contentType) ||
+                (PassThroughConstants.APPLICATION_OCTET_STREAM.equals(contentType) && contentTypeHdr == null)) {
+            msgContext.setTo(new EndpointReference(request.getRequest().getRequestLine().getUri()));
 	        msgContext.setProperty(Constants.Configuration.CONTENT_TYPE,contentType);
 	        String charSetEncoding = BuilderUtil.getCharSetEncoding(contentType);
 		    msgContext.setProperty(Constants.Configuration.CHARACTER_SET_ENCODING, charSetEncoding);


### PR DESCRIPTION
When POST request comes without Content-Type recipient may assume it as application/octet-stream ((rfc2616)). This fixes https://wso2.org/jira/browse/ESBJAVA-2183

## Purpose
Handle POST requests without Content-Type as defined in HTTP spec.

## Approach

When EI receives a POST without content type, EI considers content type as application/x-www-form-urlencoded. As per the spec, EI should handle it as application/octet-stream. The "octet-stream" is used to indicate that a body contains arbitrary binary data. So to handle content-type according to the HTTP 1.1, EI should be shipped enabling the binary relay for octet-stream Content-Type i.e configuring BinaryBuilder and ExpandingFormatter as Builder and Formatter for application/octet-stream in axis2.xml file

