### PR TITLE
Setting boolean values to the bean fails with argument type mismatch …

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyHelper.java
@@ -80,7 +80,7 @@ public class PropertyHelper {
                             method.invoke(obj, new Double[]{new Double(value)});
                         } else if (params[0].equals(boolean.class)) {
                             method = obj.getClass().getMethod(mName, boolean.class);
-                            method.invoke(obj, new Object[]{new Boolean[]{Boolean.valueOf(value)}});
+                            method.invoke(obj, new Boolean[]{Boolean.valueOf(value)});
                         } else {
                             handleException("Did not find a setter method named : " + mName +
                                     "() that takes a single String, int, long, float, double " +


### PR DESCRIPTION
When setting Boolean values to the (custom) mediators the framework fails with 
[Error.log](https://github.com/wso2/wso2-synapse/files/3013901/Error.log)
> java.lang.IllegalArgumentException: argument type mismatch

a more detailed log is attached.

## Purpose
> As explained above.

## Goals
The goal is to be able to successfully add boolean values to the mediators.

## Approach
Fixed the code in property Helper that sets the boolean value for the underlying object using reflection. Original implementation was setting an object array with nested boolean arrays (which will never be ta case in POJO type getter/setters for boolean value)  

## User stories
NA

## Release note
Boolean values can now be set to the ( custom) mediators

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **no**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
Provide high-level details about the samples related to this feature

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
Tested on:
> JDK:  jdk1.8.0_191,jdk1.8.0_192, jdk1.8.0_202 &  jdk1.7.0_80 
> OS: Windows 7 , Linux ( Amazon Linux)
 
## Learning
NA