### PR TITLE
Fix Dropping headers over local transport

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -35,9 +35,10 @@ import org.apache.axis2.util.JavaUtils;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.util.MediatorPropertyUtils;
 
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
@@ -168,7 +169,11 @@ public class PropertyMediator extends AbstractMediator {
                     headersMap.put(name, resultValue);
                 }
                 if (headers == null) {
-                    Map headersMap = new HashMap();
+                    Map<String, Object> headersMap = new TreeMap<>(new Comparator<String>() {
+                        public int compare(String o1, String o2) {
+                            return o1.compareToIgnoreCase(o2);
+                        }
+                    });
                     headersMap.put(name, resultValue);
                     axis2MessageCtx.setProperty(
                             org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
@@ -39,9 +39,10 @@ import org.apache.synapse.util.xpath.SynapseXPath;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * The header mediator is able to set a given value as a SOAP header, or remove a given
@@ -187,7 +188,11 @@ public class HeaderMediator extends AbstractMediator {
 	                headersMap.put(headerName, value);
 	            }
 	            if (headers == null) {
-	                Map headersMap = new HashMap();
+	                Map<String, Object> headersMap = new TreeMap<>(new Comparator<String>() {
+                            public int compare(String o1, String o2) {
+                                return o1.compareToIgnoreCase(o2);
+                            }
+	                });
 	                headersMap.put(headerName, value);
 	                axis2MessageCtx.setProperty(
 	                        org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -52,14 +52,12 @@ import org.apache.synapse.transport.passthru.util.TargetRequestFactory;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * This is a class for representing a request to be sent to a target.
@@ -251,7 +249,7 @@ public class TargetRequest {
         }
         
         Object o = requestMsgCtx.getProperty(MessageContext.TRANSPORT_HEADERS);
-        if (o != null && o instanceof TreeMap) {
+        if (o != null && o instanceof Map) {
             Map _headers = (Map) o;
             String trpContentType = (String) _headers.get(HTTP.CONTENT_TYPE);
             if (trpContentType != null && !trpContentType.equals("")) {


### PR DESCRIPTION
Content-Type header of GET calls is getting dropped if the preceded call is a data service call over local transport. This was due to using hashmaps instead of Treemaps for transport headers in property and header mediators. When creating the target request we check whether the transport header object type as a treemap.

This will fix the issue by using Treemaps and also checking Map type instead of limiting to specific map implementation.

Resolves wso2/product-ei#2143

## Purpose
Fix wso2/product-ei#2143

## Goals
Fix the headers dropping issue

## Approach
This will fix the issue by using Treemaps and also checking Map type instead of limiting to specific map implementation.


## User stories
> Summary of user stories addressed by this change>

## Release note
Fix Dropping headers over local transport

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.