### PR TITLE
delay connection while overflow blob process

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -437,6 +437,8 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                     }
                 }
             }
+        } else {
+            deliveryAgent.submit(msgContext, epr);
         }
     }
 	

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -342,7 +342,7 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                 try {
                     msgContext.wait();
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    log.error("Interrupted while waiting for passthru connection..", e);
                 }
             }
         }
@@ -396,7 +396,6 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                         }
                     }
                 } catch (IOException e) {
-                    // TODO Auto-generated catch block
                     handleException("IO while building message", e);
                 }
             } else {

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/PassThroughHttpSenderTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/PassThroughHttpSenderTest.java
@@ -19,6 +19,7 @@ package org.apache.synapse.transport.passthru;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.apache.axis2.Constants;
+import org.apache.axis2.addressing.EndpointReference;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.context.OperationContext;
@@ -34,6 +35,7 @@ import org.apache.http.nio.reactor.IOSession;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 import org.apache.synapse.transport.passthru.util.BufferFactory;
+import org.apache.synapse.transport.passthru.util.PassThroughTransportUtils;
 import org.apache.synapse.transport.passthru.util.SourceResponseFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -109,10 +111,11 @@ public class PassThroughHttpSenderTest extends TestCase {
         sender = PowerMockito.spy(sender);
 
         PowerMockito.when(targetConfiguration.getBufferFactory()).thenReturn(factory);
-        PowerMockito.doNothing().when(sender, "sendRequestContent", any(MessageContext.class));
+        PowerMockito.doNothing().when(sender, "sendRequestContent", any(MessageContext.class), any(EndpointReference.class));
 
         Handler.InvocationResponse response = sender.invoke(messageContext);
 
+        
         Assert.assertNotNull("PassThrough Http Sender not invoked!", response);
     }
 


### PR DESCRIPTION
**Description:**

This is about Issue https://github.com/wso2/wso2-synapse/issues/1114 (Overflow blob and connection handling when transferring large files).

If disableChunking is "true", the length is calculated by writing a file to the java temp directory via OverflowBlob for large file transfers.

However, the connection can be made to the `stale` state during the completion of the` OverflowBlob` because the process is performed after the http connection is established through the `deliveryAgent.submit ()` function.

Therefore, there are two solutions.

1. Execute `overflowBlob.writeTo (out)` and then check `pipe.isStale`, and throw an exception to handle the fault in the mediation flow.

2. Call `deliveryAgent.submit ()` after OverflowBlob processing so that the connection does not fall into `stale` state.

I applied both options.



