### PR TITLE
Add expression support for class mediator property

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorFactory.java
@@ -26,6 +26,7 @@ import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.commons.util.PropertyHelper;
+import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.mediators.ext.ClassMediator;
 
 import javax.xml.namespace.QName;
@@ -116,30 +117,7 @@ public class ClassMediatorFactory extends AbstractMediatorFactory {
             throw new SynapseException(msg, e);
         }
 
-        for (Iterator it = elem.getChildrenWithName(PROP_Q); it.hasNext();) {
-            OMElement child = (OMElement) it.next();
-
-            String propName = child.getAttribute(ATT_NAME).getAttributeValue();
-            if (propName == null) {
-                handleException(
-                    "A Class mediator property must specify the name attribute");
-            } else {
-                if (child.getAttribute(ATT_VALUE) != null) {
-                    String value = child.getAttribute(ATT_VALUE).getAttributeValue();
-                    classMediator.addProperty(propName, value);
-                    PropertyHelper.setInstanceProperty(propName, value, mediator);
-                } else {
-                    OMNode omElt = child.getFirstElement();
-                    if (omElt != null) {
-                        classMediator.addProperty(propName, omElt);
-                        PropertyHelper.setInstanceProperty(propName, omElt, mediator);
-                    } else {
-                        handleException("A Class mediator property must specify " +
-                            "name and value attributes, or a name and a child XML fragment");
-                    }
-                }
-            }
-        }
+        classMediator.addAllProperties(MediatorPropertyFactory.getMediatorProperties(elem));
 
         // after successfully creating the mediator
         // set its common attributes such as tracing etc

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorSerializer.java
@@ -51,20 +51,7 @@ public class ClassMediatorSerializer extends AbstractMediatorSerializer  {
             handleException("Invalid class mediator. The class name is required");
         }
 
-        Iterator itr = mediator.getProperties().keySet().iterator();
-        while(itr.hasNext()) {
-            String propName = (String) itr.next();
-            Object o = mediator.getProperties().get(propName);
-            OMElement prop = fac.createOMElement(PROP_Q, clazz);
-            prop.addAttribute(fac.createOMAttribute("name", nullNS, propName));
-
-            if (o instanceof String) {
-                prop.addAttribute(fac.createOMAttribute("value", nullNS, (String) o));
-            } else {
-                prop.addChild((OMNode) o);
-            }
-            clazz.addChild(prop);
-        }
+        super.serializeProperties(clazz, mediator.getProperties());
 
         return clazz;
     }


### PR DESCRIPTION
Fix https://wso2.org/jira/browse/ESBJAVA-3777

## Purpose
Currently the we can only pass static values to the class mediator property. With this fix we can pass expressions such as `get-property`, xpath, json path etc. 

## Goals
Expression support for class mediator property

## Approach
Implemented similar to the log mediators' property  i.e  MediatorProperty

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-mediation/pull/952

## Migrations (if applicable)
N/A

## Test environment
Java 1.8
 
## Learning
N/A