### PR TITLE
Fix wso2/product-ei/issues/1792

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceResponse.java
@@ -113,7 +113,11 @@ public class SourceResponse {
                 request.getConnection().getContext());
 
         if (statusLine != null) {
-            response.setStatusLine(version, status, statusLine);
+            if (versionChangeRequired) {
+                response.setStatusLine(version, status, statusLine);
+            } else {
+                response.setStatusLine(request.getVersion(), status, statusLine);
+            }
         } else if (versionChangeRequired){
         	response.setStatusLine(version, status);
         } else {


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/1792

## Goals
> Currently default response HTTP version is 1.1 If request format is 1.0 response HTTP version should also be 1.0 

## Approach
> Adding a check before sending response

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes