### PR TITLE
Fixing an issue that could cause by non empty blank values in payload…

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -399,7 +399,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @return
      */
     private boolean isJson(String value) {
-        return !(value == null || value.isEmpty()) && (value.trim().charAt(0) == '{' || value.trim().charAt(0) == '[');
+        return !(value == null || value.trim().isEmpty()) && (value.trim().charAt(0) == '{' || value.trim().charAt(0) == '[');
     }
 
     /**


### PR DESCRIPTION
Create an API like below 

```
<api xmlns="http://ws.apache.org/ns/synapse" name="dummyCall" context="/dummy">
   <resource methods="POST">
      <inSequence>
         <property name="TEST" value="    "/>
         <payloadFactory media-type="xml">
            <format>
               <jsonObject xmlns="">
                  <ok>$1</ok>
                  <test>$2</test>
                  <cool>$3</cool>
               </jsonObject>
            </format>
            <args>
               <arg evaluator="json" expression="$.ok"/>
               <arg evaluator="xml" expression="$ctx:TEST"/>
               <arg evaluator="json" expression="$.cool"/>
            </args>
         </payloadFactory>
         <respond/>
      </inSequence>
   </resource>
</api>
```
Call the API with the following payload (note the no empty "coo" value
{
	"ok" : "A  B",
	"cool" : "              "
}

Issue happens due to non empty blank values like "cool" here. 

PR addresses the issue.