### PR TITLE
Add group endpoint support for call mediator blocking invocation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -370,6 +370,8 @@ public final class SynapseConstants {
             "BLOCKING_SENDER_PRESERVE_REQ_HEADERS";
     public static final String DISABLE_CHUNKING = "DISABLE_CHUNKING";
     public static final String NO_DEFAULT_CONTENT_TYPE = "NoDefaultContentType";
+    // Synapse property to store Blocking Message Sender to do blocking invocation
+    public static final String BLOCKING_MSG_SENDER = "blockingMsgSender";
 
     /** Synapse server instance name */
     public static final String SERVER_NAME = "serverName";

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -47,6 +47,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.commons.throttle.core.ConcurrentAccessController;
 import org.apache.synapse.commons.throttle.core.ConcurrentAccessReplicator;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.apache.synapse.message.senders.blocking.BlockingMsgSender;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
@@ -80,6 +81,13 @@ public class Axis2FlexibleMEPClient {
 
             EndpointDefinition endpoint,
             org.apache.synapse.MessageContext synapseOutMessageContext) throws AxisFault {
+
+        if (synapseOutMessageContext.getProperty(SynapseConstants.BLOCKING_MSG_SENDER) != null) {
+            BlockingMsgSender blockingMsgSender = (BlockingMsgSender) synapseOutMessageContext
+                    .getProperty(SynapseConstants.BLOCKING_MSG_SENDER);
+            blockingMsgSender.send(endpoint, synapseOutMessageContext);
+            return;
+        }
 
         boolean separateListener = false;
         boolean wsSecurityEnabled = false;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -165,17 +165,18 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
             if (synInCtx.getProperty(SynapseConstants.OUT_ONLY) == null || "false"
                     .equals(synInCtx.getProperty(SynapseConstants.OUT_ONLY))) {
                 if (synInCtx.getEnvelope() != null) {
-            if (synLog.isTraceTraceEnabled()) {
-                synLog.traceTrace("Response payload received : " + synInCtx.getEnvelope());
+                    if (synLog.isTraceTraceEnabled()) {
+                        synLog.traceTrace("Response payload received : " + synInCtx.getEnvelope());
+                    }
+                    if (synLog.isTraceOrDebugEnabled()) {
+                        synLog.traceOrDebug("End : Call mediator - Blocking Call");
+                    }
+                } else {
+                    if (synLog.isTraceOrDebugEnabled()) {
+                        synLog.traceOrDebug("Service returned a null response");
+                    }
+                }
             }
-            if (synLog.isTraceOrDebugEnabled()) {
-                synLog.traceOrDebug("End : Call mediator - Blocking Call");
-            }
-        } else {
-            if (synLog.isTraceOrDebugEnabled()) {
-                synLog.traceOrDebug("Service returned a null response");
-            }
-        }}
         } else {
             log.error("Error while performing the call operation in blocking mode");
             return false;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
@@ -218,28 +218,20 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                 }
             }
 
-            MessageContext resultMsgCtx = null;
-            try {
-                if ("true".equals(synCtx.getProperty(SynapseConstants.OUT_ONLY))) {
-                    blockingMsgSender.send(endpoint, synapseOutMsgCtx);
-                } else {
-                    resultMsgCtx = blockingMsgSender.send(endpoint, synapseOutMsgCtx);
-                    setResponseHttpSc(resultMsgCtx, synCtx);
-                    if ("true".equals(resultMsgCtx.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
-                        handleFault(synCtx, (Exception) resultMsgCtx.getProperty(SynapseConstants.ERROR_EXCEPTION));
+            synapseOutMsgCtx.setProperty(SynapseConstants.BLOCKING_MSG_SENDER, blockingMsgSender);
+            endpoint.send(synapseOutMsgCtx);
+
+
+            if ("false".equals(synapseOutMsgCtx.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
+                if (synapseOutMsgCtx.getProperty(SynapseConstants.OUT_ONLY) == null || "false"
+                        .equals(synapseOutMsgCtx.getProperty(SynapseConstants.OUT_ONLY))) {
+                    setResponseHttpSc(synapseOutMsgCtx, synCtx);
+                    if (synLog.isTraceTraceEnabled()) {
+                        synLog.traceTrace("Response payload received : " + synapseOutMsgCtx.getEnvelope());
                     }
-                }
-            } catch (Exception ex) {
-                handleFault(synCtx, ex);
-            }
-
-            if (synLog.isTraceTraceEnabled()) {
-                synLog.traceTrace("Response payload received : " + resultMsgCtx.getEnvelope());
-            }
-
-            if (resultMsgCtx != null && resultMsgCtx.getEnvelope() != null) {
+                    if (synapseOutMsgCtx.getEnvelope() != null) {
                 org.apache.axis2.context.MessageContext resultAxisMsgCtx =
-                        ((Axis2MessageContext) resultMsgCtx).getAxis2MessageContext();
+                        ((Axis2MessageContext) synapseOutMsgCtx).getAxis2MessageContext();
                 org.apache.axis2.context.MessageContext inAxisMsgCtx =
                                         ((Axis2MessageContext) synCtx).getAxis2MessageContext();
                 if (JsonUtil.hasAJsonPayload(resultAxisMsgCtx)) {
@@ -247,7 +239,7 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                 } else {
                     if (targetXPath != null) {
                         Object o = targetXPath.evaluate(synCtx);
-                        OMElement result = resultMsgCtx.getEnvelope().getBody().getFirstElement();
+                        OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
                         if (o != null && o instanceof OMElement) {
                             OMNode tgtNode = (OMElement) o;
                             tgtNode.insertSiblingAfter(result);
@@ -262,10 +254,10 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                                     targetXPath.toString() + " did not yeild an OMNode", synCtx);
                         }
                     } else if (targetKey != null) {
-                        OMElement result = resultMsgCtx.getEnvelope().getBody().getFirstElement();
+                        OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
                         synCtx.setProperty(targetKey, result);
                     } else {
-                    	synCtx.setEnvelope(resultMsgCtx.getEnvelope());
+                    	synCtx.setEnvelope(synapseOutMsgCtx.getEnvelope());
                     }
                 }
                 // Set HTTP Status code
@@ -280,6 +272,11 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                 }
             } else {
                 synLog.traceOrDebug("Service returned a null response");
+            }
+                }
+            } else {
+                log.info("Error while performing the callout operation");
+                return false;
             }
 
         } catch (AxisFault e) {
@@ -442,6 +439,10 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                         endpointDefinition.setOutboundWsSecPolicyKey(outboundWsSecPolicyKey);
                     }
                 }
