### PR TITLE
Fix continuation call to avoid getting false incorrectly

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -875,11 +875,15 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     public synchronized void updateCallMediatorCount(boolean isIncrement) {
         if (isIncrement) {
             callMediatorCount++;
+            if (!continuation) {
+                log.info("Continuation call is set to true");
+            }
             continuation = true;
         } else {
             callMediatorCount--;
             if (callMediatorCount == 0) {
                 continuation = false;
+                log.info("Continuation call is set to false");
             }
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -307,7 +307,9 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
         if (endpoint != null) {
             endpoint.destroy();
         }
-        synapseEnv.updateCallMediatorCount(false);
+        if (!blocking) {
+            synapseEnv.updateCallMediatorCount(false);
+        }
     }
 
     @Override


### PR DESCRIPTION
This fix will avoid continuation call getting set to false even when the non blocking call mediators are present in the configuration while redeploying and undeploying car file having blocking call mediators.