### PR TITLE
Mediation cache clear when validate mediator redeployment

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -172,6 +172,9 @@ public final class SynapseConstants {
     public static final String SYNAPSE_LIB_LOADER = "synapse.lib.classloader";
     /** conf directory name **/
     public static final String CONF_DIRECTORY = "conf";
+    /** the name of the property used for validate mediator redeployment mediation cache clearing */
+    public static final String SYNAPSE_VALIDATE_MEDIATOR_REDEPLOYMENT_CACHE_CLEAR="synapse.validate.mediator.redeployment.mediation.cache.clear.enable";
+
 
     // hidden service parameter
     public static final String HIDDEN_SERVICE_PARAM = "hiddenService";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -46,6 +46,7 @@ import org.apache.synapse.config.SynapseConfigUtils;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.continuation.ContinuationStackManager;
+import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractListMediator;
 import org.apache.synapse.mediators.FlowContinuableMediator;
@@ -75,6 +76,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.synapse.SynapseConstants.SYNAPSE_VALIDATE_MEDIATOR_REDEPLOYMENT_CACHE_CLEAR;
 
 /**
  * Validate a message or an element against a schema
@@ -561,6 +564,27 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
             }
         }
         return result;
+    }
+
+    /**
+     * Initialize child mediators recursively
+     *
+     * @param se synapse environment
+     */
+    public void init(SynapseEnvironment se) {
+        if (Boolean.parseBoolean(se.getSynapseConfiguration().getProperty(SYNAPSE_VALIDATE_MEDIATOR_REDEPLOYMENT_CACHE_CLEAR))){
+            for(Value schemaKey :schemaKeys) {
+                Entry entry = se.getSynapseConfiguration().getEntryDefinition(schemaKey.getKeyValue());
+                entry.clearCache();
+            }
+            if (resourceMap != null && resourceMap.getResources().size() > 0) {
+                for (Map.Entry<String, String> resource : resourceMap.getResources().entrySet()) {
+                    Entry entry = se.getSynapseConfiguration().getEntryDefinition(resource.getValue());
+                    entry.clearCache();
+                }
+            }
+        }
+        super.init(se);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When the registry resources get change, ESB should be restart or wait until cachableDuration to clear the mediation cache which is used in validate mediator(when cachableDuration in ESB/repository/deployment/server/synapse-configs/default/registry.xml is large this will be a significant issue).

## Goals
> When registry resource related to the validate mediator get change, mediation cache which is used in validate mediator should be invalidated.

## Approach
> To Invalidate the mediation cache when at validate mediator redeployment(proxy redeployment). init method we can invalidate the mediation cache for the given registry schema resources.
