### PR TITLE
Fix wso2/product-ei/issues/2231

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
@@ -242,7 +242,9 @@ public class SamplingService implements Task, ManagedLifecycle {
 	 *         <code>false</code> otherwise.
 	 */
 	public boolean terminate() {
-		messageConsumer.cleanup();
+        if (messageConsumer != null) {
+            messageConsumer.cleanup();
+        }
 		return true;
 	}
 


### PR DESCRIPTION
## Purpose
> Cleanup message consumer only if it exists.

## Goals
> When scheduled message processor with <parameter name="is.active">false</parameter> deployed, it should not give a NPE.  

## Approach
> Add a NPE check 

## Related PRs
> [https://github.com/wso2/wso2-synapse/pull/749](PR)

## Test environment
> JDK 8
