### PR TITLE
Fix wso2/wso2-synapse#1197

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -276,6 +276,10 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.jettison.wso2</groupId>
 			<artifactId>jettison</artifactId>
 		</dependency>

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -31,7 +31,6 @@ import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
@@ -44,15 +43,20 @@ import org.apache.synapse.mediators.Value;
 import org.apache.synapse.util.AXIOMUtils;
 import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
+import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -512,7 +516,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
                 value = arg.getValue();
                 details.setXml(isXML(value));
                 if (!details.isXml()) {
-                    value = StringEscapeUtils.escapeXml(value);
+                    value = escapeXMLEnvelope(synCtx, value);
                 }
                 value = Matcher.quoteReplacement(value);
             } else if (arg.getExpression() != null) {
@@ -523,7 +527,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
                     // of the payload is XML.
                     details.setXml(isXML(value));
                     if (!details.isXml() && XML_TYPE.equals(getType()) && !isJson(value.trim(), arg.getExpression())) {
-                        value = StringEscapeUtils.escapeXml(value);
+                        value = escapeXMLEnvelope(synCtx, value);
                     }
                     value = Matcher.quoteReplacement(value);
                 } else {
@@ -658,6 +662,51 @@ public class PayloadFactoryMediator extends AbstractMediator {
     @Override
     public boolean isContentAltering() {
         return true;
+    }
+
+    /**
+     * Checks and returns XML version of the envelope
+     *
+     * @param msgCtx Message Context
+     * @return xmlVersion in XML Declaration
+     * @throws ParserConfigurationException failure in building message envelope document
+     * @throws IOException Error reading message envelope
+     * @throws SAXException Error parsing message envelope
+     */
+    private String checkXMLVersion(MessageContext msgCtx) throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        InputSource inputSource = new InputSource(new StringReader(msgCtx.getEnvelope().toString()));
+        Document document = documentBuilder.parse(inputSource);
+        return document.getXmlVersion();
+    }
+
+    /**
+     * Escapes XML special characters
+     *
+     * @param msgCtx Message Context
+     * @param value XML String which needs to be escaped
+     * @return XML special char escaped string
+     */
+    private String escapeXMLEnvelope(MessageContext msgCtx, String value) {
+        String xmlVersion = "1.0"; //Default is set to 1.0
+
+        try {
+            xmlVersion = checkXMLVersion(msgCtx);
+        } catch (IOException e) {
+            log.error("Error reading message envelope", e);
+        } catch (SAXException e) {
+            log.error("Error parsing message envelope", e);
+        } catch (ParserConfigurationException e) {
+            log.error("Error building message envelope document", e);
+        }
+
+        if("1.1".equals(xmlVersion)) {
+            return org.apache.commons.text.StringEscapeUtils.escapeXml11(value);
+        } else {
+            return org.apache.commons.text.StringEscapeUtils.escapeXml10(value);
+        }
+
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,11 @@
              <artifactId>commons-lang</artifactId>
              <version>${commons-lang.version}</version>
          </dependency>
+          <dependency>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-text</artifactId>
+              <version>${commons-text.version}</version>
+          </dependency>
          <dependency>
              <groupId>org.springframework</groupId>
              <artifactId>spring-core</artifactId>
@@ -1174,6 +1179,7 @@
       <groovy.version>1.1-rc-1</groovy.version>
       <servlet-api.version>2.3</servlet-api.version>
       <commons-lang.version>2.4</commons-lang.version>
+      <commons-text.version>1.6</commons-text.version>
       <snmp4j.version>2.0.3</snmp4j.version>
       <snmp4j.agent.version>2.0.5</snmp4j.agent.version>
       <project.scm.id>wso2-scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose
Use commons-text to escape xml messages in Payload factory. Previously XML envelop is escaped through commons-lang which didn't support emojis. commons-text support escaping special chars in both XML v1.0 and XML v1.1.
Issue - wso2/wso2-synapse#1197

## Goals
Support Emoji chars in payloads.

## Approach
Used commons-text v1.6 instead of commons-lang v2.4 which supports emojis and escaping other special characters.