### PR TITLE
Fix wso2/product-ei/issues/1054

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -36,6 +36,7 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.commons.util.MiscellaneousUtil;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.deployers.SynapseArtifactDeploymentException;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.Value;
 import org.mozilla.javascript.Context;
@@ -593,7 +594,14 @@ public class ScriptMediator extends AbstractMediator {
         if (language.equals(NASHORN_JAVA_SCRIPT)) {
             this.scriptEngine = engineManager.getEngineByName(NASHORN);
         } else {
-            this.scriptEngine = engineManager.getEngineByExtension(language);
+            try {
+                this.scriptEngine = engineManager.getEngineByExtension(language);
+            } finally {
+                if (scriptEngine == null ) {
+                    throw new SynapseArtifactDeploymentException("Failed to create ScriptMediator with language "
+                            + "attribute: " + language);
+                }
+            }
         }
 
         pool = new LinkedBlockingQueue<ScriptEngineWrapper>(poolSize);


### PR DESCRIPTION
## Purpose
> Fixes: https://github.com/wso2/product-ei/issues/1054

## Goals
> When deploying synapse artifacts with the given configurations, AbstractMediatorFactory tries to create a new ScriptMediator. When creating the ScriptMediator it tries to initialize the ScriptEngine.
In this method it calls the getEngineByExtension method of bsf library but since the groovy library is missing it gives exception. But getEngineByExtension method haven't handled the exception.
To fix this a SynapseArtifactDeploymentException have been thrown in the finally block.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes