### PR TITLE
fixing content-length when http method is get

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -145,7 +145,7 @@ public class TargetRequest {
         return contentLength;
     }
     
-    protected HttpRequest getHttpRequest(NHttpClientConnection conn, String path, boolean needContentLength) {
+    protected HttpRequest getHttpRequest(NHttpClientConnection conn, String path, boolean needToProcessChunking) {
         long contentLength = getContentLength(conn);
         
         MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
@@ -162,7 +162,7 @@ public class TargetRequest {
         boolean forceContentLengthCopy = 
                 requestMsgCtx.isPropertyTrue(PassThroughConstants.COPY_CONTENT_LENGTH_FROM_INCOMING);
                             
-        if (forceContentLength && needContentLength) {
+        if (forceContentLength && needToProcessChunking) {
             entity.setChunked(false);
             if (forceContentLengthCopy && contentLength != -1) {
                 if (log.isDebugEnabled()) {
@@ -176,14 +176,14 @@ public class TargetRequest {
                 request = new BasicHttpRequest(method, path, version != null ? version : HttpVersion.HTTP_1_1);
             }
         } else {
-            if (contentLength != -1 && needContentLength) {
+            if (contentLength != -1 && needToProcessChunking) {
                 if (log.isDebugEnabled()) {
                     log.debug("Set ContentLength : " + contentLength);
                 }
                 entity.setChunked(false);
                 entity.setContentLength(contentLength);
             } else {
-                if (hasEntityBody && needContentLength) {
+                if (hasEntityBody && needToProcessChunking) {
                     if (log.isDebugEnabled()) {
                         log.debug("Set chunked : " + chunk);
                     }
@@ -259,12 +259,12 @@ public class TargetRequest {
             }
         }
 
-        boolean needContentLength = !((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0))
+        boolean needToProcessChunking = !((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0))
                 || (PassThroughConstants.HTTP_GET
                         .equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD)))
                 || RelayUtils.isDeleteRequestWithoutPayload(requestMsgCtx));
 
-        request = getHttpRequest(conn, path, needContentLength);
+        request = getHttpRequest(conn, path, needToProcessChunking);
 
         //setup wsa action..
         if (request != null) {
@@ -291,7 +291,7 @@ public class TargetRequest {
         request.setParams(new DefaultedHttpParams(request.getParams(), targetConfiguration.getHttpParams()));
 
         //Chunking is not performed for request has "http 1.0" and "GET" http method
-        if (needContentLength && request instanceof BasicHttpEntityEnclosingRequest) {
+        if (needToProcessChunking && request instanceof BasicHttpEntityEnclosingRequest) {
             this.processChunking(conn, requestMsgCtx);
         }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -266,7 +266,7 @@ public class TargetRequest {
             }
         }
 
-        boolean needToProcessChunking = !((request.getProtocolVersion().equals(HttpVersion.HTTP_1_0))
+        boolean needToProcessChunking = !((version != null && version.equals(HttpVersion.HTTP_1_0))
                 || (PassThroughConstants.HTTP_GET
                         .equals(requestMsgCtx.getProperty(Constants.Configuration.HTTP_METHOD)))
                 || RelayUtils.isDeleteRequestWithoutPayload(requestMsgCtx));

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -150,24 +150,23 @@ public class TargetRequest {
         
         MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
         
-        HttpRequest request = 
-                new BasicHttpEntityEnclosingRequest(method, path, version != null ? version : HttpVersion.HTTP_1_1);
+        HttpRequest request = null;
 
-        BasicHttpEntity entity = new BasicHttpEntity();
-        
-        ((BasicHttpEntityEnclosingRequest) request).setEntity(entity);
-        
         boolean forceContentLength = 
                 requestMsgCtx.isPropertyTrue(NhttpConstants.FORCE_HTTP_CONTENT_LENGTH);
         boolean forceContentLengthCopy = 
                 requestMsgCtx.isPropertyTrue(PassThroughConstants.COPY_CONTENT_LENGTH_FROM_INCOMING);
                             
         if (forceContentLength && needToProcessChunking) {
-            entity.setChunked(false);
             if (forceContentLengthCopy && contentLength != -1) {
                 if (log.isDebugEnabled()) {
                     log.debug("Set ContentLength : " + contentLength);
                 }
+                request = new BasicHttpEntityEnclosingRequest(method, path,
+                        version != null ? version : HttpVersion.HTTP_1_1);
+                BasicHttpEntity entity = new BasicHttpEntity();
+                ((BasicHttpEntityEnclosingRequest) request).setEntity(entity);
+                entity.setChunked(false);
                 entity.setContentLength(contentLength);
             } else if (!hasEntityBody) {
                 if (log.isDebugEnabled()) {
@@ -180,6 +179,10 @@ public class TargetRequest {
                 if (log.isDebugEnabled()) {
                     log.debug("Set ContentLength : " + contentLength);
                 }
+                request = new BasicHttpEntityEnclosingRequest(method, path,
+                        version != null ? version : HttpVersion.HTTP_1_1);
+                BasicHttpEntity entity = new BasicHttpEntity();
+                ((BasicHttpEntityEnclosingRequest) request).setEntity(entity);
                 entity.setChunked(false);
                 entity.setContentLength(contentLength);
             } else {
@@ -187,6 +190,10 @@ public class TargetRequest {
                     if (log.isDebugEnabled()) {
                         log.debug("Set chunked : " + chunk);
                     }
+                    request = new BasicHttpEntityEnclosingRequest(method, path,
+                            version != null ? version : HttpVersion.HTTP_1_1);
+                    BasicHttpEntity entity = new BasicHttpEntity();
+                    ((BasicHttpEntityEnclosingRequest) request).setEntity(entity);
                     entity.setChunked(chunk);
                 } else {
                     if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
> To solve the problem that content-length header is set incorrectly for requests without payload such as GET / DELETE. 
> Generally, in case of GET / DELETE request without payload, there is no problem because [Content-Length](https://github.com/wso2/wso2-synapse/blob/072db5ce5d1bcbfc7394ef8a605020eebc729fca/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java#L145) is -1. However, if DISABLE_CHUKING is true, Content-Length is set even if GET / DELETE request without payload is set.

## Goals
> Remove content-length for GET/ DELETE requests without payload.

## Related PRs
> Fixing APIMANAGER-5916(#841) - Improvement #1054

