### PR TITLE
Changed JmsConsumer receive wait time

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
@@ -83,7 +83,7 @@ public class JmsConsumer implements MessageConsumer {
         }
 
         try {
-            Message message = consumer.receive(1);
+            Message message = consumer.receive(5000);
             if (message == null) {
                 return null;
             }


### PR DESCRIPTION
- Changed the consumer.receive(1) to consumer.receive(500) for the
getMessage function defined in MessageProcessorAdminService to work

## Purpose
To make the PoisonMessage service functionality work
