### PR TITLE
Adding the name of the proxy services in error message when the policy reference doesn't exist to help diagnose problems when deploying multiple ProxyService

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -668,7 +668,16 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
 
             for (PolicyInfo pi : policies) {
 
-                Policy policy = getPolicyFromKey(pi.getPolicyKey(), synCfg);
+                String key = pi.getPolicyKey();
+                Policy policy = null;
+
+                synCfg.getEntryDefinition(key);
+                Object o = synCfg.getEntry(key);
+                if (o == null) {
+                    handleException("NoSecurity Policy found from key " + key + " in Axis2 service \"" + name + "\"");
+                } else {
+                    policy = PolicyEngine.getPolicy(SynapseConfigUtils.getStreamSource(o).getInputStream());
+                }
 
                 if (policy == null) {
                     handleException("Cannot find Policy from the key");
@@ -874,13 +883,6 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
             ((WSDL11ToAxisServiceBuilder) wsdlToAxisServiceBuilder).
                     setCustomWSDLResolver(userDefWSDLLocator);
         }
-    }
-
-    private Policy getPolicyFromKey(String key, SynapseConfiguration synCfg) {
-
-        synCfg.getEntryDefinition(key);
-        return PolicyEngine.getPolicy(
-                SynapseConfigUtils.getStreamSource(synCfg.getEntry(key)).getInputStream());
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When we deploy multiple Proxy Service and 1 or N of them have a wrong Policy reference (in the governance registry), we can't dirrectly know in which of them we get an error

## Goals
> Adding the name of the proxy service in error message when the policy reference doesn't exist

## Approach
> Adding the name of the proxy service in handleException : 
        handleException("NoSecurity Policy found from key " + key + " in Axis2 service \\"" + name + "\\"");

## Result
>So we get message like this when the error occur:
>> NoSecurity Policy found from key gov:/ws-policy/policyname.xml in proxyservicename

>Instead of debugging with this :
>>INFO - DependencyTracker Local entry : gov:/ws-policy/policyname.xml was added to the Synapse configuration successfully
>>[2018-07-13 08:26:42,305] []  WARN - SynapseConfigUtils Cannot convert null to a StreamSource 