### PR TITLE
Fix for InlinedWSDLEndpointTestCase

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/WSDLEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/WSDLEndpointFactory.java
@@ -117,7 +117,6 @@ public class WSDLEndpointFactory extends DefaultEndpointFactory {
             String portName = wsdlElement.getAttributeValue(new QName("port"));
             // check if wsdl is supplied as a URI
             String wsdlURI = wsdlElement.getAttributeValue(new QName("uri"));
-            wsdlURI = ResolverFactory.getInstance().getResolver(wsdlURI).resolve();
             // set serviceName and portName in the endpoint. it does not matter if these are
             // null at this point. we are setting them only for serialization purpose.
             wsdlEndpoint.setServiceName(serviceName);
@@ -126,6 +125,7 @@ public class WSDLEndpointFactory extends DefaultEndpointFactory {
             String noParsing = properties.getProperty(SKIP_WSDL_PARSING);
 
             if (wsdlURI != null) {
+                wsdlURI = ResolverFactory.getInstance().getResolver(wsdlURI).resolve();
                 wsdlEndpoint.setWsdlURI(wsdlURI.trim());
                 if (noParsing == null || !JavaUtils.isTrueExplicitly(noParsing)) {
                     try {


### PR DESCRIPTION
## Purpose
Fixing java.lang.NullPointerException which occurs during 'org.wso2.carbon.esb.endpoint.test.InlinedWSDLEndpointTestCase.testInlineWSDLEndpoint' test case.