### PR TITLE
Upgrade bouncycastle dependancy

### DIFF
--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/certificatevalidation/OCSPVerifierTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/certificatevalidation/OCSPVerifierTest.java
@@ -151,7 +151,7 @@ public class OCSPVerifierTest extends TestCase {
 
                 RevokedStatus revokedStatus = new RevokedStatus(new Date(), CRLReason.privilegeWithdrawn);
                 Date nextUpdate = new Date(new Date().getTime() + TestConstants.NEXT_UPDATE_PERIOD);
-                basicOCSPRespBuilder.addResponse(certID, revokedStatus, nextUpdate, null);
+                basicOCSPRespBuilder.addResponse(certID, revokedStatus, nextUpdate, (Extensions)null);
             } else {
                 basicOCSPRespBuilder.addResponse(certID, CertificateStatus.GOOD);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1107,7 +1107,7 @@
       <org.antlr.version>3.4</org.antlr.version>
       <com.jayway.jsonpath.version>0.8.0</com.jayway.jsonpath.version>
       <qfj.version>1.5.3</qfj.version>
-      <org.bouncycastle.version>1.52</org.bouncycastle.version>
+      <org.bouncycastle.version>1.60</org.bouncycastle.version>
       <hc.httpcore.version>4.3.3</hc.httpcore.version>
       <httpcore-nio.wso2.version>4.3.3-wso2v4</httpcore-nio.wso2.version>
       <hc.httpclient.version>4.3.2</hc.httpclient.version>


### PR DESCRIPTION
## Purpose
> To upgrade the bouncycastle dependency version from 1.52 to 1.60 and fixing a test case failing due to the upgrade.