+            }
+
+            if (endpoint != null) {
+                endpoint.init(synEnv);
             }
         } catch (AxisFault e) {
             String msg = "Error initializing callout mediator : " + e.getMessage();

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CalloutMediator.java
@@ -221,7 +221,6 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
             synapseOutMsgCtx.setProperty(SynapseConstants.BLOCKING_MSG_SENDER, blockingMsgSender);
             endpoint.send(synapseOutMsgCtx);
 
-
             if ("false".equals(synapseOutMsgCtx.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
                 if (synapseOutMsgCtx.getProperty(SynapseConstants.OUT_ONLY) == null || "false"
                         .equals(synapseOutMsgCtx.getProperty(SynapseConstants.OUT_ONLY))) {
@@ -230,49 +229,47 @@ public class CalloutMediator extends AbstractMediator implements ManagedLifecycl
                         synLog.traceTrace("Response payload received : " + synapseOutMsgCtx.getEnvelope());
                     }
                     if (synapseOutMsgCtx.getEnvelope() != null) {
-                org.apache.axis2.context.MessageContext resultAxisMsgCtx =
-                        ((Axis2MessageContext) synapseOutMsgCtx).getAxis2MessageContext();
-                org.apache.axis2.context.MessageContext inAxisMsgCtx =
-                                        ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-                if (JsonUtil.hasAJsonPayload(resultAxisMsgCtx)) {
-                    JsonUtil.cloneJsonPayload(resultAxisMsgCtx, inAxisMsgCtx);
-                } else {
-                    if (targetXPath != null) {
-                        Object o = targetXPath.evaluate(synCtx);
-                        OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
-                        if (o != null && o instanceof OMElement) {
-                            OMNode tgtNode = (OMElement) o;
-                            tgtNode.insertSiblingAfter(result);
-                            tgtNode.detach();
-                        } else if (o != null && o instanceof List && !((List) o).isEmpty()) {
-                            // Always fetches *only* the first
-                            OMNode tgtNode = (OMElement) ((List) o).get(0);
-                            tgtNode.insertSiblingAfter(result);
-                            tgtNode.detach();
+                        org.apache.axis2.context.MessageContext resultAxisMsgCtx = ((Axis2MessageContext) synapseOutMsgCtx)
+                                .getAxis2MessageContext();
+                        org.apache.axis2.context.MessageContext inAxisMsgCtx = ((Axis2MessageContext) synCtx)
+                                .getAxis2MessageContext();
+                        if (JsonUtil.hasAJsonPayload(resultAxisMsgCtx)) {
+                            JsonUtil.cloneJsonPayload(resultAxisMsgCtx, inAxisMsgCtx);
                         } else {
-                            handleException("Evaluation of target XPath expression : " +
-                                    targetXPath.toString() + " did not yeild an OMNode", synCtx);
+                            if (targetXPath != null) {
+                                Object o = targetXPath.evaluate(synCtx);
+                                OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
+                                if (o != null && o instanceof OMElement) {
+                                    OMNode tgtNode = (OMElement) o;
+                                    tgtNode.insertSiblingAfter(result);
+                                    tgtNode.detach();
+                                } else if (o != null && o instanceof List && !((List) o).isEmpty()) {
+                                    // Always fetches *only* the first
+                                    OMNode tgtNode = (OMElement) ((List) o).get(0);
+                                    tgtNode.insertSiblingAfter(result);
+                                    tgtNode.detach();
+                                } else {
+                                    handleException("Evaluation of target XPath expression : " + targetXPath.toString()
+                                            + " did not yeild an OMNode", synCtx);
+                                }
+                            } else if (targetKey != null) {
+                                OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
+                                synCtx.setProperty(targetKey, result);
+                            } else {
+                                synCtx.setEnvelope(synapseOutMsgCtx.getEnvelope());
+                            }
                         }
-                    } else if (targetKey != null) {
-                        OMElement result = synapseOutMsgCtx.getEnvelope().getBody().getFirstElement();
-                        synCtx.setProperty(targetKey, result);
+                        // Set HTTP Status code
+                        inAxisMsgCtx.setProperty(SynapseConstants.HTTP_SC,
+                                resultAxisMsgCtx.getProperty(SynapseConstants.HTTP_SC));
+                        if ("false".equals(synCtx.getProperty(SynapseConstants.BLOCKING_SENDER_PRESERVE_REQ_HEADERS))) {
+                            inAxisMsgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,
+                                    resultAxisMsgCtx
+                                            .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS));
+                        }
                     } else {
-                    	synCtx.setEnvelope(synapseOutMsgCtx.getEnvelope());
+                        synLog.traceOrDebug("Service returned a null response");
                     }
-                }
-                // Set HTTP Status code
-                inAxisMsgCtx.setProperty(SynapseConstants.HTTP_SC,
-                                         resultAxisMsgCtx.getProperty(SynapseConstants.HTTP_SC));
-                if ("false".equals(synCtx.getProperty(
-                        SynapseConstants.BLOCKING_SENDER_PRESERVE_REQ_HEADERS))) {
-                    inAxisMsgCtx.setProperty(
-                            org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,
-                            resultAxisMsgCtx.getProperty(
-                                    org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS));
-                }
-            } else {
-                synLog.traceOrDebug("Service returned a null response");
-            }
                 }
             } else {
                 log.info("Error while performing the callout operation");

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/SendMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/SendMediator.java
@@ -88,6 +88,7 @@ public class SendMediator extends AbstractMediator implements ManagedLifecycle {
             keySet.remove(SynapseConstants.CONTINUATION_CALL);
             keySet.remove(EndpointDefinition.DYNAMIC_URL_VALUE);
             keySet.remove(SynapseConstants.LAST_ENDPOINT);
+            keySet.remove(SynapseConstants.BLOCKING_MSG_SENDER);
         }
 
         if (receivingSequence != null) {

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -548,7 +548,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			if (messageConsumer != null && messageConsumer.isAlive()) {
 				messageToDispatch.setProperty(SynapseConstants.BLOCKING_MSG_SENDER, sender);
 				endpoint.send(messageToDispatch);
-				if ("true".equals(messageToDispatch.getProperty(SynapseConstants.OUT_ONLY))){
+				if ("true".equals(messageToDispatch.getProperty(SynapseConstants.OUT_ONLY))) {
 					if ("true".equals(messageToDispatch.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
 						throw new SynapseException("Error sending Message to the endpoint",
 								(Exception) messageToDispatch.getProperty(SynapseConstants.ERROR_EXCEPTION));

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -546,7 +546,16 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			updateAxis2MessageContext(messageToDispatch);
 
 			if (messageConsumer != null && messageConsumer.isAlive()) {
-				outCtx = sender.send(endpoint, messageToDispatch);
+				messageToDispatch.setProperty(SynapseConstants.BLOCKING_MSG_SENDER, sender);
+				endpoint.send(messageToDispatch);
+				if ("true".equals(messageToDispatch.getProperty(SynapseConstants.OUT_ONLY))){
+					if ("true".equals(messageToDispatch.getProperty(SynapseConstants.BLOCKING_SENDER_ERROR))) {
+						throw new SynapseException("Error sending Message to the endpoint",
+								(Exception) messageToDispatch.getProperty(SynapseConstants.ERROR_EXCEPTION));
+					}
+				} else {
+					outCtx = messageToDispatch;
+				}
 			}
 
 			/*

--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -430,8 +430,7 @@ public class BlockingMsgSender {
 
                 synapseInMsgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, fault.getMessage());
                 synapseInMsgCtx.setProperty(SynapseConstants.ERROR_DETAIL,
-                        fault.getDetail() != null ?
-                                fault.getDetail().getText() : "");
+                        fault.getDetail() != null ? fault.getDetail().getText() : "");
                 if (!isOutOnly) {
                     org.apache.axis2.context.MessageContext faultMC = fault.getFaultMessageContext();
                     if (faultMC != null) {


### PR DESCRIPTION
## Purpose
Group endpoint support for call mediator blocking invocation

## Goals
Call Mediator blocking invocation only support for leaf endpoint and does not support group endpoint (failover endpoint, load balance endpoint).
## Approach


## User stories
N/A
## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
N/A

## Certification
N/A

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
https://github.com/wso2/product-ei/pull/2139

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
JDK versions-1.8
Operating systems-Ubuntu 16.04
Product- EI-6.2.0
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.