### PR TITLE
set correct request object to process chunking

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -193,7 +193,8 @@ public class TargetRequest {
         
   
                                                             
-        if (hasEntityBody) {
+        if (hasEntityBody || !((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0)) ||
+                (("GET").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))) || (("DELETE").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))))) {
             request = new BasicHttpEntityEnclosingRequest(method, path,
                     version != null ? version : HttpVersion.HTTP_1_1);
 


### PR DESCRIPTION
## Purpose
> Below exception occure, when http call with method `POST` with `content-type : application/octet-stream` and `content-length: 0`
> Because TargetRequest.start() function assign BasicHttpRequest when hasEntityBody is false.
> But, a POST request may not have an entity body.

```
java.lang.ClassCastException: org.apache.http.message.BasicHttpRequest cannot be cast to org.apache.http.message.BasicHttpEntityEnclosingRequest
        at org.apache.synapse.transport.passthru.TargetRequest.processChunking(TargetRequest.java:327)
        at org.apache.synapse.transport.passthru.TargetRequest.start(TargetRequest.java:267)
        at org.apache.synapse.transport.passthru.TargetHandler.requestReady(TargetHandler.java:169)
```

## Goals
> So, TargetRequest.start() function should assign BasicHttpEntityEnclosingRequest if conditions is that call the TargetRequest.processChunking() function

## Approach
> I added additional condition that is same as the condition which call the TargetRequest.processChunking() function

original condition
```
if (hasEntityBody) {
  ... BasicHttpEntityEnclosingRequest 
} else {
  ... BasicHttpRequest 
}
```

conditions to call the TargetRequest.processChunking() function
```
if (!((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0)) ||
      (("GET").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))) || 
      (("DELETE").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))))) {
            this.processChunking(conn, requestMsgCtx);
}
```

modified conditions
```
if (hasEntityBody || !((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0)) ||
                (("GET").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))) || (("DELETE").equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD))))) {
  ... BasicHttpEntityEnclosingRequest 
} else {
  ... BasicHttpRequest 
}
```
