### PR TITLE
Add fix for issue in setting content-type 

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -51,6 +51,7 @@ import org.apache.axis2.transport.http.HTTPTransportUtils;
 import org.apache.axis2.util.MessageContextBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpInetConnection;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -197,10 +198,9 @@ public class ServerWorker implements Runnable {
             // as per spec: https://tools.ietf.org/html/rfc2616#page-43
             if (HTTPConstants.HTTP_METHOD_GET.equals(httpMethod)) {
                 contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
-            } else {
-                Map transportHeaders = (Map) msgContext.getProperty(MessageContext.TRANSPORT_HEADERS);
-                String contentLength = transportHeaders.get(PassThroughConstants.HTTP_CONTENT_LENGTH).toString();
-                if (HTTPConstants.HTTP_METHOD_POST.equals(httpMethod) && Integer.parseInt(contentLength) != 0 ) {
+            } else if (HTTPConstants.HTTP_METHOD_POST.equals(httpMethod)) {
+                if (request.isEntityEnclosing() &&
+                        ((HttpEntityEnclosingRequest) request.getRequest()).getEntity().getContentLength() != 0) {
                     contentType = PassThroughConstants.APPLICATION_OCTET_STREAM;
                 }
             }


### PR DESCRIPTION
## Purpose
This PR contains changes to solve issues in adding content-type for the requests that are sent without content-type header. Current implementation adds content-type as application/octet-stream for all incoming requests that do not have content-type header, except GET method. This fix introduces the changes to add content-type as application/octet-stream for the POST request which has body but not content-type.
Relevant specification can be found in [here](https://tools.ietf.org/html/rfc2616#page-43). It fixes the issue - [Content-Type:application/octet-stream is added when no Content-type header is provided #3926](https://github.com/wso2/product-apim/issues/3926)