### PR TITLE
Upgrade axis2 and axis-transport versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1119,8 +1119,8 @@
       <mina.version>1.1.0</mina.version>
       <jms-1.1-spec.version>1.1</jms-1.1-spec.version>
       <!-- Axis2 and its dependencies -->
-      <axis2.version>1.6.1-wso2v22</axis2.version>
-      <axis2.transport.version>2.0.0-wso2v11</axis2.transport.version>
+      <axis2.version>1.6.1-wso2v23</axis2.version>
+      <axis2.transport.version>2.0.0-wso2v12</axis2.transport.version>
       <axiom.version>1.2.11-wso2v11</axiom.version>
       <xml_schema.version>1.4.3</xml_schema.version>
       <xml_apis.version>1.3.04</xml_apis.version>


### PR DESCRIPTION
Upgraded axis2 and axis2-transport versions to 1.6.1-wso2v23 and 2.0.0-wso2v12 respectively.