### PR TITLE
refactor: fix typo in RelayUtils.java

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -117,7 +117,7 @@ public class RelayUtils {
                     }
                 }
 
-                builldMessage(messageContext, earlyBuild, in);
+                buildMessage(messageContext, earlyBuild, in);
                 return;
             }
         } else {
@@ -130,7 +130,7 @@ public class RelayUtils {
         }
     }
 
-    public static void builldMessage(MessageContext messageContext, boolean earlyBuild,
+    public static void buildMessage(MessageContext messageContext, boolean earlyBuild,
                                      InputStream in) throws IOException, AxisFault {
         ByteArrayOutputStream byteArrayOutputStream = null;
         if (forceXmlValidation || forceJSONValidation) {


### PR DESCRIPTION

## Purpose
> Fix typo in `RelayUtils.java`: `builldMessage() --> buildMessage()` i.e. Remove redundant `l`.


