### PR TITLE
Fix issues in concurrent access throttling

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
@@ -95,8 +95,4 @@ public class ConcurrentAccessController implements Serializable {
 		}
 
 	}
-
-	public int get() {
-		return counter.get();
-	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
@@ -30,25 +30,25 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class ConcurrentAccessController implements Serializable {
 
-	private static Log log = LogFactory.getLog(ConcurrentAccessController.class.getName());
+    private static Log log = LogFactory.getLog(ConcurrentAccessController.class.getName());
 
-	/* The Max number of concurrent access */
-	private int limit;
-	/* The counter variable - hold current access count */
-	private AtomicInteger counter;
+    /* The Max number of concurrent access */
+    private int limit;
+    /* The counter variable - hold current access count */
+    private AtomicInteger counter;
 
-	private static final long serialVersionUID = -6857325377726757251L;
+    private static final long serialVersionUID = -6857325377726757251L;
 
-	public ConcurrentAccessController(int limit) {
-		this.limit = limit;
-		this.counter = new AtomicInteger(limit);
-	}
+    public ConcurrentAccessController(int limit) {
+        this.limit = limit;
+        this.counter = new AtomicInteger(limit);
+    }
 
-	/**
-	 * Decrements by one the current value and Returns the previous value
-	 *
-	 * @return the previous value
-	 */
+    /**
+     * Decrements by one the current value and Returns the previous value
+     *
+     * @return the previous value
+     */
     public int getAndDecrement() {
         if (counter.get() <= 0) {
             return 0;
@@ -56,11 +56,11 @@ public class ConcurrentAccessController implements Serializable {
         return counter.getAndDecrement();
     }
 
-	/**
-	 * Increments by one the current value and Returns the the updated value
-	 *
-	 * @return the updated value
-	 */
+    /**
+     * Increments by one the current value and Returns the the updated value
+     *
+     * @return the updated value
+     */
     public int incrementAndGet() {
         if (counter.get() >= limit) {
             return limit;
@@ -68,31 +68,31 @@ public class ConcurrentAccessController implements Serializable {
         return this.counter.incrementAndGet();
     }
 
-	/**
-	 * Gets  the Max number of access - access limit
-	 *
-	 * @return the limit
-	 */
-	public int getLimit() {
-		return this.limit;
-	}
+    /**
+     * Gets  the Max number of access - access limit
+     *
+     * @return the limit
+     */
+    public int getLimit() {
+        return this.limit;
+    }
 
-	/**
-	 * Resets the counter and the limit
-	 *
-	 * @param newValue The new Value
-	 */
-	public void set(int newValue) {
-		this.counter.set(newValue);
-		this.limit = newValue;
-	}
+    /**
+     * Resets the counter and the limit
+     *
+     * @param newValue The new Value
+     */
+    public void set(int newValue) {
+        this.counter.set(newValue);
+        this.limit = newValue;
+    }
 
-	public void updateCounter(boolean isIncrement) {
-		if (isIncrement) {
-			incrementAndGet();
-		} else {
-			getAndDecrement();
-		}
+    public void updateCounter(boolean isIncrement) {
+        if (isIncrement) {
+            incrementAndGet();
+        } else {
+            getAndDecrement();
+        }
 
-	}
+    }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessController.java
@@ -49,28 +49,24 @@ public class ConcurrentAccessController implements Serializable {
 	 *
 	 * @return the previous value
 	 */
-	public int getAndDecrement() {
-		int ret = this.counter.getAndDecrement();
-		if (ret <= 0) {
-			this.counter.incrementAndGet();
-			return 0;
-		} else {
-			return ret;
-		}
-	}
+    public int getAndDecrement() {
+        if (counter.get() <= 0) {
+            return 0;
+        }
+        return counter.getAndDecrement();
+    }
 
 	/**
 	 * Increments by one the current value and Returns the the updated value
 	 *
 	 * @return the updated value
 	 */
-	public int incrementAndGet() {
-		int ret = this.counter.incrementAndGet();
-		if (ret < 0) {
-			return 0;
-		}
-		return ret;
-	}
+    public int incrementAndGet() {
+        if (counter.get() >= limit) {
+            return limit;
+        }
+        return this.counter.incrementAndGet();
+    }
 
 	/**
 	 * Gets  the Max number of access - access limit
@@ -91,4 +87,16 @@ public class ConcurrentAccessController implements Serializable {
 		this.limit = newValue;
 	}
 
+	public void updateCounter(boolean isIncrement) {
+		if (isIncrement) {
+			incrementAndGet();
+		} else {
+			getAndDecrement();
+		}
+
+	}
+
+	public int get() {
+		return counter.get();
+	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ConcurrentAccessReplicator.java
@@ -33,7 +33,7 @@ public class ConcurrentAccessReplicator {
         this.configContext = configContext;
     }
 
-    public void replicate(String key, ConcurrentAccessController concurrentAccessController) {
+    public void replicate(String key, Boolean action) {
         try {
             ClusteringAgent clusteringAgent =
                     configContext.getAxisConfiguration().getClusteringAgent();
@@ -42,9 +42,7 @@ public class ConcurrentAccessReplicator {
                     log.debug("Replicating ConcurrentAccessController " + key +
                             " in a ClusterMessage.");
                 }
-                clusteringAgent.sendMessage(
-                        new ConcurrentAccessUpdateClusterMessage(key, concurrentAccessController),
-                        true);
+                clusteringAgent.sendMessage(new ConcurrentAccessUpdateClusterMessage(key, action), true);
             }
         } catch (ClusteringFault e) {
             if (log.isErrorEnabled()) {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -587,7 +587,7 @@ public class Axis2FlexibleMEPClient {
                 String throttleKey = (String) synapseOutMessageContext
                         .getProperty(SynapseConstants.SYNAPSE_CONCURRENCY_THROTTLE_KEY);
                 if (concurrentAccessReplicator != null) {
-                    concurrentAccessReplicator.replicate(throttleKey, concurrentAccessController);
+                    concurrentAccessReplicator.replicate(throttleKey, true);
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -433,7 +433,7 @@ public class Axis2Sender {
             String throttleKey = (String) smc.getProperty(SynapseConstants.SYNAPSE_CONCURRENCY_THROTTLE_KEY);
 
             if (concurrentAccessReplicator != null) {
-                concurrentAccessReplicator.replicate(throttleKey, concurrentAccessController);
+                concurrentAccessReplicator.replicate(throttleKey, true);
             }
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -73,9 +73,6 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
 
     private static final Log log = LogFactory.getLog(SynapseCallbackReceiver.class);
 
-    /** This is the synchronized callbackStore that maps outgoing messageID's to callback objects */
-//    private final Map<String, AxisCallback> callbackStore;  // will made thread safe in the constructor
-
     /**
      * Create the *single* instance of this class that would be used by all anonymous services
      * used for outgoing messaging.
@@ -84,8 +81,6 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
      */
     public SynapseCallbackReceiver(SynapseConfiguration synCfg,
                                    ServerContextInformation contextInformation) {
-
-//        callbackStore = Collections.synchronizedMap(new HashMap<String, AxisCallback>());
 
         // create the Timer object and a TimeoutHandler task
         TimeoutHandler timeoutHandler = new TimeoutHandler(callbackStore, contextInformation);

--- a/modules/core/src/main/java/org/apache/synapse/util/ConcurrencyThrottlingUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/ConcurrencyThrottlingUtils.java
@@ -57,7 +57,7 @@ public class ConcurrencyThrottlingUtils {
                     .getProperty(SynapseConstants.SYNAPSE_CONCURRENT_ACCESS_REPLICATOR);
             String throttleKey = (String) synCtx.getProperty(SynapseConstants.SYNAPSE_CONCURRENCY_THROTTLE_KEY);
             if (concurrentAccessReplicator != null) {
-                concurrentAccessReplicator.replicate(throttleKey, concurrentAccessController);
+                concurrentAccessReplicator.replicate(throttleKey, true);
             }
             //once decremented, clear the flag since we no longer required to decrement the value
             //concurrency throttle access controller


### PR DESCRIPTION
## Purpose
> When Throttling is configured with cache mediator in a cluster fronted by an LB. After some time, the no of available connections depletes to zero.

## Goals
> Resolves wso2/product-ei#1862

## Approach
> In this fix it passes a Boolean value (true - increment the counter, false - decrement the counter) in the cluster message and once the cluster message is received in the other node updating the counter accordingly. And removed the local reference of the counter in the throttle mediator. So the update will reflect on the same counter. Also as above, it sends the cluster message only the request is accepted by the throttle policy. 