### PR TITLE
Resolve wso2/product-ei#414

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonDataSource.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonDataSource.java
@@ -85,7 +85,6 @@ final class JsonDataSource implements OMDataSource {
 
     public void serialize(XMLStreamWriter xmlWriter) throws XMLStreamException {
         XMLStreamReader reader = getReader();
-        xmlWriter.writeStartDocument();
         while (reader.hasNext()) {
             int x = reader.next();
             switch (x) {
@@ -117,7 +116,6 @@ final class JsonDataSource implements OMDataSource {
                     xmlWriter.writeEndElement();
                     break;
                 case XMLStreamConstants.END_DOCUMENT:
-                    xmlWriter.writeEndDocument();
                     break;
                 case XMLStreamConstants.SPACE:
                     break;
@@ -138,9 +136,7 @@ final class JsonDataSource implements OMDataSource {
                     throw new OMException();
             }
         }
-        xmlWriter.writeEndDocument();
         xmlWriter.flush();
-        xmlWriter.close();
     }
 
     public XMLStreamReader getReader() throws XMLStreamException {

--- a/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonDataSourceTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/json/JsonDataSourceTest.java
@@ -47,13 +47,8 @@ public class JsonDataSourceTest extends TestCase {
                                             "<url>http://org.wso2.json/32_32</url>" +
                                             "</jsonObject>";
 
-    public static final String expectedXMLWithDecl = "<?xml version='1.0' encoding='UTF-8'?>" +
-                                            "<jsonObject>" +
-                                            "<id>0001</id>" +
-                                            "<ok>true</ok>" +
-                                            "<amount>5250</amount>" +
-                                            "<url>http://org.wso2.json/32_32</url>" +
-                                            "</jsonObject>";
+    public static final String expectedXMLWithDecl =
+            "<jsonObject><id>0001</id><ok>true</ok><amount>5250</amount><url>http://org.wso2.json/32_32</url></jsonObject>";
 
     public void testSerializeJson() throws FileNotFoundException, XMLStreamException {
         JsonDataSource jsonDataSource = createJsonDatasource();


### PR DESCRIPTION
## Purpose
> Resolve wso2/product-ei#414

## Goals
> No exception or errors when a soap client sends a message which is passed to a JSON backend and when the returned response is converted to text/xml.

## Approach
> This issue is fixed by using the existing way of serializing using XMLStreamWriter rather than implementing it again. Our own implementation has caused this issue.

## Test environment
> JDK 8 | Ubuntu 17.10