### PR TITLE
Fix CApp with inbound EP redeployment fails in windows

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -212,4 +212,9 @@ public class PassThroughConstants {
 
     public static final String MESSAGE_SIZE_VALIDATION_SUM = "MESSAGE_SIZE_VALIDATION_SUM";
     public static final String SOURCE_CONNECTION_DROPPED = "SOURCE_CONNECTION_DROPPED";
+
+    /**
+     * System property to configure verification timeout (iterative verification) in seconds for port.
+     */
+    public static final String SYSTEMPROP_PORT_CLOSE_VERIFY_TIMEOUT = "synapse.transport.portCloseVerifyTimeout";
 }


### PR DESCRIPTION
## Purpose
> Fix Re-deployment of the CAR file with the endpoint fails in the windows environment

## Goals
> Fix: https://github.com/wso2/product-ei/issues/1730

## Approach
> validate whether the port is closed successfully. Here we wait till port is successfully get closed iteratively trying to bind a ServerSocket to the relevant port. As default time check for 10s and log warning and move on.

## Documentation
> https://github.com/wso2/product-ei/issues/1757