### PR TITLE
Set default content type header

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -86,6 +86,8 @@ public class ServerWorker implements Runnable {
     private SourceConfiguration sourceConfiguration = null;
 
     private static final String SOAP_ACTION_HEADER = "SOAPAction";
+
+    private static final String HTTP_METHOD = "HTTP_METHOD";
         
     /** WSDL processor for Get requests */
     private HttpGetRequestProcessor httpGetRequestProcessor = null;
@@ -188,6 +190,14 @@ public class ServerWorker implements Runnable {
         // recipient should consider it as application/octet-stream (rfc2616)
         if (contentType == null || contentType.isEmpty()) {
             contentType = PassThroughConstants.APPLICATION_OCTET_STREAM;
+        }
+        // Temp fix for https://github.com/wso2/product-ei/issues/2001
+        // This need to be fixed properly , with out this fix , the query parameters of the dataServices get request
+        // got null if it is not given content type header
+        if (HTTPConstants.HTTP_METHOD_GET.equals(msgContext.getProperty(HTTP_METHOD)) || (
+                HTTPConstants.HEADER_DELETE.equals(msgContext.getProperty(HTTP_METHOD)) && ("0")
+                        .equals(msgContext.getProperty(PassThroughConstants.HTTP_CONTENT_LENGTH).toString()))) {
+            contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
         }
         if (HTTPConstants.MEDIA_TYPE_X_WWW_FORM.equals(contentType) ||
                 (PassThroughConstants.APPLICATION_OCTET_STREAM.equals(contentType) && contentTypeHdr == null)) {


### PR DESCRIPTION
REST requests with get method was set content type application/x-www-form-urlencoded earlier, this behaviour was changed with https://github.com/wso2/wso2-synapse/pull/1015
setting the content type header as it is causing some issues with query params
