### PR TITLE
Fix wso2/product-ei/issues/1820

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationFactory.java
@@ -164,7 +164,7 @@ public class SynapseXMLConfigurationFactory implements ConfigurationFactory {
             if (proxy != null) {
                 config.addProxyService(proxy.getName(), proxy);
             }
-        } catch (Exception e) {
+        } catch (Exception | NoClassDefFoundError e) {
             String msg = "Proxy Service configuration: " + elem.getAttributeValue((
                     new QName(XMLConfigConstants.NULL_NAMESPACE, "name"))) + " cannot be built";
             handleConfigurationError(SynapseConstants.FAIL_SAFE_MODE_PROXY_SERVICES, msg, e);
@@ -481,7 +481,7 @@ public class SynapseXMLConfigurationFactory implements ConfigurationFactory {
         }
     }
 
-    private static void handleConfigurationError(String componentType, String msg, Exception e) {
+    private static void handleConfigurationError(String componentType, String msg, Throwable e) {
         if (SynapseConfigUtils.isFailSafeEnabled(componentType)) {
             log.warn(msg + " - Continue in fail-safe mode", e);
         } else {


### PR DESCRIPTION
## Purpose
> Fixes: https://github.com/wso2/product-ei/issues/1820

## Goals
> When a proxy with groove dependency is added to the EI-6.1.1 then the server is started but the mgt console is not accessible. This is happening since when calliing the getEngineByExtension method
of bsf library it throws NoClassDefFoundError and it haven't been handled. To fix this NoClassDefFoundError have been caught in the SynapseXMLConfigurationFactory.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
