### PR TITLE
Set content length for empty POST/PUT request

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/StatisticIdentityGeneratorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/StatisticIdentityGeneratorTest.java
@@ -140,8 +140,9 @@ public class StatisticIdentityGeneratorTest {
      */
     @Test
     public void testReportingEndEvent() {
-        cleanUp();
+        addElementsForReportingEndEvent();
         StatisticIdentityGenerator.reportingEndEvent(COMPONENT, ComponentType.API, artifactHolder);
+        StatisticIdentityGenerator.reportingEndEvent(COMPONENT, ComponentType.SEQUENCE, artifactHolder);
         Assert.assertEquals("validating new parent value set by the method",
                 COMPONENT_ID, artifactHolder.getLastParent());
         Assert.assertEquals("stack must be empty since popped by the method", artifactHolder.getStack().size(), 0);
@@ -214,5 +215,17 @@ public class StatisticIdentityGeneratorTest {
         }
         artifactHolder.getList().add(structuringElement);
         artifactHolder.setId(0);
+    }
+
+    private void addElementsForReportingEndEvent() {
+        int size = artifactHolder.getStack().size();
+        if (size >= 1) {
+            while (size != 0) {
+                artifactHolder.getStack().pop();
+                size = artifactHolder.getStack().size();
+            }
+        }
+        artifactHolder.getStack().add(structuringElement);
+        artifactHolder.getStack().add(structuringElement);
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -212,16 +212,16 @@ public class TargetRequest {
 
             if (forceContentLength) {
                 entity.setChunked(false);
-                if (forceContentLengthCopy && contentLength > 0) {
+                if (forceContentLengthCopy && contentLength != -1) {
                     entity.setContentLength(contentLength);
                 }
-            }else{
-             if (contentLength != -1) {
-                entity.setChunked(false);
-                entity.setContentLength(contentLength);
             } else {
-                entity.setChunked(chunk);
-            }
+                if (contentLength != -1) {
+                    entity.setChunked(false);
+                    entity.setContentLength(contentLength);
+                } else {
+                    entity.setChunked(chunk);
+                }
             }
 
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

When forceContentLength property set to true, the content length header will be adding to the request going out from the EI.