### PR TITLE
Fix wso2/product-ei/issues/1875

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -461,8 +461,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
                     // XML escape the result of an expression that produces a literal, if the target format
                     // of the payload is XML.
                     details.setXml(isXML(value));
-                    if (!details.isXml() && !arg.getExpression().getPathType().equals(SynapsePath.JSON_PATH)
-                            && XML_TYPE.equals(getType())) {
+                    if (!details.isXml() && XML_TYPE.equals(getType())) {
                         value = StringEscapeUtils.escapeXml(value);
                     }
                     value = Matcher.quoteReplacement(value);


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/1875

## Goals
> Enable character escaping for values taken from json path expressions in PayloadFactory mediator.
Ex :- {"message" : "test < report"}
Here thought < is a valid character for json its a reserved character for xml.
So needs to escaped properly like <message>test &lt; report</message>

## Approach
> Remove the check for JSON_PATH which was evaluated before escaping XML. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes