### PR TITLE
Fix synapse cache update issue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
@@ -928,7 +928,9 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
                 o.entryRemoved((Entry) entry);
             }
         } else {
-            handleException("No entry exists by the key : " + key);
+            if (log.isDebugEnabled()) {
+                log.debug("No entry exists by the key : " + key);
+            }
         }
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -573,23 +573,6 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
      * @param synapseEnvironment synapse environment
      */
     public void init(SynapseEnvironment synapseEnvironment) {
-        if (Boolean.parseBoolean(synapseEnvironment.getSynapseConfiguration()
-                .getProperty(SYNAPSE_VALIDATE_MEDIATOR_REDEPLOYMENT_CACHE_CLEAR))) {
-            for (Value schemaKey : schemaKeys) {
-                Entry entry = synapseEnvironment.getSynapseConfiguration().getEntryDefinition(schemaKey.getKeyValue());
-                if (entry != null) {
-                    synapseEnvironment.getSynapseConfiguration().removeEntry(schemaKey.getKeyValue());
-                }
-            }
-            if (resourceMap != null && resourceMap.getResources().size() > 0) {
-                for (Map.Entry<String, String> resource : resourceMap.getResources().entrySet()) {
-                    Entry entry = synapseEnvironment.getSynapseConfiguration().getEntryDefinition(resource.getValue());
-                    if (entry != null) {
-                        synapseEnvironment.getSynapseConfiguration().removeEntry(resource.getValue());
-                    }
-                }
-            }
-        }
         super.init(synapseEnvironment);
     }
 


### PR DESCRIPTION
## Purpose
> Synapse cache maintain its own cache to store registry entries. When the registry resource get change, ESB should be restart or wait until cachableDuration to clear the mediation cache. This PR is to instead of waiting for cachableDuration, remove relavant entry in Synapse cache when registry is updated.

## Approach
> Registry handler can be used to send notification to Synapse cache if some registry entry is changed. New RegistryCachingHandler handler class added to the Carbon mediation to clear cache in Synapse cache. This handler will remove cache for put, delete, rename and move operations on registry entry.  

Resolve https://github.com/wso2/product-ei/issues/2361