### PR TITLE
Add observability feature

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -365,6 +365,8 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
 
             // set properties on response
             response.setServerSide(true);
+            response.setProperty(PassThroughConstants.CORRELATION_ID,
+                    axisOutMsgCtx.getProperty(PassThroughConstants.CORRELATION_ID));
             response.setProperty(SynapseConstants.ISRESPONSE_PROPERTY, Boolean.TRUE);
             response.setProperty(MessageContext.TRANSPORT_OUT,
                     axisOutMsgCtx.getProperty(MessageContext.TRANSPORT_OUT));

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -103,17 +103,13 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
 
         synCtx.setProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
                            EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
-
-
-
         //observability code starts here
-        String originalCorrelationId=null;
-        boolean correlationEnabled = ((Axis2MessageContext)synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-        if (correlationEnabled) {
-             originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_ID).toString();
+        String originalCorrelationId = null;
+        boolean correlationLoggingEnabled = ((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY);
+        if (correlationLoggingEnabled) {
+            originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_ID).toString();
         }
         //observability code ends here
-
 
         // get the targets list, clone the message for the number of targets and then
         // mediate the cloned messages using the targets
@@ -125,9 +121,8 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
                     " messages for " + (isSequential() ? "sequential processing" : "parallel processing"));
             }
 
-
             //Observability code
-            if (correlationEnabled) {
+            if (correlationLoggingEnabled) {
                 ((Axis2MessageContext) synCtx).getAxis2MessageContext().setProperty(PassThroughConstants.CORRELATION_ID, originalCorrelationId + "_" + i);
             }
             //Observability code ends here

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -105,7 +105,8 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
                            EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
         //observability code starts here
         String originalCorrelationId = null;
-        boolean correlationLoggingEnabled = ((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY);
+        boolean correlationLoggingEnabled = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY);
         if (correlationLoggingEnabled) {
             originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_ID).toString();
         }
