### PR TITLE
Fix Restful dispatcher to set AxisOperation correctly.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpConstants.java
@@ -19,6 +19,8 @@
 
 package org.apache.synapse.transport.nhttp;
 
+import javax.xml.namespace.QName;
+
 public class NhttpConstants {
     public static final String TRUE = "TRUE";
     /**
@@ -262,4 +264,15 @@ public class NhttpConstants {
     public static final String CONNECTION_DROPPED = "CONNECTION_DROPPED";
 
     public static final int DEFAULT_SOCKET_TIMEOUT = 60000;
+
+    /**
+     * The operation name used by the Synapse service (for message mediation)
+     */
+    public static final QName SYNAPSE_OPERATION_NAME = new QName("mediate");
+
+    /**
+     * The default operation name used by the axis service
+     */
+    public static final String DEFAULT_MEDIATE_OPERATION = "_default_mediate_operation_";
+
 }


### PR DESCRIPTION
When receiving rest request axis2 checks whether axis operation is set in the message context to build the request message. Therefore we have to set axis operation before we handed over the request to axis engine. If axis operation is already set in the message context to take it from there. If not take the axis operation from axis service.
PUBLIC JIRA: https://wso2.org/jira/browse/ESBJAVA-3689

## Purpose
To Provide the capability to access request content within synapse message context when a mime HTTP request with attachments is received to the EI.