### PR TITLE
Fix response swap when FORCE_SC_ACCEPTED present

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -98,26 +98,8 @@ public class Axis2Sender {
      * @param smc the Synapse message context sent as the response
      */
     public static void sendBack(org.apache.synapse.MessageContext smc) {
-        Object responseStateObj = smc.getProperty(SynapseConstants.RESPONSE_STATE);
-
-        // Prevent two responses for a single request message
-        if (responseStateObj != null) {
-            if (responseStateObj instanceof ResponseState) {
-                ResponseState responseState = (ResponseState) responseStateObj;
-                synchronized (responseState) {
-                    if (responseState.isRespondDone()) {
-                        log.warn("Trying to send a response to an already responded client request - " +
-                                getInputInfo(smc));
-                        return;
-                    } else {
-                        responseState.setRespondDone();
-                    }
-                }
-            } else {
-                // This can happen only if the user has used the SynapseConstants.RESPONSE_STATE as a user property
-                handleException("Response State must be of type : " + ResponseState.class +
-                        ". " + SynapseConstants.RESPONSE_STATE + " must not be used as an user property name", null);
-            }
+        if (preventMultipleResponses(smc)) {
+            return;
         }
 
         MessageContext messageContext = ((Axis2MessageContext) smc).getAxis2MessageContext();
@@ -265,6 +247,40 @@ public class Axis2Sender {
         return false;
     }
 
+    /**
+     * This will ensure only one response is sent for a single request.
+     * In HTTP request-response paradigm only a one response is allowed for a single request.
+     * Due to synapse configuration issues, there is a chance of multiple response getting sent for a single request
+     * Calling this method from all the places where we sent out a response message from engine
+     * will prevent that from happening
+     *
+     * @param messageContext Synapse message context
+     * @return whether a response is already sent
+     */
+    public static boolean preventMultipleResponses(org.apache.synapse.MessageContext messageContext) {
+        Object responseStateObj = messageContext.getProperty(SynapseConstants.RESPONSE_STATE);
+        // Prevent two responses for a single request message
+        if (responseStateObj != null) {
+            if (responseStateObj instanceof ResponseState) {
+                ResponseState responseState = (ResponseState) responseStateObj;
+                synchronized (responseState) {
+                    if (responseState.isRespondDone()) {
+                        log.warn("Trying to send a response to an already responded client request - " + getInputInfo(
+                                messageContext));
+                        return true;
+                    } else {
+                        responseState.setRespondDone();
+                    }
+                }
+            } else {
+                // This can happen only if the user has used the SynapseConstants.RESPONSE_STATE as a user property
+                handleException("Response State must be of type : " + ResponseState.class + ". "
+                        + SynapseConstants.RESPONSE_STATE + " must not be used as an user property name", null);
+            }
+        }
+        return false;
+    }
+
     private static void handleException(String msg, Exception e) {
         log.error(msg, e);
         throw new SynapseException(msg, e);
@@ -304,6 +320,8 @@ public class Axis2Sender {
             inputInfo = "Proxy Name : " + smc.getProperty("proxy.name");
         } else if (smc.getProperty("REST_API_CONTEXT") != null) {
             inputInfo = "Rest API Context : " + smc.getProperty("REST_API_CONTEXT");
+        } else if (smc.getProperty(SynapseConstants.INBOUND_ENDPOINT_NAME) != null) {
+            inputInfo = "Inbound endpoint : " + smc.getProperty(SynapseConstants.INBOUND_ENDPOINT_NAME);
         }
         return inputInfo;
     }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -237,7 +237,6 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
 
 
             synCtx.setEnvironment(this);
-            setResponseState(synCtx);
 
             if (!invokeHandlers(synCtx)) {
                 return false;
@@ -1124,17 +1123,5 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
      */
     public void setDebugEnabled(boolean isDebugEnabled) {
         this.isDebugEnabled = isDebugEnabled;
-    }
-
-    /**
-     * Set the response state of the context
-     *
-     * @param synCtx synapse message context
-     * */
-    private void setResponseState(MessageContext synCtx) {
-        Boolean isContinuationCall = (Boolean) synCtx.getProperty(SynapseConstants.CONTINUATION_CALL);
-        if (!(synCtx.isResponse() || (isContinuationCall != null && isContinuationCall))) {
-            synCtx.setProperty(SynapseConstants.RESPONSE_STATE, new ResponseState());
-        }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -267,7 +267,7 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
                 debugManager.advertiseMediationFlowTerminatePoint(synCtx);
                 debugManager.releaseMediationFlowLock();
             }
-
+            doPostInjectUpdates(synCtx);
         }
     }
 


### PR DESCRIPTION
When configuration has FORCE_SC_ACCEPTED and respond in a different path(like fault sequence)
two requests are comming on a same conntion receives swapped/incorrect response
wso2/product-ei#1829

## Purpose
Fix response swapping when 202 accepted is added

## Goals
Make sure correct response is sent to all requests

## Approach
Fixed by validating the response state

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/carbon-mediation/pull/979

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
N/A