### PR TITLE
Fix response swapping when a FORCE_SC_ACCEPTED is used

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -262,6 +262,7 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
                 CloseEventCollector.tryEndFlow(synCtx, this.name, ComponentType.PROXYSERVICE,
                         statisticReportingIndex, true);
             }
+            doPostInjectUpdates(synCtx);
             if(synCtx.getEnvironment().isDebuggerEnabled()) {
                 SynapseDebugManager debugManager = synCtx.getEnvironment().getSynapseDebugManager();
                 debugManager.advertiseMediationFlowTerminatePoint(synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
@@ -27,6 +27,7 @@ import org.apache.synapse.FaultHandler;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
 
 /**
  * This message receiver should be configured in the Axis2 configuration as the
@@ -85,7 +86,7 @@ public class SynapseMessageReceiver implements MessageReceiver {
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_SOAP11, mc.isSOAP11());
 
         try {
-            // invoke synapse message mediation through the main sequence
+            // invoke synapse message mediation through the APIs/main sequence
             synCtx.getEnvironment().injectMessage(synCtx);
 
         } catch (SynapseException syne) {
@@ -98,6 +99,8 @@ public class SynapseMessageReceiver implements MessageReceiver {
                 warn(traceOn, "Exception encountered but no fault handler found - " +
                     "message dropped", synCtx);
             }
+        } finally {
+            doPostInjectUpdates(synCtx);
         }
     }
 
@@ -119,6 +122,25 @@ public class SynapseMessageReceiver implements MessageReceiver {
         }
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);
+        }
+    }
+
+    /**
+     * Do the cleanup work, metadata updates in the return path of Message Receiver tread
+     * after injecting the message to the engine
+     *
+     * @param messageContext Synapse Message Context
+     */
+    protected void doPostInjectUpdates(MessageContext messageContext) {
+
+        org.apache.axis2.context.MessageContext axis2Ctx =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        // If FORCE_SC_ACCEPTED is set, mark response is sent and prevent multiple response being sent
+        if (axis2Ctx.isPropertyTrue(NhttpConstants.FORCE_SC_ACCEPTED)) {
+            if (Axis2Sender.preventMultipleResponses(messageContext)) {
+                throw new SynapseException(
+                        "Trying to send a 202 Accepted response to an already responded client request");
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR fixes response swapping issue(Because of sending multiple responses to same request) which can be occurred when FORCE_SC_ACCEPTED is used and a respond mediator is used. 
Issue - https://github.com/wso2/product-ei/issues/1829

## Goals
Prevent sending multiple responses to the same request received.