### PR TITLE
Forced xml parser to build the xml message

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
@@ -144,7 +144,7 @@ public abstract class AbstractListMediator extends AbstractMediator
             }
             RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(), false);
         } catch (Exception e) {
-            handleException("Error while building message", e, synCtx);
+            handleException("Error while building message. " + e.getMessage(), e, synCtx);
         }
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -222,4 +222,7 @@ public class PassThroughConstants {
      * System property to configure verification timeout (iterative verification) in seconds for port.
      */
     public static final String SYSTEMPROP_PORT_CLOSE_VERIFY_TIMEOUT = "synapse.transport.portCloseVerifyTimeout";
+
+    //Validate the bad formed xml message by building the whole xml document.
+    public static final String FORCE_XML_MESSAGE_VALIDATION = "force.xml.message.validation";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -66,6 +66,8 @@ public class PassThroughConstants {
     public static final String ERROR_DETAIL = "ERROR_DETAIL";
     /** The message context property name which holds the exception (if any) for the last encountered exception */
     public static final String ERROR_EXCEPTION = "ERROR_EXCEPTION";
+    /** An Axis2 message context property that hols the raw payload when an error occurs while building message */
+    public static final String RAW_PAYLOAD = "RAW_PAYLOAD";
 
     // ********** DO NOT CHANGE THESE UNLESS CORRESPONDING SYNAPSE CONSTANT ARE CHANGED ************
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -124,6 +124,10 @@ public class PassThroughConfiguration {
         return getBooleanProperty(PassThroughConfigPNames.SERVER_HEADER_PRESERVE, false);
     }
 
+    public boolean isForcedXmlMessageValidationEnabled() {
+        return getBooleanProperty(PassThroughConstants.FORCE_XML_MESSAGE_VALIDATION, false);
+    }
+
     public String getPreserveHttpHeaders() {
         return getStringProperty(PassThroughConfigPNames.HTTP_HEADERS_PRESERVE, "");
     }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -57,6 +57,8 @@ public class RelayUtils {
 
     private static Boolean forcePTBuild = null;
 
+    private static boolean forceXmlValidation = false;
+
     static {
         if (forcePTBuild == null) {
             forcePTBuild = PassThroughConfiguration.getInstance().getBooleanProperty(
@@ -67,6 +69,7 @@ public class RelayUtils {
             // this to keep track ignore the builder operation eventhough
             // content level is enable.
         }
+        forceXmlValidation = PassThroughConfiguration.getInstance().isForcedXmlMessageValidationEnabled();
     }
 
     public static void buildMessage(org.apache.axis2.context.MessageContext msgCtx)
@@ -155,6 +158,11 @@ public class RelayUtils {
 
                 if (!earlyBuild) {
                     processAddressing(messageContext);
+                }
+                //force validation makes sure that the xml is well formed(not having multi root element).
+                if (forceXmlValidation) {
+                    messageContext.getEnvelope().buildWithAttachments();
+                    messageContext.getEnvelope().getBody().getFirstElement().buildNext();
                 }
             }
         } catch (Exception e) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -130,13 +130,8 @@ public class RelayUtils {
             //read input stream to store raw data and create inputStream again.
             //then the raw data can be logged after an error while building the message.
             byteArrayOutputStream = new ByteArrayOutputStream();
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = in.read(buffer)) > -1 ) {
-                byteArrayOutputStream.write(buffer, 0, len);
-            }
+            IOUtils.copy(in, byteArrayOutputStream);
             byteArrayOutputStream.flush();
-
             // Open new InputStreams using the recorded bytes and assign to in
             in =  new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
         }


### PR DESCRIPTION
When a xml is not well formed(multi root document), EI does not throw error. In this fix we can force EI to build the message and validate the xml.

using below property in passthru-http.properties, we can make ESB to force build message and validate. By default this value is false.

force.xml.message.validation=true