### PR TITLE
Fix wso2/product-ei/issues/1760

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfigUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfigUtils.java
@@ -451,16 +451,19 @@ public class SynapseConfigUtils {
                                 "HostName verification disabled");
                     }
 
-                    connection.setHostnameVerifier(new javax.net.ssl.HostnameVerifier() {
-                        public boolean verify(String hostname, javax.net.ssl.SSLSession session) {
+                    HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+                        @Override
+                        public boolean verify(String hostname, SSLSession sslSession) {
                             if (log.isTraceEnabled()) {
                                 log.trace("HostName verification disabled");
                                 log.trace("Host:   " + hostname);
-                                log.trace("Peer Host:  " + session.getPeerHost());
+                                log.trace("Peer Host:  " + sslSession.getPeerHost());
                             }
                             return true;
                         }
-                    });
+                    };
+                    connection.setHostnameVerifier(hostnameVerifier);
+
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Using default HostName verifier...");


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/1760

## Goals
> Enabling to add WSDL endpoints which doesn't have host-name in the certificate. 

## Approach
> Change hostnameVerifier implementation. 

## User stories
> Adding a WSDL endpoint with hostname verification disabled.
When adding a WSDL endpoint WSO2EI uses HttpsUrlConnection to communicate with the remote endpoint. 
So disable host-name verification method mentioned in [https://docs.wso2.com/display/ADMIN44x/Enabling+HostName+Verification#EnablingHostNameVerification-Configuringhostnameverification(Carbon4.4.17onwards)](https://docs.wso2.com/display/ADMIN44x/Enabling+HostName+Verification#EnablingHostNameVerification-Configuringhostnameverification(Carbon4.4.17onwards) ) not works here. ( HTTPS used instead of HTTP )

So to disable host-name verification for this scenario user have to add following configuration to his synapse.properties file in <EI_HOME>/Conf directory

keystore.trust.location=repository/resources/security/client-truststore.jks
keystore.trust.type=JKS
keystore.trust.alias=wso2carbon
keystore.trust.store.password=wso2carbon
keystore.trust.parameters=enableHostnameVerifier=false

However disabling host-name verification is not recommended and should be done at your own risk.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> [https://docs.wso2.com/display/EI611/WSDL+Endpoint](https://docs.wso2.com/display/EI611/WSDL+Endpoint)

## Test environment
> Ubuntu 16.04 , JDK 8