### PR TITLE
Fix synapse test failure

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ClassMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ClassMediatorSerializationTest.java
@@ -51,10 +51,10 @@ public class ClassMediatorSerializationTest extends AbstractTestCase {
         assertTrue(serialization(inputXml, classMediatorSerializer));
     }
 
-    public void testClassMediatorSerializationWithInlineProperty() throws Exception {
+    public void testClassMediatorSerializationWithExpressionProperty() throws Exception {
         String inputXml = "<class xmlns=\"http://ws.apache.org/ns/synapse\" " +
                 "name=\"org.apache.synapse.config.xml.TestMediator\">" +
-                "<property name=\"testElemProp\"><test/></property></class> ";
+                "<property name=\"testElemProp\" expression=\"ElemPropExpression\"></property></class> ";
         assertTrue(serialization(inputXml, classMediatorFactory, classMediatorSerializer));
         assertTrue(serialization(inputXml, classMediatorSerializer));
     }


### PR DESCRIPTION
## Purpose
Fix synapse test failure

## Goals
Even the inline property is serialized properly it cannot be set to a class mediator's instance variable
Hence fixing the test to validate the expression attribute

## Approach
Fix the invalid serialization validation

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
wso2/wso2-synapse#1016

## Migrations (if applicable)
N/A

## Test environment
java 1.8
 
## Learning
N/A