### PR TITLE
Fix [EI] Add escapeXmlChars attribute to payload factory mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -45,6 +45,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     private static final QName ATT_LITERAL = new QName("literal");
 
     private static final QName TYPE_Q = new QName("media-type");// media-type attribute in payloadFactory
+    private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");// escape xml chars attribute in payloadFactory
 
     private final String JSON_TYPE="json";
     private final String XML_TYPE="xml";
@@ -62,6 +63,9 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         } else {
             payloadFactoryMediator.setType(XML_TYPE);
         }
+
+        boolean escapeXmlCharsValue = Boolean.parseBoolean(elem.getAttributeValue(ESCAPE_XML_CHARS_Q));
+        payloadFactoryMediator.setEscapeXmlChars(escapeXmlCharsValue); //set the escape xml chars in json payloads for the PF
 
         OMElement formatElem = elem.getFirstChildWithName(FORMAT_Q);
         if (formatElem != null) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -40,6 +40,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
     private static final String EVALUATOR = "evaluator";
     private final String JSON_TYPE="json";
     private final String MEDIA_TYPE="media-type";
+    private final String ESCAPE_XML_CHARS="escapeXmlChars";
 
     private final String XML = "xml";
     private final String JSON = "json";
@@ -67,6 +68,11 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
 
         if(mediator.getType()!=null){
             payloadFactoryElem.addAttribute(fac.createOMAttribute(MEDIA_TYPE,null,mediator.getType()));
+        }
+
+        if (mediator.isEscapeXmlChars()) {
+            payloadFactoryElem.addAttribute(fac.createOMAttribute(ESCAPE_XML_CHARS,null,
+                    Boolean.toString(mediator.isEscapeXmlChars())));
         }
 
         saveTracingState(payloadFactoryElem, mediator);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -66,6 +66,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
     private boolean isFormatDynamic = false;
     private String formatRaw;
     private String mediaType = XML_TYPE;
+    private boolean escapeXmlChars = false;
     private final static String JSON_CONTENT_TYPE = "application/json";
     private final static String XML_CONTENT_TYPE  = "application/xml";
     private final static String TEXT_CONTENT_TYPE  = "text/plain";
@@ -334,7 +335,11 @@ public class PayloadFactoryMediator extends AbstractMediator {
                     String trimmedReplacementValue = replacementValue.trim();
                     // This is to replace " with \" and \\ with \\\\
                     //replacing other json special characters i.e \b, \f, \n \r, \t
-                    if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) {
+                    if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE) &&
+                            isEscapeXmlChars()) {
+                        //checks whether the escapeXmlChars attribute is true when media-type and evaluator is json and
+                        //escapes xml chars. otherwise json messages with non escaped xml characters will fail to build
+                        //in content aware mediators.
                         replacementValue = escapeXMLSpecialChars(replacementValue);
                     }
                     else if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE) &&
@@ -660,4 +665,11 @@ public class PayloadFactoryMediator extends AbstractMediator {
         return true;
     }
 
+    public boolean isEscapeXmlChars() {
+        return escapeXmlChars;
+    }
+
+    public void setEscapeXmlChars(boolean escapeXmlChars) {
+        this.escapeXmlChars = escapeXmlChars;
+    }
 }


### PR DESCRIPTION
## Purpose
Add escapeXmlChars attribute to payload factory mediator. This attribute will escape xml characters in json payloads if set to true.
Issue - https://github.com/wso2/product-ei/issues/2810
Related PR - https://github.com/wso2-support/wso2-synapse/pull/439