@@ -117,8 +118,8 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
         int i = 0;
         while (iter.hasNext()) {
             if (synLog.isTraceOrDebugEnabled()) {
-                synLog.traceOrDebug("Submitting " + (i+1) + " of " + targets.size() +
-                    " messages for " + (isSequential() ? "sequential processing" : "parallel processing"));
+                synLog.traceOrDebug("Submitting " + (i + 1) + " of " + targets.size() +
+                        " messages for " + (isSequential() ? "sequential processing" : "parallel processing"));
             }
 
             //Observability code

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -105,8 +105,10 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
                            EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
         //observability code starts here
         String originalCorrelationId = null;
-        if (((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
-            originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_ID).toString();
+        if (((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
+            originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                    getProperty(PassThroughConstants.CORRELATION_ID).toString();
         }
         //observability code ends here
 
@@ -121,8 +123,10 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
             }
 
             //Observability code
-            if (((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
-                ((Axis2MessageContext) synCtx).getAxis2MessageContext().setProperty(PassThroughConstants.CORRELATION_ID, originalCorrelationId + "_" + i);
+            if (((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                    isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
+                ((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                        setProperty(PassThroughConstants.CORRELATION_ID, originalCorrelationId + "_" + i);
             }
             //Observability code ends here
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -123,8 +123,7 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
             }
 
             //Observability code
-            if (((Axis2MessageContext) synCtx).getAxis2MessageContext().
-                    isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
+            if (originalCorrelationId != null) {
                 ((Axis2MessageContext) synCtx).getAxis2MessageContext().
                         setProperty(PassThroughConstants.CORRELATION_ID, originalCorrelationId + "_" + i);
             }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -105,9 +105,7 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
                            EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
         //observability code starts here
         String originalCorrelationId = null;
-        boolean correlationLoggingEnabled = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
-                isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY);
-        if (correlationLoggingEnabled) {
+        if (((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
             originalCorrelationId = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(PassThroughConstants.CORRELATION_ID).toString();
         }
         //observability code ends here
@@ -123,7 +121,7 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
             }
 
             //Observability code
-            if (correlationLoggingEnabled) {
+            if (((Axis2MessageContext) synCtx).getAxis2MessageContext().isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
                 ((Axis2MessageContext) synCtx).getAxis2MessageContext().setProperty(PassThroughConstants.CORRELATION_ID, originalCorrelationId + "_" + i);
             }
             //Observability code ends here

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -274,19 +274,11 @@ public class DeliveryAgent {
         TargetRequest request = TargetRequestFactory.create(msgContext, route, targetConfiguration);
         TargetContext.setRequest(conn, request);
         //check whether correlation logs are enabled for correlation logs
-        conn.getContext().
-                setAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, msgContext.getProperty(PassThroughConstants.
-                        CORRELATION_LOG_STATE_PROPERTY).toString());
-        boolean correlationLoggingEnabled = msgContext.getProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().
-                equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        boolean correlationLoggingEnabled = targetConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
         if (correlationLoggingEnabled) {
-            long corTime = System.currentTimeMillis();
-            long startTime = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_TIME);
-            MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, msgContext.getProperty(PassThroughConstants.CORRELATION_ID).toString());
-            correlationLog.info((corTime - startTime) + "| HTTP | " +conn.getContext().getAttribute("http.connection"));
-            MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
+            long startTime = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED);
             conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID, msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
-            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_TIME, corTime);
+            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, startTime);
         }
 
         Pipe pipe = (Pipe) msgContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -53,8 +53,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public class DeliveryAgent {
 
     private static final Log log = LogFactory.getLog(DeliveryAgent.class);
-    /**log for correlationLog*/
-    private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
     /**
      * This Map holds the messages that need to be delivered. But at the moment maximum
@@ -273,11 +271,9 @@ public class DeliveryAgent {
         }
         TargetRequest request = TargetRequestFactory.create(msgContext, route, targetConfiguration);
         TargetContext.setRequest(conn, request);
-        //check whether correlation logs are enabled for correlation logs
-        if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
-            long startTime = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED);
-            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID, msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
-            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, startTime);
+        if (targetConfiguration.getCorrelationStatus()) {
+            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID,
+                    msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
         }
 
         Pipe pipe = (Pipe) msgContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -271,7 +271,7 @@ public class DeliveryAgent {
         }
         TargetRequest request = TargetRequestFactory.create(msgContext, route, targetConfiguration);
         TargetContext.setRequest(conn, request);
-        if (targetConfiguration.getCorrelationStatus()) {
+        if (targetConfiguration.isCorrelationLoggingEnabled()) {
             conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID,
                     msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -274,8 +274,7 @@ public class DeliveryAgent {
         TargetRequest request = TargetRequestFactory.create(msgContext, route, targetConfiguration);
         TargetContext.setRequest(conn, request);
         //check whether correlation logs are enabled for correlation logs
-        boolean correlationLoggingEnabled = targetConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-        if (correlationLoggingEnabled) {
+        if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
             long startTime = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED);
             conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID, msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
             conn.getContext().setAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, startTime);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -53,9 +53,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public class DeliveryAgent {
 
     private static final Log log = LogFactory.getLog(DeliveryAgent.class);
-
     /**log for correlationLog*/
-    private static final Log correlate = LogFactory.getLog("CORRELATION_LOGGER");
+    private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
     /**
      * This Map holds the messages that need to be delivered. But at the moment maximum
@@ -274,25 +273,20 @@ public class DeliveryAgent {
         }
         TargetRequest request = TargetRequestFactory.create(msgContext, route, targetConfiguration);
         TargetContext.setRequest(conn, request);
-
-
-        //check whether correlation logs are enabled
-        conn.getContext().setAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, msgContext.getProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString());
-        boolean correlationEnabled = msgContext.getProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-
-        if (correlationEnabled) {
-
-            long cor_time = System.currentTimeMillis();
-            long start_time = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_TIME);
-            MDC.put("Correlation-ID", msgContext.getProperty(PassThroughConstants.CORRELATION_ID).toString());
-            correlate.info((cor_time - start_time) + "| HTTP");
-            MDC.remove("Correlation-ID");
-            //setting the correlation_id to response [observability]
-            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID, msgContext.getProperty("correlation_id"));
-            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_TIME, cor_time);
-
-            //observability code ends here
-
+        //check whether correlation logs are enabled for correlation logs
+        conn.getContext().
+                setAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, msgContext.getProperty(PassThroughConstants.
+                        CORRELATION_LOG_STATE_PROPERTY).toString());
+        boolean correlationLoggingEnabled = msgContext.getProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().
+                equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        if (correlationLoggingEnabled) {
+            long corTime = System.currentTimeMillis();
+            long startTime = (long) msgContext.getProperty(PassThroughConstants.CORRELATION_TIME);
+            MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, msgContext.getProperty(PassThroughConstants.CORRELATION_ID).toString());
+            correlationLog.info((corTime - startTime) + "| HTTP | " +conn.getContext().getAttribute("http.connection"));
+            MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
+            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_ID, msgContext.getProperty(PassThroughConstants.CORRELATION_ID));
+            conn.getContext().setAttribute(PassThroughConstants.CORRELATION_TIME, corTime);
         }
 
         Pipe pipe = (Pipe) msgContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -245,6 +245,6 @@ public class PassThroughConstants {
     public static final String CORRELATION_LOGS_SYS_PROPERTY = "EnableCorrelationLogs";
     public static final String CORRELATION_MDC_PROPERTY = "Correlation-ID";
     public static final String CORRELATION_LOGGER = "CORRELATION_LOGGER";
-    public static final String CORRELATION_REQ_SEND_TO_BACKEND_TIME = "REQUEST_SENT_TIME";
-    public static final String CORRELATION_REQUEST_ARRIVED_TIME = "REQUEST_RECEIVED_TIME";
+    public static final String CORRELATION_REQ_SEND_TO_BACKEND_TIME = "CORRELATION_REQ_SEND_TO_BACKEND_TIME";
+    public static final String CORRELATION_REQUEST_ARRIVED_TIME = "CORRELATION_REQUEST_ARRIVED_TIME";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -234,4 +234,12 @@ public class PassThroughConstants {
 
     //Check for invalid json message by parsing the input message
     public static final String FORCE_JSON_MESSAGE_VALIDATION = "force.json.message.validation";
+
+    /**constants for the EI observability*/
+    public static final String CORRELATION_ENABLE_STATE = "true";
+    public static final String CORRELATION_DISABLE_STATE = "false";
+    public static final String CORRELATION_LOG_STATE_PROPERTY = "correlationLogState";
+    public static final String CORRELATION_ID = "correlation_id";
+    public  static final  String CORRELATION_TIME= "correlation_time";
+    public  static final  String CORRELATION_LOGS_SYS_PROPERTY= "EnableCorrelationLogs";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -16,6 +16,8 @@
 
 package org.apache.synapse.transport.passthru;
 
+import org.omg.CORBA.PUBLIC_MEMBER;
+
 public class PassThroughConstants {
 
     public static final int DEFAULT_IO_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
@@ -240,8 +242,9 @@ public class PassThroughConstants {
     public static final String CORRELATION_DISABLE_STATE = "false";
     public static final String CORRELATION_LOG_STATE_PROPERTY = "correlationLogState";
     public static final String CORRELATION_ID = "correlation_id";
-    public  static final  String CORRELATION_TIME= "correlation_time";
-    public  static final  String CORRELATION_LOGS_SYS_PROPERTY= "EnableCorrelationLogs";
-    public static  final String CORRELATION_MDC_PROPERTY = "Correlation-ID";
+    public static final String CORRELATION_LOGS_SYS_PROPERTY = "EnableCorrelationLogs";
+    public static final String CORRELATION_MDC_PROPERTY = "Correlation-ID";
     public static final String CORRELATION_LOGGER = "CORRELATION_LOGGER";
+    public static final String CORRELATION_REQ_SEND_TO_BACKEND = "REQUEST_SENT_TIME";
+    public static final String CORRELATION_REQUEST_ARRIVED = "REQUEST_RECEIVED_TIME";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -242,4 +242,6 @@ public class PassThroughConstants {
     public static final String CORRELATION_ID = "correlation_id";
     public  static final  String CORRELATION_TIME= "correlation_time";
     public  static final  String CORRELATION_LOGS_SYS_PROPERTY= "EnableCorrelationLogs";
+    public static  final String CORRELATION_MDC_PROPERTY = "Correlation-ID";
+    public static final String CORRELATION_LOGGER = "CORRELATION_LOGGER";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -237,14 +237,14 @@ public class PassThroughConstants {
     //Check for invalid json message by parsing the input message
     public static final String FORCE_JSON_MESSAGE_VALIDATION = "force.json.message.validation";
 
-    /**constants for the EI observability*/
-    public static final String CORRELATION_ENABLE_STATE = "true";
-    public static final String CORRELATION_DISABLE_STATE = "false";
+    /**
+     * constants for the EI observability
+     */
     public static final String CORRELATION_LOG_STATE_PROPERTY = "correlationLogState";
     public static final String CORRELATION_ID = "correlation_id";
     public static final String CORRELATION_LOGS_SYS_PROPERTY = "EnableCorrelationLogs";
     public static final String CORRELATION_MDC_PROPERTY = "Correlation-ID";
     public static final String CORRELATION_LOGGER = "CORRELATION_LOGGER";
-    public static final String CORRELATION_REQ_SEND_TO_BACKEND = "REQUEST_SENT_TIME";
-    public static final String CORRELATION_REQUEST_ARRIVED = "REQUEST_RECEIVED_TIME";
+    public static final String CORRELATION_REQ_SEND_TO_BACKEND_TIME = "REQUEST_SENT_TIME";
+    public static final String CORRELATION_REQUEST_ARRIVED_TIME = "REQUEST_RECEIVED_TIME";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -152,8 +152,6 @@ public class PassThroughHttpListener implements TransportListener {
         portParam.getParameterElement().setText(String.valueOf(operatingPort));
 
         System.setProperty(transportInDescription.getName() + ".nio.port", String.valueOf(operatingPort));
-        String correlationSysStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
-        cfgCtx.setProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY, correlationSysStatus);
 
         Object obj = cfgCtx.getProperty(PassThroughConstants.PASS_THROUGH_TRANSPORT_WORKER_POOL);
         WorkerPool workerPool = null;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -152,6 +152,8 @@ public class PassThroughHttpListener implements TransportListener {
         portParam.getParameterElement().setText(String.valueOf(operatingPort));
 
         System.setProperty(transportInDescription.getName() + ".nio.port", String.valueOf(operatingPort));
+        String correlationSysStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
+        cfgCtx.setProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY, correlationSysStatus);
 
         Object obj = cfgCtx.getProperty(PassThroughConstants.PASS_THROUGH_TRANSPORT_WORKER_POOL);
         WorkerPool workerPool = null;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -464,7 +464,19 @@ public class ServerWorker implements Runnable {
 //        msgContext.setProperty(Constants.OUT_TRANSPORT_INFO, this);
         
         NHttpServerConnection conn = request.getConnection();
-        
+
+
+        //observability measurements
+        boolean correlationEnabled = conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        if(correlationEnabled) {
+            msgContext.setProperty(PassThroughConstants.CORRELATION_ID, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
+            msgContext.setProperty(PassThroughConstants.CORRELATION_TIME, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_TIME));
+        }
+        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY));
+        //observability code ends here
+
+
+
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()
                 .getTransportOut(Constants.TRANSPORT_HTTPS));

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -465,8 +465,7 @@ public class ServerWorker implements Runnable {
         
         NHttpServerConnection conn = request.getConnection();
         //observability measurements
-        boolean correlationLoggingEnabled = sourceConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-        if (correlationLoggingEnabled) {
+        if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(sourceConfiguration.getCorrelationStatus())) {
             msgContext.setProperty(PassThroughConstants.CORRELATION_ID, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
             msgContext.setProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED));
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -465,12 +465,12 @@ public class ServerWorker implements Runnable {
         
         NHttpServerConnection conn = request.getConnection();
         //observability measurements
-        if (sourceConfiguration.getCorrelationStatus()) {
+        if (sourceConfiguration.isCorrelationLoggingEnabled()) {
             msgContext.setProperty(PassThroughConstants.CORRELATION_ID,
                     conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
         }
         msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY,
-                sourceConfiguration.getCorrelationStatus());
+                sourceConfiguration.isCorrelationLoggingEnabled());
         //observability code ends here
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -465,14 +465,12 @@ public class ServerWorker implements Runnable {
         
         NHttpServerConnection conn = request.getConnection();
         //observability measurements
-        boolean correlationLoggingEnabled = conn.getContext().
-                getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-        if(correlationLoggingEnabled) {
+        boolean correlationLoggingEnabled = sourceConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        if (correlationLoggingEnabled) {
             msgContext.setProperty(PassThroughConstants.CORRELATION_ID, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
-            msgContext.setProperty(PassThroughConstants.CORRELATION_TIME, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_TIME));
+            msgContext.setProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED));
         }
-        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY,
-                conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY));
+        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, sourceConfiguration.getCorrelationStatus());
         //observability code ends here
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -464,19 +464,16 @@ public class ServerWorker implements Runnable {
 //        msgContext.setProperty(Constants.OUT_TRANSPORT_INFO, this);
         
         NHttpServerConnection conn = request.getConnection();
-
-
         //observability measurements
-        boolean correlationEnabled = conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-        if(correlationEnabled) {
+        boolean correlationLoggingEnabled = conn.getContext().
+                getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        if(correlationLoggingEnabled) {
             msgContext.setProperty(PassThroughConstants.CORRELATION_ID, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
             msgContext.setProperty(PassThroughConstants.CORRELATION_TIME, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_TIME));
         }
-        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY));
+        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY,
+                conn.getContext().getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY));
         //observability code ends here
-
-
-
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()
                 .getTransportOut(Constants.TRANSPORT_HTTPS));

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -465,11 +465,12 @@ public class ServerWorker implements Runnable {
         
         NHttpServerConnection conn = request.getConnection();
         //observability measurements
-        if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(sourceConfiguration.getCorrelationStatus())) {
-            msgContext.setProperty(PassThroughConstants.CORRELATION_ID, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
-            msgContext.setProperty(PassThroughConstants.CORRELATION_REQUEST_ARRIVED, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED));
+        if (sourceConfiguration.getCorrelationStatus()) {
+            msgContext.setProperty(PassThroughConstants.CORRELATION_ID,
+                    conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
         }
-        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY, sourceConfiguration.getCorrelationStatus());
+        msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY,
+                sourceConfiguration.getCorrelationStatus());
         //observability code ends here
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -133,9 +133,7 @@ public class SourceHandler implements NHttpServerEventHandler {
 
             }
             //check correlationEnabling parameter
-            String correlationStatus = sourceConfiguration.getCorrelationStatus();
-            boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-            if (correlationLoggingEnabled) {
+            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(sourceConfiguration.getCorrelationStatus())) {
                 setCorrelationId(httpContext, request);
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, httpContext.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                 correlationLog.info(" | HTTP | " + httpContext.getAttribute("http.connection") + " | "
@@ -304,9 +302,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                 response.start(conn);
                 conn.getContext().setAttribute(PassThroughConstants.RES_TO_CLIENT_WRITE_START_TIME,
                         System.currentTimeMillis());
-                String correlationStatus = sourceConfiguration.getCorrelationStatus();
-                boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-                if (correlationLoggingEnabled) {
+                if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(sourceConfiguration.getCorrelationStatus())) {
                     MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                     correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | RESPONSE WRITE STARTED");
                     MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
@@ -383,8 +379,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                 context.setAttribute(PassThroughConstants.RES_TO_CLIENT_WRITE_END_TIME,departure);
                 context.setAttribute(PassThroughConstants.RES_DEPARTURE_TIME,departure);
 
-                boolean correlationLoggingEnabled = sourceConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-                if (correlationLoggingEnabled) {
+                if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(sourceConfiguration.getCorrelationStatus())) {
                     long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_REQUEST_ARRIVED);
                     MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                     correlationLog.info(" | HTTP | " + context.getAttribute("http.connection") + " | RESPONSE WRITE COMPLETE");

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -58,7 +58,7 @@ import java.util.Properties;
 public class TargetHandler implements NHttpClientEventHandler {
     private static Log log = LogFactory.getLog(TargetHandler.class);
 
-    /**log for correlationLog*/
+    /** log for correlation.log */
     private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
 
@@ -174,11 +174,13 @@ public class TargetHandler implements NHttpClientEventHandler {
                 targetConfiguration.getMetrics().incrementMessagesSent();
             }
             context.setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME, System.currentTimeMillis());
-            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
+            if (targetConfiguration.getCorrelationStatus()) {
                 long corTime = System.currentTimeMillis();
-                context.setAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND, corTime);
-                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID));
-                correlationLog.info(" | HTTP | " + context.getAttribute("http.connection") + " | REQUEST WRITE STARTED");
+                context.setAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND_TIME, corTime);
+                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,
+                        context.getAttribute(PassThroughConstants.CORRELATION_ID));
+                correlationLog.info(" | HTTP State | " + context.getAttribute("http.connection")
+                        + " | REQUEST WRITE STARTED");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
             }
             context.setAttribute(PassThroughConstants.REQ_DEPARTURE_TIME, System.currentTimeMillis());
@@ -322,12 +324,15 @@ public class TargetHandler implements NHttpClientEventHandler {
             NHttpServerConnection sourceConn =
                     (NHttpServerConnection) requestMsgContext.getProperty(PassThroughConstants.PASS_THROUGH_SOURCE_CONNECTION);
             //check correlation logs enabled
-            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
+            if (targetConfiguration.getCorrelationStatus()) {
                 long corTime = System.currentTimeMillis();
-                long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND);
-                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
-                correlationLog.info(" | HTTP | " + context.getAttribute("http.connection")+" | RESPONSE READ STARTED");
-                correlationLog.info((corTime-startTime)+" | HTTP | "+context.getAttribute("http.request")+" | BACKEND LATENCY" );
+                long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND_TIME);
+                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,
+                        context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
+                correlationLog.info(" | HTTP State | " +
+                        context.getAttribute("http.connection") + " | RESPONSE READ STARTED");
+                correlationLog.info((corTime - startTime) + " | HTTP | " +
+                        context.getAttribute("http.request") + " | BACKEND LATENCY");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
                 //Observability code ends here
             }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -174,9 +174,7 @@ public class TargetHandler implements NHttpClientEventHandler {
                 targetConfiguration.getMetrics().incrementMessagesSent();
             }
             context.setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME, System.currentTimeMillis());
-            String correlationStatus = targetConfiguration.getCorrelationStatus();
-            boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-            if (correlationLoggingEnabled) {
+            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
                 long corTime = System.currentTimeMillis();
                 context.setAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND, corTime);
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID));
@@ -324,8 +322,7 @@ public class TargetHandler implements NHttpClientEventHandler {
             NHttpServerConnection sourceConn =
                     (NHttpServerConnection) requestMsgContext.getProperty(PassThroughConstants.PASS_THROUGH_SOURCE_CONNECTION);
             //check correlation logs enabled
-            boolean correlationLoggingEnabled = targetConfiguration.getCorrelationStatus().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-            if (correlationLoggingEnabled) {
+            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
                 long corTime = System.currentTimeMillis();
                 long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND);
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -59,7 +59,7 @@ public class TargetHandler implements NHttpClientEventHandler {
     private static Log log = LogFactory.getLog(TargetHandler.class);
 
     /**log for correlationLog*/
-    private static final Log correlate = LogFactory.getLog("CORRELATION_LOGGER");
+    private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
 
     /** Delivery agent */
@@ -268,17 +268,16 @@ public class TargetHandler implements NHttpClientEventHandler {
 
     public void responseReceived(NHttpClientConnection conn) {
         HttpContext context = conn.getContext();
-
         //check correlation logs enabled
-        boolean correlationEnabled = context.getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-
-        if(correlationEnabled) {
-            long cor_time = System.currentTimeMillis();
-            long start_time = (long) context.getAttribute(PassThroughConstants.CORRELATION_TIME);
-            MDC.put("Correlation-ID", context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
-            correlate.info((cor_time - start_time) + "| HTTP");
-            MDC.remove("Correlation-ID");
-            context.setAttribute(PassThroughConstants.CORRELATION_TIME, cor_time);
+        boolean correlationLoggingEnabled = context.getAttribute(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY).toString().
+                equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+        if(correlationLoggingEnabled) {
+            long corTime = System.currentTimeMillis();
+            long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_TIME);
+            MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, context.getAttribute(PassThroughConstants.CORRELATION_ID).toString());
+            correlationLog.info((corTime - startTime) + "| HTTP | "+ context.getAttribute("http.connection"));
+            MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
+            context.setAttribute(PassThroughConstants.CORRELATION_TIME, corTime);
             //Observability code ends here
         }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -61,7 +61,6 @@ public class TargetHandler implements NHttpClientEventHandler {
     /** log for correlation.log */
     private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
-
     /** Delivery agent */
     private final DeliveryAgent deliveryAgent;
 
@@ -174,7 +173,7 @@ public class TargetHandler implements NHttpClientEventHandler {
                 targetConfiguration.getMetrics().incrementMessagesSent();
             }
             context.setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME, System.currentTimeMillis());
-            if (targetConfiguration.getCorrelationStatus()) {
+            if (targetConfiguration.isCorrelationLoggingEnabled()) {
                 long corTime = System.currentTimeMillis();
                 context.setAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND_TIME, corTime);
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,
@@ -324,7 +323,7 @@ public class TargetHandler implements NHttpClientEventHandler {
             NHttpServerConnection sourceConn =
                     (NHttpServerConnection) requestMsgContext.getProperty(PassThroughConstants.PASS_THROUGH_SOURCE_CONNECTION);
             //check correlation logs enabled
-            if (targetConfiguration.getCorrelationStatus()) {
+            if (targetConfiguration.isCorrelationLoggingEnabled()) {
                 long corTime = System.currentTimeMillis();
                 long startTime = (long) context.getAttribute(PassThroughConstants.CORRELATION_REQ_SEND_TO_BACKEND_TIME);
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -381,7 +381,7 @@ public class TargetRequest {
         if (encoder.isCompleted()) {
           conn.getContext().setAttribute(PassThroughConstants.REQ_DEPARTURE_TIME, System.currentTimeMillis());
           conn.getContext().setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME,System.currentTimeMillis());
-            if (targetConfiguration.getCorrelationStatus()) {
+            if (targetConfiguration.isCorrelationLoggingEnabled()) {
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,
                         conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                 correlationLog.info(" | HTTP State | "

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -90,7 +90,7 @@ public class TargetRequest {
     private boolean hasEntityBody = true;
     /** Keep alive request */
     private boolean keepAlive = true;
-    /**logger for correlation log*/
+    /** logger for correlation.log */
     private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
 
@@ -381,9 +381,11 @@ public class TargetRequest {
         if (encoder.isCompleted()) {
           conn.getContext().setAttribute(PassThroughConstants.REQ_DEPARTURE_TIME, System.currentTimeMillis());
           conn.getContext().setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME,System.currentTimeMillis());
-            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
-                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
-                correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | REQUEST WRITE COMPLETE");
+            if (targetConfiguration.getCorrelationStatus()) {
+                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY,
+                        conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
+                correlationLog.info(" | HTTP State | "
+                        + conn.getContext().getAttribute("http.connection") + " | REQUEST WRITE COMPLETE");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
             }
             targetConfiguration.getMetrics().

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -381,9 +381,7 @@ public class TargetRequest {
         if (encoder.isCompleted()) {
           conn.getContext().setAttribute(PassThroughConstants.REQ_DEPARTURE_TIME, System.currentTimeMillis());
           conn.getContext().setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME,System.currentTimeMillis());
-            String correlationStatus = targetConfiguration.getCorrelationStatus();
-            boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-            if (correlationLoggingEnabled) {
+            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                 correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | REQUEST WRITE COMPLETE");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -62,7 +62,7 @@ public class TargetResponse {
     private boolean expectResponseBody = true;
     /** Whether to shutdown connection after response completion*/
     private boolean forceShutdownConnectionOnComplete = false;
-    /**logger for correlation log*/
+    /** logger for correlation.log */
     private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
     public TargetResponse(TargetConfiguration targetConfiguration,
@@ -149,9 +149,11 @@ public class TargetResponse {
             conn.getContext().setAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_END_TIME,System.currentTimeMillis());
             conn.getContext().setAttribute(PassThroughConstants.RES_ARRIVAL_TIME,System.currentTimeMillis());
             TargetContext.updateState(conn, ProtocolState.RESPONSE_DONE);
-            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
-                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
-                correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | RESPONSE READ COMPLETE");
+            if (targetConfiguration.getCorrelationStatus()) {
+                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().
+                        getAttribute(PassThroughConstants.CORRELATION_ID).toString());
+                correlationLog.info(" | HTTP State | "
+                        + conn.getContext().getAttribute("http.connection") + " | RESPONSE READ COMPLETE");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
             }
             targetConfiguration.getMetrics().notifyReceivedMessageSize(

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -149,7 +149,7 @@ public class TargetResponse {
             conn.getContext().setAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_END_TIME,System.currentTimeMillis());
             conn.getContext().setAttribute(PassThroughConstants.RES_ARRIVAL_TIME,System.currentTimeMillis());
             TargetContext.updateState(conn, ProtocolState.RESPONSE_DONE);
-            if (targetConfiguration.getCorrelationStatus()) {
+            if (targetConfiguration.isCorrelationLoggingEnabled()) {
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().
                         getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                 correlationLog.info(" | HTTP State | "

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -149,9 +149,7 @@ public class TargetResponse {
             conn.getContext().setAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_END_TIME,System.currentTimeMillis());
             conn.getContext().setAttribute(PassThroughConstants.RES_ARRIVAL_TIME,System.currentTimeMillis());
             TargetContext.updateState(conn, ProtocolState.RESPONSE_DONE);
-            String correlationStatus = targetConfiguration.getCorrelationStatus();
-            boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
-            if (correlationLoggingEnabled) {
+            if (PassThroughConstants.CORRELATION_ENABLE_STATE.equals(targetConfiguration.getCorrelationStatus())) {
                 MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
                 correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | RESPONSE READ COMPLETE");
                 MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -17,11 +17,14 @@
 package org.apache.synapse.transport.passthru;
 
 import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.*;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.nio.ContentDecoder;
 import org.apache.http.nio.NHttpClientConnection;
+import org.apache.log4j.MDC;
 import org.apache.synapse.transport.http.conn.LoggingNHttpClientConnection;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 
@@ -59,6 +62,8 @@ public class TargetResponse {
     private boolean expectResponseBody = true;
     /** Whether to shutdown connection after response completion*/
     private boolean forceShutdownConnectionOnComplete = false;
+    /**logger for correlation log*/
+    private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
     public TargetResponse(TargetConfiguration targetConfiguration,
                           HttpResponse response,
@@ -144,7 +149,13 @@ public class TargetResponse {
             conn.getContext().setAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_END_TIME,System.currentTimeMillis());
             conn.getContext().setAttribute(PassThroughConstants.RES_ARRIVAL_TIME,System.currentTimeMillis());
             TargetContext.updateState(conn, ProtocolState.RESPONSE_DONE);
-
+            String correlationStatus = targetConfiguration.getCorrelationStatus();
+            boolean correlationLoggingEnabled = correlationStatus.equals(PassThroughConstants.CORRELATION_ENABLE_STATE);
+            if (correlationLoggingEnabled) {
+                MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID).toString());
+                correlationLog.info(" | HTTP | " + conn.getContext().getAttribute("http.connection") + " | RESPONSE READ COMPLETE");
+                MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
+            }
             targetConfiguration.getMetrics().notifyReceivedMessageSize(
                     conn.getMetrics().getReceivedBytesCount());
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -61,7 +61,7 @@ public abstract class BaseConfiguration {
 
     protected PassThroughConfiguration conf = PassThroughConfiguration.getInstance();
 
-    private Boolean correlationStatus = false;
+    private Boolean correlationLoggingEnabled = false;
 
     private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
     private static final String PASSTHROUGH_THREAD_ID ="PassThroughMessageProcessor";
@@ -93,7 +93,7 @@ public abstract class BaseConfiguration {
         ioReactorConfig = buildIOReactorConfig();
         String sysCorrelationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
         if (sysCorrelationStatus != null) {
-            correlationStatus = sysCorrelationStatus.equalsIgnoreCase("true");
+            correlationLoggingEnabled = sysCorrelationStatus.equalsIgnoreCase("true");
         }
 
         bufferFactory = new BufferFactory(iOBufferSize, new HeapByteBufferAllocator(), 512);
@@ -180,6 +180,6 @@ public abstract class BaseConfiguration {
         return metrics;
     }
 
-    public Boolean getCorrelationStatus(){return correlationStatus;}
+    public Boolean isCorrelationLoggingEnabled(){return correlationLoggingEnabled;}
 
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 import org.apache.http.protocol.HTTP;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
 import org.apache.synapse.transport.passthru.util.BufferFactory;
 
@@ -60,6 +61,8 @@ public abstract class BaseConfiguration {
 
     protected PassThroughConfiguration conf = PassThroughConfiguration.getInstance();
 
+    private String correlationStatus = null;
+
     private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
     private static final String PASSTHROUGH_THREAD_ID ="PassThroughMessageProcessor";
 
@@ -88,6 +91,12 @@ public abstract class BaseConfiguration {
 
         httpParams = buildHttpParams();
         ioReactorConfig = buildIOReactorConfig();
+        correlationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
+        if (correlationStatus != null) {
+            correlationStatus = correlationStatus.toLowerCase();
+        } else {
+            correlationStatus = PassThroughConstants.CORRELATION_DISABLE_STATE;
+        }
 
         bufferFactory = new BufferFactory(iOBufferSize, new HeapByteBufferAllocator(), 512);
     }
@@ -172,5 +181,7 @@ public abstract class BaseConfiguration {
     public PassThroughTransportMetricsCollector getMetrics() {
         return metrics;
     }
+
+    public String getCorrelationStatus(){return correlationStatus;}
 
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -61,7 +61,7 @@ public abstract class BaseConfiguration {
 
     protected PassThroughConfiguration conf = PassThroughConfiguration.getInstance();
 
-    private String correlationStatus = null;
+    private Boolean correlationStatus = false;
 
     private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
     private static final String PASSTHROUGH_THREAD_ID ="PassThroughMessageProcessor";
@@ -91,11 +91,9 @@ public abstract class BaseConfiguration {
 
         httpParams = buildHttpParams();
         ioReactorConfig = buildIOReactorConfig();
-        correlationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
-        if (correlationStatus != null) {
-            correlationStatus = correlationStatus.toLowerCase();
-        } else {
-            correlationStatus = PassThroughConstants.CORRELATION_DISABLE_STATE;
+        String sysCorrelationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
+        if (sysCorrelationStatus != null) {
+            correlationStatus = sysCorrelationStatus.equalsIgnoreCase("true");
         }
 
         bufferFactory = new BufferFactory(iOBufferSize, new HeapByteBufferAllocator(), 512);
@@ -182,6 +180,6 @@ public abstract class BaseConfiguration {
         return metrics;
     }
 
-    public String getCorrelationStatus(){return correlationStatus;}
+    public Boolean getCorrelationStatus(){return correlationStatus;}
 
 }


### PR DESCRIPTION
## Purpose
Added code to implement observability feature in EI. This will create a correlation log (if enabled by the user) for each request, indicating the time at different places in the transport.

## Goals
Add correlation logs (enabled by system properties), to help locate issues in transport.

## Approach
Added code to SourceHandler, ServerWorker, DeliveryAgent, TargetHandler(nhttp), BaseConfiguration, TargetRequest, TargetResponse CloneMediator and SynapseConstants classes.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
-Following is a log generated for a simple request.

09 Oct 2018 15:33:42,449 | REST-0000-0000-0000-0004 | HTTP-Listener I/O dispatcher-2 |  | HTTP | http-incoming-2 | GET | /api/querydoctor/surgery | REQUEST ARRIVED
09 Oct 2018 15:33:42,851 | REST-0000-0000-0000-0004 | HTTP-Sender I/O dispatcher-4 |  | HTTP | http-outgoing-4 | REQUEST WRITE STARTED
09 Oct 2018 15:33:43,103 | REST-0000-0000-0000-0004 | HTTP-Sender I/O dispatcher-4 |  | HTTP | http-outgoing-4 | RESPONSE READ STARTED
09 Oct 2018 15:33:43,103 | REST-0000-0000-0000-0004 | HTTP-Sender I/O dispatcher-4 | 252 | HTTP | GET /healthcare/surgery [Cookie: SERVERID=s0, Accept: */*, Cache-Control: no-cache, correlation_id: REST-0000-0000-0000-0004, Postman-Token: 2905e360-6a2e-b4eb-60fb-2ebfb22a9eaa, Accept-Encoding: gzip, deflate, Accept-Language: en-US,en;q=0.9,si;q=0.8, Host: wso2training-restsamples.wso2apps.com, Connection: Keep-Alive, User-Agent: Synapse-PT-HttpComponents-NIO] | BACKEND LATENCY
09 Oct 2018 15:33:43,104 | REST-0000-0000-0000-0004 | HTTP-Sender I/O dispatcher-4 |  | HTTP | http-outgoing-4 | RESPONSE READ COMPLETE
09 Oct 2018 15:33:43,106 | REST-0000-0000-0000-0004 | HTTP-Listener I/O dispatcher-2 |  | HTTP | http-incoming-2 | RESPONSE WRITE STARTED
09 Oct 2018 15:33:43,106 | REST-0000-0000-0000-0004 | HTTP-Listener I/O dispatcher-2 |  | HTTP | http-incoming-2 | RESPONSE WRITE COMPLETE
09 Oct 2018 15:33:43,106 | REST-0000-0000-0000-0004 | HTTP-Listener I/O dispatcher-2 | 657 | http-incoming-2 | HTTP | ROUND-TRIP LATENCY 


## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
macOS High Sierra, java version "1.8.0_171"
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.