### PR TITLE
Avoid the error when sequence template is undeployed

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/TemplateDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/TemplateDeployer.java
@@ -35,6 +35,7 @@ import org.apache.synapse.mediators.template.TemplateMediator;
 
 import javax.xml.namespace.QName;
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 public class TemplateDeployer extends AbstractSynapseArtifactDeployer {
@@ -214,22 +215,18 @@ public class TemplateDeployer extends AbstractSynapseArtifactDeployer {
 
         try {
             Template st = null;
-            try {
+            Map<String, Template> templates = getSynapseConfiguration().getEndpointTemplates();
+            if (templates.containsKey(artifactName)) {
                 st = getSynapseConfiguration().getEndpointTemplate(artifactName);
-            } catch (SynapseException e) {
-                //could not locate an endpoint template for this particular un-delpoyment. This name refers
-                //probably to a sequence tempalte. Thus if  throws a Synapse exception with following message
-                //catch n log that and continue this process for undeployment of a sequence template
-                if (e.getMessage().indexOf("Cannot locate an either local or remote entry for key") != -1) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Undeploying template is not of endpoint type. Undeployer will now check " +
-                                  "for sequence template for the key: " + artifactName);
-                    }
-                } else {
-                    //different error hence stop undeployment/report failure
-                    throw e;
+            } else {
+                //the undeployed template is not an endpoint template
+                //therefore, it must be a sequence template
+                if (log.isDebugEnabled()) {
+                    log.debug("Undeploying template is not of endpoint type. Undeployer will now check "
+                            + "for sequence template for the key: " + artifactName);
                 }
             }
+
             if (st != null) {
                 getSynapseConfiguration().removeEndpointTemplate(artifactName);
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
> When sequence template is undeployed, an error "Cannot locate an either local or remote entry for key : " is printed because before undeploying the template, it's checked whether the template is of type endpoint. The error occurs at this point. 

## Approach
> To avoid this error, we first retrieve all the endpoint templates and check whether the key of the template to be deleted is among them. If yes, then we can proceed. Else, we should go for deleting the sequence template.