### PR TITLE
Add connection eviction mechanism

### DIFF
--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -222,6 +222,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.tngtech.java</groupId>
+            <artifactId>junit-dataprovider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -24,6 +24,8 @@ public class PassThroughConstants {
     public static final String REQUEST_MESSAGE_CONTEXT = "REQUEST_MESSAGE_CONTEXT";
     public static final String CONNECTION_POOL = "CONNECTION_POOL";
     public static final String TUNNEL_HANDLER = "TUNNEL_HANDLER";
+    public static final String CONNECTION_INIT_TIME = "CONNECTION_INIT_TIME";
+    public static final String CONNECTION_RELEASE_TIME = "CONNECTION_RELEASE_TIME";
 
     public static final String TRUE = "TRUE";
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.synapse.transport.passthru.config;
+
+/**
+ * This class holds the parameters related to control the connection removal.
+ */
+public class ConnectionTimeoutConfiguration {
+
+    private int connectionIdleTime;
+    private int maximumConnectionLifeSpan;
+
+    public ConnectionTimeoutConfiguration(int connectionIdleTime, int maximumConnectionLifeSpan) {
+
+        this.connectionIdleTime = connectionIdleTime;
+        this.maximumConnectionLifeSpan = maximumConnectionLifeSpan;
+    }
+
+    public int getConnectionIdleTime() {
+        return connectionIdleTime;
+    }
+
+    public int getMaximumConnectionLifeSpane() {
+        return maximumConnectionLifeSpan;
+    }
+
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -81,6 +81,16 @@ public interface PassThroughConfigPNames {
     public String DISABLE_KEEPALIVE = "http.connection.disable.keepalive";
 
     /**
+     * Defines the time interval for idle connection removal.
+     */
+    public String CONNECTION_IDLE_TIME = "transport.sender.connection.idle.time";
+
+    /**
+     * Defines the time interval for maximum connection lifespan.
+     */
+    public String MAXIMUM_CONNECTION_LIFESPAN = "transport.sender.connection.maximum.lifespan";
+
+    /**
      * Defines the maximum number of connections per host port
      */
     public String MAX_CONNECTION_PER_HOST_PORT = "http.max.connection.per.host.port";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -136,6 +136,14 @@ public class PassThroughConfiguration {
         return getStringProperty(PassThroughConfigPNames.HTTP_HEADERS_PRESERVE, "");
     }
 
+    public int getConnectionIdleTime() {
+        return getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, Integer.MAX_VALUE);
+    }
+
+    public int getMaximumConnectionLifespan() {
+        return getIntProperty(PassThroughConfigPNames.MAXIMUM_CONNECTION_LIFESPAN, Integer.MAX_VALUE);
+    }
+
     /**
      * Loads the properties from a given property file path
      *

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
@@ -59,6 +59,8 @@ public class TargetConfiguration extends BaseConfiguration {
 
     private TargetConnections connections = null;
 
+    private ConnectionTimeoutConfiguration connectionTimeoutConfiguration;
+
     public TargetConfiguration(ConfigurationContext configurationContext,
                                ParameterInclude parameters,
                                WorkerPool pool,
@@ -75,6 +77,7 @@ public class TargetConfiguration extends BaseConfiguration {
                         new RequestExpectContinue()
          });
         this.proxyAuthenticator = proxyAuthenticator;
+        this.connectionTimeoutConfiguration = new ConnectionTimeoutConfiguration(conf.getConnectionIdleTime(), conf.getMaximumConnectionLifespan());
     }
 
     public void build() throws AxisFault {
@@ -113,6 +116,10 @@ public class TargetConfiguration extends BaseConfiguration {
 
     public void setConnections(TargetConnections connections) {
         this.connections = connections;
+    }
+
+    public ConnectionTimeoutConfiguration getConnectionTimeoutConfiguration() {
+        return connectionTimeoutConfiguration;
     }
 
     /**
@@ -158,3 +165,4 @@ public class TargetConfiguration extends BaseConfiguration {
     }
 
 }
+

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
@@ -16,16 +16,19 @@
 
 package org.apache.synapse.transport.passthru.connections;
 
-import org.apache.http.conn.routing.HttpRoute;
-import org.apache.http.nio.NHttpClientConnection;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.nio.NHttpClientConnection;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.synapse.transport.http.conn.SynapseHTTPRequestFactory;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.config.ConnectionTimeoutConfiguration;
 
-import java.util.List;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -40,6 +43,9 @@ public class HostConnections {
     private final int maxSize;
     // number of awaiting connections
     private int pendingConnections;
+    private int connectionIdleTime;
+    // maximum life span of a connection
+    private int maximumConnectionLifeSpan;
     // list of free connections available
     private List<NHttpClientConnection> freeConnections = new ArrayList<NHttpClientConnection>();
     // list of connections in use
@@ -55,6 +61,16 @@ public class HostConnections {
         this.maxSize = maxSize;
     }
 
+    public HostConnections(HttpRoute route, int maxSize, ConnectionTimeoutConfiguration connectionTimeoutConfiguration) {
+        if (log.isDebugEnabled()) {
+            log.debug("Creating new connection pool: " + route);
+        }
+        this.route = route;
+        this.maxSize = maxSize;
+        this.connectionIdleTime = connectionTimeoutConfiguration.getConnectionIdleTime();
+        this.maximumConnectionLifeSpan = connectionTimeoutConfiguration.getMaximumConnectionLifeSpane();
+    }
+
     /**
      * Get a connection for the host:port
      *
@@ -63,14 +79,26 @@ public class HostConnections {
     public NHttpClientConnection getConnection() {
         lock.lock();
         try {
-            if (freeConnections.size() > 0) {
+            while (!freeConnections.isEmpty()) {
                 if (log.isDebugEnabled()) {
                     log.debug("Returning an existing free connection " + route);
                 }
                 NHttpClientConnection conn = freeConnections.get(0);
-                freeConnections.remove(conn);
-                busyConnections.add(conn);
-                return conn;
+                long currentTime = System.currentTimeMillis();
+                long connectionInitTime = (Long) conn.getContext().getAttribute(PassThroughConstants.CONNECTION_INIT_TIME);
+                long lastReleasedTime = (Long) conn.getContext().getAttribute(PassThroughConstants.CONNECTION_RELEASE_TIME);
+                if (isMaximumLifeSpanExceeded(currentTime, connectionInitTime) || isIdleTimeExceeded(currentTime, lastReleasedTime)) {
+                    freeConnections.remove(conn);
+                    try {
+                        conn.shutdown();
+                    } catch (IOException io) {
+                        log.error("Error occured while shutting down connection." + io.getMessage());
+                    }
+                } else {
+                    freeConnections.remove(conn);
+                    busyConnections.add(conn);
+                    return conn;
+                }
             }
         } finally {
             lock.unlock();
@@ -78,12 +106,33 @@ public class HostConnections {
         return null;
     }
 
+    private boolean isIdleTimeExceeded(long currentTime, long lastReleasedTime) {
+        if (connectionIdleTime > 0 && currentTime > lastReleasedTime + connectionIdleTime) {
+            if (log.isDebugEnabled()) {
+                log.debug("Connection has been idle for " + (currentTime - lastReleasedTime) + " milliseconds.");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isMaximumLifeSpanExceeded(long currentTime, long connectionInitTime) {
+        if (maximumConnectionLifeSpan > 0 && currentTime > maximumConnectionLifeSpan + connectionInitTime) {
+            if (log.isDebugEnabled()) {
+                log.debug("Connection has been persisted for " + (currentTime - connectionInitTime)
+                                  + " milliseconds where the maximum connection life span is " + maximumConnectionLifeSpan + " milliseconds.");
+            }
+            return true;
+        }
+        return false;
+    }
+
     public void release(NHttpClientConnection conn) {
         conn.getMetrics().reset();
         HttpContext ctx = conn.getContext();
         ctx.removeAttribute(ExecutionContext.HTTP_REQUEST);
         ctx.removeAttribute(ExecutionContext.HTTP_RESPONSE);
-
+        ctx.setAttribute(PassThroughConstants.CONNECTION_RELEASE_TIME, System.currentTimeMillis());
         ctx.removeAttribute(SynapseHTTPRequestFactory.ENDPOINT_URL);
         lock.lock();
         try {
@@ -114,6 +163,7 @@ public class HostConnections {
         }
         lock.lock();
         try {
+            conn.getContext().setAttribute(PassThroughConstants.CONNECTION_INIT_TIME, System.currentTimeMillis());
             busyConnections.add(conn);
         } finally {
             lock.unlock();
@@ -144,7 +194,7 @@ public class HostConnections {
         } finally {
             lock.unlock();
         }
-    }    
+    }
 
     public HttpRoute getRoute() {
         return route;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
@@ -37,18 +37,33 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class HostConnections {
     private static final Log log = LogFactory.getLog(HostConnections.class);
-    // route
+    /**
+     * route
+     */
     private final HttpRoute route;
-    // maximum number of connections allowed for this host + port
+    /**
+     * maximum number of connections allowed for this host + port
+     */
     private final int maxSize;
-    // number of awaiting connections
+    /**
+     * number of awaiting connections
+     */
     private int pendingConnections;
+    /**
+     * connection idle time for connection removal
+     */
     private int connectionIdleTime;
-    // maximum life span of a connection
+    /**
+     * maximum life span of a connection
+     */
     private int maximumConnectionLifeSpan;
-    // list of free connections available
+    /**
+     * list of free connections available
+     */
     private List<NHttpClientConnection> freeConnections = new ArrayList<NHttpClientConnection>();
-    // list of connections in use
+    /**
+     * list of connections in use
+     */
     private List<NHttpClientConnection> busyConnections = new ArrayList<NHttpClientConnection>();
 
     private Lock lock = new ReentrantLock();
@@ -92,7 +107,7 @@ public class HostConnections {
                     try {
                         conn.shutdown();
                     } catch (IOException io) {
-                        log.error("Error occured while shutting down connection." + io.getMessage());
+                        log.error("Error occurred while shutting down connection." + io.getMessage());
                     }
                 } else {
                     freeConnections.remove(conn);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
@@ -25,6 +25,7 @@ import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.synapse.transport.passthru.ConnectCallback;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.TargetContext;
+import org.apache.synapse.transport.passthru.config.ConnectionTimeoutConfiguration;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 
 import java.io.IOException;
@@ -56,6 +57,9 @@ public class TargetConnections {
     /** callback invoked when a connection is made */
     private ConnectCallback callback = null;
 
+    /** Configurations to use remove idle connections */
+    private ConnectionTimeoutConfiguration idleConnectionConfiguration;
+
     /**
      * Create a TargetConnections with the given IO-Reactor
      *
@@ -70,6 +74,7 @@ public class TargetConnections {
         this.maxConnections = targetConfiguration.getMaxConnections();
         this.ioReactor = ioReactor;
         this.callback = callback;
+        this.idleConnectionConfiguration = targetConfiguration.getConnectionTimeoutConfiguration();
     }
 
     /**

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/connections/HostConnectionsTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/connections/HostConnectionsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.synapse.transport.passthru.connections;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.http.nio.NHttpClientConnection;
+import org.apache.http.protocol.HttpContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.config.ConnectionTimeoutConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.support.membermodification.MemberModifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.times;
+
+@RunWith(DataProviderRunner.class)
+public class HostConnectionsTest {
+
+    @DataProvider
+    public static Object[][] data() {
+
+        return new Object[][]{
+                {10, 20},
+                {20, 25},
+        };
+    }
+
+    @Test
+    @UseDataProvider("data")
+    public void getConnection(final int connectionIdleTime, final int maximumConnectionLifeSpan) throws Exception {
+
+        NHttpClientConnection nHttpClientConnection = Mockito.mock(NHttpClientConnection.class);
+        List<NHttpClientConnection> freeConnections = new ArrayList<>();
+        freeConnections.add(nHttpClientConnection);
+        ConnectionTimeoutConfiguration conf = new ConnectionTimeoutConfiguration(connectionIdleTime, maximumConnectionLifeSpan);
+        HostConnections hostConnections = new HostConnections(null, 1, conf);
+        MemberModifier.field(HostConnections.class, "freeConnections").set(hostConnections, freeConnections);
+        long currentTime = System.currentTimeMillis();
+        Mockito.when((nHttpClientConnection.getContext())).thenReturn(Mockito.mock(HttpContext.class));
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_INIT_TIME))
+                .thenReturn(0L);
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_RELEASE_TIME))
+                .thenReturn(currentTime);
+        hostConnections.getConnection();
+        Mockito.verify(nHttpClientConnection, times(1)).shutdown();
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_INIT_TIME))
+                .thenReturn(currentTime);
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_RELEASE_TIME))
+                .thenReturn(0L);
+        hostConnections.getConnection();
+        Mockito.verify(nHttpClientConnection, times(1)).shutdown();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -956,6 +956,12 @@
               <scope>test</scope>
           </dependency>
           <dependency>
+              <groupId>com.tngtech.java</groupId>
+              <artifactId>junit-dataprovider</artifactId>
+              <version>${dataprovider.version}</version>
+              <scope>test</scope>
+          </dependency>
+          <dependency>
               <groupId>org.jacoco</groupId>
               <artifactId>org.jacoco.agent</artifactId>
               <classifier>runtime</classifier>
@@ -1183,6 +1189,7 @@
       <jacoco.agent.version>0.7.9</jacoco.agent.version>
       <jacoco.ant.version>0.7.9</jacoco.ant.version>
       <powermock.version>1.7.1</powermock.version>
+      <dataprovider.version>1.5.0</dataprovider.version>
       <activemq.version>5.2.0</activemq.version>
       <rhino.version>1.7R4</rhino.version>
       <jetty.version>7.2.0.v20101020</jetty.version>


### PR DESCRIPTION
## Purpose
> Purpose of this pr is to add connection eviction mechanism to wso2-synapse. User can configure "connection idle time" and "maximum connection life span" parameters in passthru-http.properties. When the connection is idle for a time of "connection idle time" or a connection persisted for a time more than "maximum connection lifespan", then the connection is removed from the connection pool.
resolve  https://github.com/wso2/product-ei/issues/2592