### PR TITLE
Updated removeSeqContinuationState method in ContinuationStackManager

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/continuation/ContinuationStackManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/continuation/ContinuationStackManager.java
@@ -93,9 +93,7 @@ public class ContinuationStackManager {
         if (synCtx.isContinuationEnabled() && !synCtx.getContinuationStateStack().isEmpty()) {
             if (!SequenceType.ANON.equals(seqType)) {
                 ContinuationStackManager.popContinuationStateStack(synCtx);
-            } else {
-                removeReliantContinuationState(synCtx);
-            }
+            } 
         }
     }
 


### PR DESCRIPTION
For anonymous sequences, the reliant continuation state is removed (as
opposed to popping the continuation state stack) after processing. This is an error,
since no reliant continuation state is added when the anonymous sequence
is started: the method addSeqContinuationState only pushes a
continuation state onto the stack for non-anonymous sequences, but
doesn't do anything for anonymous sequences.

I have created this based on the v2.1.7wso2v15 tag and tested in wso2ei-6.1.1 (which used the v2.1.7wso2v15 synapse-core). Please check this fix, since I was unable to run the synapse-core unit tests on my system.
