### PR TITLE
Revert "Fix messageType not being set correctly"

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -27,6 +27,7 @@ import org.apache.axis2.addressing.RelatesTo;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.async.AxisCallback;
 import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.util.CallbackReceiver;
 import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.httpclient.HttpStatus;
@@ -413,9 +414,14 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
                 response.removeProperty(AddressingConstants.DISABLE_ADDRESSING_FOR_OUT_MESSAGES);
             }
 
-            // ContentType set in response msgCtx will be used as the messageType
-            response.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE,
-                    response.getProperty(Constants.Configuration.CONTENT_TYPE));
+            Object messageType = axisOutMsgCtx.getProperty(
+                    org.apache.axis2.Constants.Configuration.MESSAGE_TYPE);
+            if (!HTTPConstants.MEDIA_TYPE_X_WWW_FORM.equals(messageType)) {
+                 // copy the message type property that's used by the out message to the
+                 // response message
+                response.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE,
+                    messageType);
+            }
 
             // compare original received message (axisOutMsgCtx) soap version with the response
             // if they are different change to original version 


### PR DESCRIPTION
Reverts wso2/wso2-synapse#1143 Since setting ContentType as the MessageType is not a valid fix