### PR TITLE
Fixed the 'http DELETE is not working without its content-type header'

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -220,20 +220,55 @@ public class RelayUtils {
      * @param msgContext MessageContext
      * @return whether the request is a DELETE without payload
      */
-    public static boolean isDeleteRequestWithoutPayload (MessageContext msgContext) {
+    public static boolean isDeleteRequestWithoutPayload (MessageContext msgContext) throws AxisFault {
         if (PassThroughConstants.HTTP_DELETE.equals(msgContext.getProperty(Constants.Configuration.HTTP_METHOD))) {
 
             //If message builder not invoked (Passthrough may contain entity body) OR delete with payload
             if (!Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED)) ||
                     !Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.NO_ENTITY_BODY))) {
                 //HTTP DELETE request with payload
-                return false;
+                if (!isEmptyPayloadStream(msgContext)) {
+                    return false;
+                }
             }
             //Empty payload delete request
             return true;
         }
         //Not a HTTP DELETE request
         return false;
+    }
+
+    private static boolean isEmptyPayloadStream(MessageContext messageContext) throws AxisFault {
+
+        boolean isEmpty = false;
+        BufferedInputStream bufferedInputStream = (BufferedInputStream) messageContext
+                .getProperty(PassThroughConstants.BUFFERED_INPUT_STREAM);
+        if (bufferedInputStream != null) {
+            try {
+                bufferedInputStream.reset();
+                bufferedInputStream.mark(0);
+            } catch (Exception e) {
+                // just ignore the error
+            }
+
+        } else {
+            final Pipe pipe = (Pipe) messageContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);
+            if (pipe != null) {
+                InputStream in = pipe.getInputStream();
+                bufferedInputStream = new BufferedInputStream(in);
+                // TODO: need to handle properly for the moment lets use around 100k
+                // buffer.
+                bufferedInputStream.mark(128 * 1024);
+                messageContext.setProperty(PassThroughConstants.BUFFERED_INPUT_STREAM,
+                        bufferedInputStream);
+            }
+        }
+        try {
+            isEmpty = RelayUtils.isEmptyPayloadStream(bufferedInputStream);
+        } catch (IOException e) {
+            handleException("Error while checking Message Payload Exists ", e);
+        }
+        return isEmpty;
     }
 
     /**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -145,8 +145,8 @@ public class RelayUtils {
             try {
                 bufferedInputStream.reset();
                 bufferedInputStream.mark(0);
-            } catch (Exception e) {
-                // just ignore the error
+            } catch (IOException e) {
+                handleException("Error while checking bufferedInputStream", e);
             }
 
         } else {
@@ -210,7 +210,6 @@ public class RelayUtils {
         }
         return;
     }
-
 
 
     /**


### PR DESCRIPTION
## Purpose
These fixes are resolved the issue in delete service since it is not working without the content-type header.

## Approach
when payload stream of DeleteRequest is empty, it needs to return false in the method.


#https://github.com/wso2/product-apim/issues/4033