### PR TITLE
Fix invalid configuration in multi-ssl-profile.xml breaking all the API Call issue

### DIFF
--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -48,7 +48,8 @@
 			                org.apache.synapse.transport.passthru.*,
 			                org.apache.synapse.transport.certificatevalidation.*,
                             org.apache.synapse.transport.dynamicconfigurations.*,
-                            org.apache.synapse.transport.customlogsetter.*
+                            org.apache.synapse.transport.customlogsetter.*,
+                            org.apache.synapse.transport.exceptions.*
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.namespace,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/exceptions/InvalidConfigurationException.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/exceptions/InvalidConfigurationException.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.synapse.transport.exceptions;
+/**
+ * This class is used for handling SSL configuration error which is identify at runtime
+ */
+public class InvalidConfigurationException extends RuntimeException {
+    public InvalidConfigurationException() {
+        super();
+    }
+    public InvalidConfigurationException(String s) {
+        super(s);
+    }
+    public InvalidConfigurationException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+    public InvalidConfigurationException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/HttpCoreNIOSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/HttpCoreNIOSender.java
@@ -74,6 +74,7 @@ import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.commons.util.TemporaryData;
+import org.apache.synapse.transport.exceptions.InvalidConfigurationException;
 import org.apache.synapse.transport.http.conn.ClientConnFactory;
 import org.apache.synapse.transport.http.conn.ProxyConfig;
 import org.apache.synapse.transport.nhttp.config.ClientConnFactoryBuilder;
@@ -1023,18 +1024,22 @@ public class HttpCoreNIOSender extends AbstractHandler implements TransportSende
      */
     public void reload(TransportOutDescription transportOut) throws AxisFault {
         log.info("HttpCoreNIOSender reloading SSL Config..");
-        //create new connection factory
-        ClientConnFactoryBuilder contextBuilder = initConnFactoryBuilder(transportOut);
-        connFactory = contextBuilder.createConnFactory(params);
+        try {
+            //create new connection factory
+            ClientConnFactoryBuilder contextBuilder = initConnFactoryBuilder(transportOut);
+            connFactory = contextBuilder.createConnFactory(params);
 
-        //set new connection factory
-        handler.setConnFactory(connFactory);
-        iodispatch.setConnFactory(connFactory);
+            //set new connection factory
+            handler.setConnFactory(connFactory);
+            iodispatch.setConnFactory(connFactory);
 
-        //close existing connections to apply new settings
-        handler.resetConnectionPool(connFactory.getHostList());
+            //close existing connections to apply new settings
+            handler.resetConnectionPool(connFactory.getHostList());
 
-        log.info("HttpCoreNIO " + name + " Sender updated with Dynamic Configuration Updates ...");
+            log.info("HttpCoreNIO " + name + " Sender updated with Dynamic Configuration Updates ...");
+        } catch (InvalidConfigurationException configFault) {
+            log.error("Ignoring reload SSL config since there is an invalid configuration.", configFault);
+        }
     }
 
 }


### PR DESCRIPTION
### Purpose
Resolves https://github.com/wso2/wso2-synapse/issues/1226
### Goal
When there is a configuration error in the initial startup. The server will shut down immediately.
If there is a configuration error in dynamically updated SSL, the server will continue to process ignoring that update.
### Approach
Throw runtime exception if there is an issue in the configuration. This will stop the server startup. If there is an error in dynamic change path, catch that specific runtime exception and ignore the update and proceed.