### PR TITLE
Fix hostname verification against target

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientSSLSetupHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientSSLSetupHandler.java
@@ -20,6 +20,8 @@ package org.apache.synapse.transport.http.conn;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 
 import javax.net.ssl.SSLEngine;
@@ -162,7 +164,16 @@ public class ClientSSLSetupHandler implements SSLSetupHandler {
     public void verify(IOSession iosession, SSLSession sslsession) throws SSLException {
         SocketAddress remoteAddress = iosession.getRemoteAddress();
         String address;
-        if (remoteAddress instanceof InetSocketAddress) {
+        String endpoint = (String) iosession.getAttribute(SynapseHTTPRequestFactory.ENDPOINT_URL);
+        if (endpoint != null && !endpoint.isEmpty()) {
+            try {
+                URI endpointURI = new URI(endpoint);
+                address = endpointURI.getHost();
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Invalid endpointURI: "+ endpoint, e);
+            }
+
+        } else if (remoteAddress instanceof InetSocketAddress) {
             address = ((InetSocketAddress) remoteAddress).getHostName();
         } else {
             address = remoteAddress.toString();


### PR DESCRIPTION
## Purpose
Fix hostname verification against target

## Goals
Fix hostname verification exception

## Approach
When verifying the host name, it is verified against the proxy host name instead of the actual target host name.
IOSession has the target endpoint. By retrieving the value, fixing to verify against the target host name.
public: https://wso2.org/jira/browse/ESBJAVA-5289

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/wso2-synapse/pull/393

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A