### PR TITLE
Fix NPE when backend response has no Content-Length header

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceResponse.java
@@ -184,9 +184,9 @@ public class SourceResponse {
         if (entity == null &&
             PassThroughConstants.HTTP_HEAD.equalsIgnoreCase(request.getRequest().getRequestLine().getMethod())) {
             if (response.getFirstHeader(PassThroughConstants.ORGINAL_CONTEN_LENGTH) == null && response.getFirstHeader(
-		            HTTP.CONTENT_LEN).getValue() != null && (response.getFirstHeader(HTTP.CONTENT_LEN).getValue().equals("0"))) {
+		            HTTP.CONTENT_LEN) != null && (response.getFirstHeader(HTTP.CONTENT_LEN).getValue().equals("0"))) {
                 response.removeHeaders(HTTP.CONTENT_LEN);
-            } else {
+            } else if (response.getFirstHeader(PassThroughConstants.ORGINAL_CONTEN_LENGTH) != null) {
                 response.removeHeaders(HTTP.CONTENT_LEN);
                 response.addHeader(HTTP.CONTENT_LEN,
                                    response.getFirstHeader(PassThroughConstants.ORGINAL_CONTEN_LENGTH).getValue());


### PR DESCRIPTION
## Purpose
> When a backend responds to the EI without a content-length header and when the EI tries to respond back to the client, an NPE is thrown.

Fixed issue : wso2/product-ei#2130
