### PR TITLE
Clone OMElement to allow modifications from multiple threads

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -212,9 +212,9 @@ public class PayloadFactoryMediator extends AbstractMediator {
             }
             String text = "";
             if (entry instanceof OMElement) {
-                OMElement e = (OMElement) entry;
-                removeIndentations(e);
-                text = e.toString();
+                OMElement omElement = ((OMElement) entry).cloneOMElement();
+                removeIndentations(omElement);
+                text = omElement.toString();
             } else if (entry instanceof OMText) {
                 text = ((OMText) entry).getText();
             } else if (entry instanceof String) {


### PR DESCRIPTION
## Purpose
When using payload factory mediator where the format is defined dynamically within the registry, there could be a concurrency issue when multiple threads try to modify the same element (to trim indentations). Need to avoid that race condition.

## Approach
Fix is to clone the element before modifying.

Fixes wso2/product-ei#3006