### PR TITLE
Fix: obtain the modified raw count for a DB Report

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/db/DBReportMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/db/DBReportMediator.java
@@ -32,6 +32,8 @@ import java.sql.Connection;
  */
 public class DBReportMediator extends AbstractDBMediator {
 
+    public static final String MODIFIED_ROW_COUNT_PROP_NAME = "DBREPORT_MODIFIED_RAW_COUNT";
+
     public boolean isUseTransaction() {
         return useTransaction;
     }
@@ -83,6 +85,9 @@ public class DBReportMediator extends AbstractDBMediator {
                             "No rows were inserted for statement : " + stmnt.getRawStatement());
                 }
             }
+
+            // Set row count that modified by executing SQL command as a property
+            msgCtx.setProperty(MODIFIED_ROW_COUNT_PROP_NAME, count);
 
             if (!(threadInTx || useTransaction)) {
                 if (!con.getAutoCommit()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/HttpCoreNIOSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/HttpCoreNIOSender.java
@@ -158,7 +158,9 @@ public class HttpCoreNIOSender extends AbstractHandler implements TransportSende
         connpool = new ConnectionPool();
 
         proxyConfig = new ProxyConfigBuilder().build(transportOut);
-        log.info(proxyConfig.logProxyConfig());
+        if (log.isDebugEnabled()) {
+            log.debug(proxyConfig.logProxyConfig());
+        }
 
         Parameter param = transportOut.getParameter("warnOnHTTP500");
         if (param != null) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ClientConnFactoryBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ClientConnFactoryBuilder.java
@@ -290,8 +290,8 @@ public class ClientConnFactoryBuilder {
             try {
                 KeyStore keyStore = KeyStore.getInstance(type);
                 fis = new FileInputStream(location);
-                if (log.isInfoEnabled()) {
-                    log.info(name + " Loading Identity Keystore from : " + location);
+                if (log.isDebugEnabled()) {
+                    log.debug(name + " Loading Identity Keystore from : " + location);
                 }
 
                 keyStore.load(fis, storePassword.toCharArray());
@@ -329,8 +329,8 @@ public class ClientConnFactoryBuilder {
             try {
                 KeyStore trustStore = KeyStore.getInstance(type);
                 fis = new FileInputStream(location);
-                if (log.isInfoEnabled()) {
-                    log.info(name + " Loading Trust Keystore from : " + location);
+                if (log.isDebugEnabled()) {
+                    log.debug(name + " Loading Trust Keystore from : " + location);
                 }
 
                 trustStore.load(fis, storePassword.toCharArray());
@@ -391,8 +391,8 @@ public class ClientConnFactoryBuilder {
          
             try (FileInputStream fis = new FileInputStream(location)) { 
                 KeyStore keyStore = KeyStore.getInstance(type);             
-                if (log.isInfoEnabled()) {
-                    log.info(name + " Loading Identity Keystore from : " + location);
+                if (log.isDebugEnabled()) {
+                    log.debug(name + " Loading Identity Keystore from : " + location);
                 }
 
                 keyStore.load(fis, storePassword.toCharArray());
@@ -423,8 +423,8 @@ public class ClientConnFactoryBuilder {
             try (FileInputStream fis = new FileInputStream(location)) {
                 KeyStore trustStore = KeyStore.getInstance(type);
         
-                if (log.isInfoEnabled()) {
-                    log.info(name + " Loading Trust Keystore from : " + location);
+                if (log.isDebugEnabled()) {
+                    log.debug(name + " Loading Trust Keystore from : " + location);
                 }
 
                 trustStore.load(fis, storePassword.toCharArray());

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ServerConnFactoryBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ServerConnFactoryBuilder.java
@@ -96,7 +96,7 @@ public class ServerConnFactoryBuilder {
             try {
                 KeyStore keyStore = KeyStore.getInstance(type);
                 fis = new FileInputStream(location);
-                if (log.isInfoEnabled()) {
+                if (log.isDebugEnabled()) {
                     log.debug(name + " Loading Identity Keystore from : " + location);
                 }
 
@@ -148,7 +148,7 @@ public class ServerConnFactoryBuilder {
             try {
                 KeyStore trustStore = KeyStore.getInstance(type);
                 fis = new FileInputStream(location);
-                if (log.isInfoEnabled()) {
+                if (log.isDebugEnabled()) {
                     log.debug(name + " Loading Trust Keystore from : " + location);
                 }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -144,7 +144,9 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                  "passthru-" + namePrefix.toLowerCase() + "-sender");
         
         proxyConfig = new ProxyConfigBuilder().build(transportOutDescription);
-        log.info(proxyConfig.logProxyConfig());
+        if (log.isDebugEnabled()) {
+            log.debug(proxyConfig.logProxyConfig());
+        }
 
         targetConfiguration = new TargetConfiguration(configurationContext,
                 transportOutDescription, workerPool, metrics,


### PR DESCRIPTION
## Purpose
Introduce a way to obtain the modified raw count for a DB Report mediator update or insert query
Fix: https://github.com/wso2/product-ei/issues/2330
+
Refactor some logs