### PR TITLE
Fix wso2/product-ei/issues/1054

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/AbstractSynapseArtifactDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/AbstractSynapseArtifactDeployer.java
@@ -40,7 +40,10 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
 
 import javax.xml.stream.XMLStreamException;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Properties;
 
 /**
@@ -193,12 +196,15 @@ public abstract class AbstractSynapseArtifactDeployer extends AbstractDeployer {
                         } else {
                             artifactName = deploySynapseArtifact(element, filename, properties);
                         }
-                    } catch (SynapseArtifactDeploymentException sade) {
+
+                        //To avoid deployment of service when NoClassDefFoundError thrown while creating a mediator
+
+                    } catch (SynapseArtifactDeploymentException | NoClassDefFoundError e) {
                         log.error("Deployment of the Synapse Artifact from file : "
-                                + filename + " : Failed!", sade);
+                                + filename + " : Failed!", e);
                         log.info("The file has been backed up into : "
                                 + backupFile(deploymentFileData.getFile()));
-                        throw new DeploymentException(sade);
+                        throw new DeploymentException(e);
                     }
                 }
                 if (artifactName != null) {


### PR DESCRIPTION

## Purpose
> Fixes: https://github.com/wso2/product-ei/issues/1054

## Goals
> When deploying synapse artifacts with the given configurations, AbstractMediatorFactory tries to create a new ScriptMediator. When creating the ScriptMediator it tries to initialize the ScriptEngine.
In this method it calls the getEngineByExtension method of bsf library but since the groovy library is missing it throws NoClassDefFoundError. But deploy method of AbstractSynapseArtifactDeployer haven't handled this error. So service get deployed without ScriptMediator.
To fix this a NoClassDefFoundError have been caught in the deploy method of AbstractSynapseArtifactDeployer.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
