### PR TITLE
Add capability to set an encrypted value for SFTP parameters

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
@@ -557,7 +557,13 @@ public class PollTableEntry extends AbstractPollTableEntry {
                 moveTimestampFormat = new SimpleDateFormat(moveFileTimestampFormat);
             }
 
-            setVfsSchemeProperties(VFSUtils.parseSchemeFileOptions(fileURI, params));
+            Map<String, String> schemeFileOptions = VFSUtils.parseSchemeFileOptions(fileURI, params);
+            if (schemeFileOptions != null) {
+                for (Map.Entry<String, String> schemeFileOption : schemeFileOptions.entrySet()) {
+                    schemeFileOption.setValue(decryptIfRequired(schemeFileOption.getValue()));
+                }
+            }
+            setVfsSchemeProperties(schemeFileOptions);
 
             String strStreaming = ParamUtils.getOptionalParam(params, VFSConstants.STREAMING);
             if (strStreaming != null) {


### PR DESCRIPTION
## Purpose
{wso2:vault-decrypt('encryptedVal')} format can be used to set encrypted values for transport.vfs.SFTPIdentities and transport.vfs.SFTPIdentityPassPhrase parameters.

Resolves: wso2/product-ei#3031

## Approach
Values provided in the above format are decrypted before using.
