### PR TITLE
Stop non-blocking call when continuation stack is empty

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -31,7 +31,7 @@ import org.apache.axis2.description.TransportOutDescription;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-
+import org.apache.synapse.ContinuationState;
 import org.apache.synapse.FaultHandler;
 import org.apache.synapse.SynapseHandler;
 import org.apache.synapse.Mediator;
@@ -751,6 +751,15 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
             // ideally this should never happens
             log.warn("ContinuationStateStack empty. No ContinuationState to mediate the response ");
             return false;
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Start : Contents of Continuation Stack");
+                for (ContinuationState state : synCtx.getContinuationStateStack()) {
+                    SeqContinuationState seqstate = (SeqContinuationState) state;
+                    log.debug("Sequence Type : " + seqstate.getSeqType() + " Sequence Name : " + seqstate.getSeqName());
+                }
+                log.debug("End : Contents of Continuation Stack");
+            }
         }
 
         if (RuntimeStatisticCollector.isStatisticsEnabled()) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -20,6 +20,7 @@
 package org.apache.synapse.mediators.builtin;
 
 import org.apache.axis2.AxisFault;
+import org.apache.synapse.ContinuationState;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SequenceType;
@@ -30,6 +31,7 @@ import org.apache.synapse.aspects.ComponentType;
 import org.apache.synapse.aspects.flow.statistics.StatisticIdentityGenerator;
 import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
 import org.apache.synapse.continuation.ContinuationStackManager;
+import org.apache.synapse.continuation.SeqContinuationState;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.endpoints.DefaultEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
@@ -195,6 +197,21 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
      */
     private boolean handleNonBlockingCall(MessageContext synInCtx) {
         SynapseLog synLog = getLog(synInCtx);
+
+        if (synInCtx.getContinuationStateStack().isEmpty()) {
+            //ideally this place should not be reached
+            throw new SynapseException("Continuation Stack Empty! Cannot proceed with the call");
+        } else {
+            if (synLog.isTraceOrDebugEnabled()) {
+                synLog.traceOrDebug("Start : Contents of Continuation Stack");
+                for (ContinuationState state : synInCtx.getContinuationStateStack()) {
+                    SeqContinuationState seqstate = (SeqContinuationState) state;
+                    synLog.traceOrDebug(
+                            "Sequence Type : " + seqstate.getSeqType() + " Sequence Name : " + seqstate.getSeqName());
+                }
+                synLog.traceOrDebug("End : Contents of Continuation Stack");
+            }
+        }
 
         if (synLog.isTraceOrDebugEnabled()) {
             synLog.traceOrDebug("Start : Call mediator - Non Blocking Call");


### PR DESCRIPTION
## Purpose
>Stop the call mediator's non-blocking call when the continuation stack is empty. Also, print the contents of the stack in the debug mode.

