### PR TITLE
Add log rotation for http logs.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NHttpConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NHttpConfiguration.java
@@ -68,6 +68,9 @@ public final class NHttpConfiguration {
     // general
     private static final String G_BUFFER_SIZE  = "nhttp_buffer_size";
     private static final String G_DISABLED_HTTP_METHODS = "nhttp_disabled_methods";
+
+    // log file rotation
+    private static final String IS_LOG_ROTATABLE = "nhttp.is.log.rotatable";
   
     //additional rest dispatch handlers
     private static final String NHTTP_REST_DISPATCHER_SERVICE="nhttp.rest.dispatcher.service";
@@ -195,6 +198,10 @@ public final class NHttpConfiguration {
 
     public int getBufferSize() {
         return getProperty(G_BUFFER_SIZE, BUFFER_SIZE);
+    }
+
+    public boolean isLogRotatable() {
+        return getBooleanValue(IS_LOG_ROTATABLE, false);
     }
 
     public boolean isKeepAliveDisabled() {


### PR DESCRIPTION
## Purpose
> Implement log rotation, and making it configurable from nhttp.properties
Fixes wso2/product-ei/issues/2420

## Goals
> Make http logs rotatable like carbon logs

## Approach
> Create new log file with date appended to file name when the date is changed. 

## Documentation
> Add nhttp.is.log.rotatable=true property to nhttp.properties file to enable the rog-rotation.
Default value is false 