### PR TITLE
Add connection eviction mechanism

### DIFF
--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -226,6 +226,11 @@
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.tngtech.java</groupId>
+            <artifactId>junit-dataprovider</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties />

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -24,6 +24,8 @@ public class PassThroughConstants {
     public static final String REQUEST_MESSAGE_CONTEXT = "REQUEST_MESSAGE_CONTEXT";
     public static final String CONNECTION_POOL = "CONNECTION_POOL";
     public static final String TUNNEL_HANDLER = "TUNNEL_HANDLER";
+    public static final String CONNECTION_INIT_TIME = "CONNECTION_INIT_TIME";
+    public static final String CONNECTION_RELEASE_TIME = "CONNECTION_RELEASE_TIME";
 
     public static final String TRUE = "TRUE";
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.synapse.transport.passthru.config;
+
+/**
+ * This class holds the parameters related to control the connection removal.
+ *
+ * Scenario:
+ * This issue happens when calling salesforce endpoint with keepalive connections. First ESB create the connection with
+ * salesforce and send the request and get the response. However if the connection is idle for 1min and ESB used the
+ * 1min idle connection to send the next message, salesforce will reset the connection. As a solution to this we decided
+ * to introduce a connection eviction mechanism as an improvement. So if a connection is idle for a "connectionIdletime"
+ * of time or a connection persisted for more than it's "maximumConnectionLifeSpan" then the connection is removed from
+ * the connection pool.
+ */
+public class ConnectionTimeoutConfiguration {
+
+    private int connectionIdleTime;
+    private int maximumConnectionLifeSpan;
+
+    public ConnectionTimeoutConfiguration(int connectionIdleTime, int maximumConnectionLifeSpan) {
+        this.connectionIdleTime = connectionIdleTime;
+        this.maximumConnectionLifeSpan = maximumConnectionLifeSpan;
+    }
+
+    public int getConnectionIdleTime() {
+        return connectionIdleTime;
+    }
+
+    public int getMaximumConnectionLifeSpane() {
+        return maximumConnectionLifeSpan;
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -81,6 +81,17 @@ public interface PassThroughConfigPNames {
     public String DISABLE_KEEPALIVE = "http.connection.disable.keepalive";
 
     /**
+     * Defines the time interval for idle connection removal.
+     */
+    public String CONNECTION_IDLE_TIME = "transport.sender.connection.idle.time";
+
+    /**
+     * Defines the time interval for maximum connection lifespan.
+     */
+    public String MAXIMUM_CONNECTION_LIFESPAN = "transport.sender.connection.maximum.lifespan";
+
+
+    /**
      * Defines the maximum number of connections per host port
      */
     public String MAX_CONNECTION_PER_HOST_PORT = "http.max.connection.per.host.port";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -136,6 +136,13 @@ public class PassThroughConfiguration {
         return getStringProperty(PassThroughConfigPNames.HTTP_HEADERS_PRESERVE, "");
     }
 
+    public int getConnectionIdleTime() {
+        return getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, Integer.MAX_VALUE);
+    }
+    public int getMaximumConnectionLifespan() {
+        return getIntProperty(PassThroughConfigPNames.MAXIMUM_CONNECTION_LIFESPAN, Integer.MAX_VALUE);
+    }
+
     /**
      * Loads the properties from a given property file path
      *

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
@@ -57,6 +57,8 @@ public class TargetConfiguration extends BaseConfiguration {
     /** Http headers which should be preserved */
     private List<String> preserveHttpHeaders;
 
+    private ConnectionTimeoutConfiguration connectionTimeoutConfiguration;
+    
     private TargetConnections connections = null;
 
     public TargetConfiguration(ConfigurationContext configurationContext,
@@ -74,6 +76,8 @@ public class TargetConfiguration extends BaseConfiguration {
                         new RequestUserAgent(),
                         new RequestExpectContinue()
          });
+        this.connectionTimeoutConfiguration = new ConnectionTimeoutConfiguration(conf.getConnectionIdleTime(),
+                                                                                 conf.getMaximumConnectionLifespan());
         this.proxyAuthenticator = proxyAuthenticator;
     }
 

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/connections/HostConnectionsTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/connections/HostConnectionsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.synapse.transport.passthru.connections;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.http.nio.NHttpClientConnection;
+import org.apache.http.protocol.HttpContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.config.ConnectionTimeoutConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.support.membermodification.MemberModifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.times;
+
+@RunWith(DataProviderRunner.class)
+public class HostConnectionsTest {
+
+    @DataProvider
+    public static Object[][] data() {
+
+        return new Object[][]{
+                {10, 20},
+                {20, 25},
+        };
+    }
+
+    @Test
+    @UseDataProvider("data")
+    public void testGetConnection(final int connectionIdleTime, final int maximumConnectionLifeSpan) throws Exception {
+
+        NHttpClientConnection nHttpClientConnection = Mockito.mock(NHttpClientConnection.class);
+        List<NHttpClientConnection> freeConnections = new ArrayList<>();
+        freeConnections.add(nHttpClientConnection);
+        ConnectionTimeoutConfiguration conf = new ConnectionTimeoutConfiguration(connectionIdleTime,
+                                                                                 maximumConnectionLifeSpan);
+        HostConnections hostConnections = new HostConnections(null, 1, conf);
+        MemberModifier.field(HostConnections.class, "freeConnections").set(hostConnections, freeConnections);
+        long currentTime = System.currentTimeMillis();
+        Mockito.when((nHttpClientConnection.getContext())).thenReturn(Mockito.mock(HttpContext.class));
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_INIT_TIME))
+                .thenReturn(0L);
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants
+                                                                                    .CONNECTION_RELEASE_TIME))
+                .thenReturn(currentTime);
+        hostConnections.getConnection();
+        Mockito.verify(nHttpClientConnection, times(1)).shutdown();
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants.CONNECTION_INIT_TIME))
+                .thenReturn(currentTime);
+        Mockito.when((Long) nHttpClientConnection.getContext().getAttribute(PassThroughConstants
+                                                                                    .CONNECTION_RELEASE_TIME))
+                .thenReturn(0L);
+        hostConnections.getConnection();
+        Mockito.verify(nHttpClientConnection, times(1)).shutdown();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -956,6 +956,12 @@
               <scope>test</scope>
           </dependency>
           <dependency>
+              <groupId>com.tngtech.java</groupId>
+              <artifactId>junit-dataprovider</artifactId>
+              <version>${dataprovider.version}</version>
+              <scope>test</scope>
+          </dependency>
+          <dependency>
               <groupId>org.jacoco</groupId>
               <artifactId>org.jacoco.agent</artifactId>
               <classifier>runtime</classifier>
@@ -1183,6 +1189,7 @@
       <jacoco.agent.version>0.7.9</jacoco.agent.version>
       <jacoco.ant.version>0.7.9</jacoco.ant.version>
       <powermock.version>1.7.1</powermock.version>
+      <dataprovider.version>1.5.0</dataprovider.version>
       <activemq.version>5.2.0</activemq.version>
       <rhino.version>1.7R4</rhino.version>
       <jetty.version>7.2.0.v20101020</jetty.version>


### PR DESCRIPTION
## Purpose
We need to add maximum-connection-lifespan and connection-idle-timeout parameters to passthru-http.properties. Here if a connection is persisted in the connection pool for a time more than the maximum-connection-lifespan or if a connection is idle for a time more than connection-idle-timeout then the connection is removed from the connection pool. Resolve https://github.com/wso2/product-ei/issues/2613