### PR TITLE
Add out-only MEP to vfs transport

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportSender.java
@@ -162,12 +162,7 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
      */
     public void sendMessage(MessageContext msgCtx, String targetAddress,
                             OutTransportInfo outTransportInfo) throws AxisFault {
-
-        if (waitForSynchronousResponse(msgCtx)) {
-            throw new AxisFault("The VFS transport doesn't support synchronous responses. " +
-                    "Please use the appropriate (out only) message exchange pattern.");
-        }
-
+        setOutOnlyMep(msgCtx);
         VFSOutTransportInfo vfsOutInfo = null;
         if (targetAddress != null) {
             vfsOutInfo = new VFSOutTransportInfo(targetAddress, globalFileLockingFlag);
@@ -443,5 +438,13 @@ public class VFSTransportSender extends AbstractTransportSender implements Manag
             }
         }
         return null;
+    }
+
+    /** This method sets out-only as the message exchange pattern
+     * */
+    private void setOutOnlyMep(MessageContext msgCtx) {
+        if (msgCtx.getAxisOperation() != null && msgCtx.getAxisOperation().getMessageExchangePattern() != null) {
+            msgCtx.getAxisOperation().setMessageExchangePattern("http://www.w3.org/ns/wsdl/out-only");
+        }
     }
 }


### PR DESCRIPTION
## Purpose
> This enforces the out-only as the MEP in vfs transport and removes synchronous response waiting in vfs.

## Goals
> Resolves: https://github.com/wso2/product-ei/issues/3116

## Approach
> Enforces the out-only message exchange pattern in the vfs transport at vfsTransportSender and remove the waiting for synchronous responses. 

## User stories
> Sending a message to a proxy service and writing the reply to a local file using a vfs proxy

## Test environment
> java version "1.8.0_171"
> macOS High Sierra
 
