### PR TITLE
Add comments to Proxy Services and APIs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
@@ -20,7 +20,10 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMComment;
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
+import org.apache.axiom.om.util.CommonUtils;
 import org.apache.axis2.description.WSDL2Constants;
 import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.logging.Log;
@@ -32,6 +35,7 @@ import org.apache.synapse.aspects.AspectConfiguration;
 import org.apache.synapse.config.xml.endpoints.EndpointFactory;
 import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.mediators.base.SequenceMediator;
+import org.apache.synapse.util.CommentListUtil;
 import org.apache.synapse.util.PolicyInfo;
 
 import javax.xml.namespace.QName;
@@ -375,8 +379,11 @@ public class ProxyServiceFactory {
             proxy.setWsSecEnabled(true);
         }
 
+        CommentListUtil.addAllCommentChildrenToList(elem, proxy.getCommentsList());
+
         return proxy;
     }
+
 
     private static void handleException(String msg) {
         log.error(msg);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
@@ -20,10 +20,7 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMAttribute;
-import org.apache.axiom.om.OMComment;
 import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.OMNode;
-import org.apache.axiom.om.util.CommonUtils;
 import org.apache.axis2.description.WSDL2Constants;
 import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.logging.Log;
@@ -379,7 +376,7 @@ public class ProxyServiceFactory {
             proxy.setWsSecEnabled(true);
         }
 
-        CommentListUtil.addAllCommentChildrenToList(elem, proxy.getCommentsList());
+        CommentListUtil.populateComments(elem, proxy.getCommentsList());
 
         return proxy;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceSerializer.java
@@ -29,6 +29,7 @@ import org.apache.synapse.config.xml.endpoints.EndpointSerializer;
 import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.mediators.base.SequenceMediator;
+import org.apache.synapse.util.CommentListUtil;
 import org.apache.synapse.util.PolicyInfo;
 
 import java.net.URI;
@@ -237,6 +238,8 @@ public class ProxyServiceSerializer {
         if (parent != null) {
             parent.addChild(proxy);
         }
+
+        CommentListUtil.serializeComments(proxy, service.getCommentsList());
         return proxy;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SequenceMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SequenceMediatorFactory.java
@@ -109,6 +109,8 @@ public class SequenceMediatorFactory extends AbstractListMediatorFactory {
                 throw new SynapseException(msg);
             }
         }
+
+        addAllCommentChildrenToList(elem, seqMediator.getCommentsList());
         return seqMediator;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorFactory.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.mediators.template.TemplateMediator;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
@@ -69,6 +70,8 @@ public class TemplateMediatorFactory extends AbstractListMediatorFactory {
         if (onErrorAttr != null) {
             templateTemplateMediator.setErrorHandler(onErrorAttr.getAttributeValue());
         }
+
+        CommentListUtil.populateComments(elem, templateTemplateMediator.getCommentsList());
         return templateTemplateMediator;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorSerializer.java
@@ -21,6 +21,7 @@ package org.apache.synapse.config.xml;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.template.TemplateMediator;
+import org.apache.synapse.util.CommentListUtil;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -55,6 +56,8 @@ public class TemplateMediatorSerializer extends AbstractListMediatorSerializer {
         if (mediator.getErrorHandler() != null) {
             templateElem.addAttribute(fac.createOMAttribute("onError", nullNS, mediator.getErrorHandler()));
         }
+
+        CommentListUtil.serializeComments(templateElem, mediator.getCommentsList());
 
         return templateElem;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/AddressEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/AddressEndpointFactory.java
@@ -24,9 +24,11 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.endpoints.resolvers.ResolverFactory;
+import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.AddressEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Properties;
@@ -90,6 +92,8 @@ public class AddressEndpointFactory extends DefaultEndpointFactory {
         }
 
         processProperties(addressEndpoint, epConfig);
+
+        CommentListUtil.populateComments(addressElement, addressEndpoint.getCommentsList());
 
         return addressEndpoint;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/DefaultEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/DefaultEndpointFactory.java
@@ -24,9 +24,11 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.aspects.AspectConfiguration;
 import org.apache.synapse.config.xml.XMLConfigConstants;
+import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.DefaultEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Properties;
@@ -88,6 +90,8 @@ public class DefaultEndpointFactory extends EndpointFactory {
         }
 
         processProperties(defaultEndpoint, epConfig);
+
+        CommentListUtil.populateComments(defaultElement, defaultEndpoint.getCommentsList());
         
         return defaultEndpoint;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointSerializer.java
@@ -33,6 +33,7 @@ import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.MediatorPropertySerializer;
 import org.apache.synapse.endpoints.*;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Collection;
@@ -162,6 +163,8 @@ public abstract class EndpointSerializer {
             element.addAttribute(EndpointFactory.ON_FAULT_Q.getLocalPart(),
                     messageStore, null);
         }
+
+        CommentListUtil.serializeComments(element, ((AbstractEndpoint) endpoint).getCommentsList());
     }
 
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointFactory.java
@@ -30,6 +30,7 @@ import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.endpoints.HTTPEndpoint;
 import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Properties;
@@ -114,6 +115,8 @@ public class HTTPEndpointFactory extends DefaultEndpointFactory {
         }
 
         processProperties(httpEndpoint, epConfig);
+
+        CommentListUtil.populateComments(epConfig, httpEndpoint.getCommentsList());
 
         return httpEndpoint;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointFactory.java
@@ -24,7 +24,6 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.endpoints.resolvers.ResolverFactory;
-import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.TemplateEndpoint;
 import org.apache.synapse.util.CommentListUtil;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointFactory.java
@@ -24,8 +24,10 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.xml.endpoints.resolvers.ResolverFactory;
+import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.TemplateEndpoint;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Iterator;
@@ -86,6 +88,8 @@ public class TemplateEndpointFactory extends EndpointFactory {
             templateEndpoint.addParameter(paramName.getAttributeValue(),
                     paramValue.getAttributeValue());
         }
+
+        CommentListUtil.populateComments(endpointElement, templateEndpoint.getCommentsList());
 
         return templateEndpoint;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateEndpointSerializer.java
@@ -27,6 +27,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.TemplateEndpoint;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Map;
@@ -69,6 +70,8 @@ public class TemplateEndpointSerializer extends EndpointSerializer {
                 paramElement.addAttribute(fac.createOMAttribute("value", nullNS, entry.getValue()));
             }
         }
+
+        CommentListUtil.serializeComments(endpointElement, ((TemplateEndpoint) epr).getCommentsList());
 
         return endpointElement;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateFactory.java
@@ -27,6 +27,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.endpoints.Template;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Iterator;
@@ -78,6 +79,8 @@ public class TemplateFactory {
             handleException("endpoint element is required in an endpoint template");
         }
         template.setElement(endpointElement);
+
+        CommentListUtil.populateComments(element, template.getCommentsList());
 
         return template;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/TemplateSerializer.java
@@ -26,6 +26,7 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.endpoints.Template;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.List;
@@ -57,6 +58,8 @@ public class TemplateSerializer {
         if (parent != null) {
             parent.addChild(templateElement);
         }
+
+        CommentListUtil.serializeComments(templateElement, template.getCommentsList());
 
         return templateElement;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/WSDLEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/WSDLEndpointFactory.java
@@ -32,6 +32,7 @@ import org.apache.synapse.config.xml.endpoints.utils.WSDL11EndpointBuilder;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.WSDLEndpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.io.File;
@@ -194,6 +195,8 @@ public class WSDLEndpointFactory extends DefaultEndpointFactory {
 
         // process the parameters
         processProperties(wsdlEndpoint, epConfig);
+
+        CommentListUtil.populateComments(epConfig, wsdlEndpoint.getCommentsList());
 
         return wsdlEndpoint;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
@@ -149,7 +149,7 @@ public class APIFactory {
             }
         }
 
-        CommentListUtil.addAllCommentChildrenToList(apiElt, api.getCommentsList());
+        CommentListUtil.populateComments(apiElt, api.getCommentsList());
 
         return api;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
@@ -33,6 +33,7 @@ import org.apache.synapse.rest.API;
 import org.apache.synapse.rest.Handler;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.rest.version.VersionStrategy;
+import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
 import java.util.Iterator;
@@ -147,6 +148,8 @@ public class APIFactory {
                 }
             }
         }
+
+        CommentListUtil.addAllCommentChildrenToList(apiElt, api.getCommentsList());
 
         return api;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APISerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APISerializer.java
@@ -27,6 +27,7 @@ import org.apache.synapse.rest.API;
 import org.apache.synapse.rest.Handler;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.rest.Resource;
+import org.apache.synapse.util.CommentListUtil;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -103,6 +104,8 @@ public class APISerializer {
         } else if (api.getProtocol() == RESTConstants.PROTOCOL_HTTPS_ONLY) {
             apiElt.addAttribute("transports", Constants.TRANSPORT_HTTPS, null);
         }
+
+        CommentListUtil.serializeComments(apiElt, api.getCommentsList());
 
         return apiElt;
     }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -258,7 +258,7 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
     private AxisService axisService;
 
     /**
-     * Comment Texts List associated with the proxy service
+     * Holds the list of comments associated with the proxy service.
      */
     private List<String> commentsList = new ArrayList<String>();
 

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -258,6 +258,11 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
     private AxisService axisService;
 
     /**
+     * Comment Texts List associated with the proxy service
+     */
+    private List<String> commentsList = new ArrayList<String>();
+
+    /**
      * Constructor
      *
      * @param name the name of the Proxy service
@@ -1425,4 +1430,12 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
 		}
 		StatisticIdentityGenerator.reportingEndEvent(proxyId, ComponentType.PROXYSERVICE, holder);
 	}
+
+    public List<String> getCommentsList() {
+        return commentsList;
+    }
+
+    public void setCommentsList(List<String> commentsList) {
+        this.commentsList = commentsList;
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -51,12 +51,7 @@ import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.transport.passthru.util.RelayConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 
 /**
  * An abstract base class for all Endpoint implementations
@@ -114,6 +109,11 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
     protected String artifactContainerName;
 
     private boolean isEdited = false;
+
+    /**
+     * Holds the list of comments associated with the proxy service.
+     */
+    private List<String> commentsList = new ArrayList<String>();
 
     protected AbstractEndpoint() {
         log = LogFactory.getLog(this.getClass());
@@ -279,6 +279,14 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
         contentAware = definition != null && ((definition.getFormat() != null && !definition.getFormat().equals(SynapseConstants.FORMAT_REST)) ||
                 definition.isSecurityOn() || definition.isReliableMessagingOn() ||
                 definition.isAddressingOn() || definition.isUseMTOM()|| definition.isUseSwa());
+    }
+
+    public List<String> getCommentsList() {
+        return commentsList;
+    }
+
+    public void setCommentsList(List<String> commentsList) {
+        this.commentsList = commentsList;
     }
 
     public boolean readyToSend() {

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -51,7 +51,13 @@ import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.transport.passthru.util.RelayConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 
-import java.util.*;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.Stack;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * An abstract base class for all Endpoint implementations

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/Template.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/Template.java
@@ -51,6 +51,11 @@ public class Template implements SynapseArtifact {
 
     private boolean isEdited;
 
+    /**
+     * Holds the list of comments associated with the proxy service.
+     */
+    private List<String> commentsList = new ArrayList<String>();
+
     public Endpoint create(TemplateEndpoint templateEndpoint, Properties properties) {
         // first go through all the elements and replace with the parameters
         OMElement clonedElement = element.cloneOMElement();
@@ -171,5 +176,13 @@ public class Template implements SynapseArtifact {
 
     public void setIsEdited(boolean isEdited) {
         this.isEdited = isEdited;
+    }
+
+    public List<String> getCommentsList() {
+        return commentsList;
+    }
+
+    public void setCommentsList(List<String> commentsList) {
+        this.commentsList = commentsList;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
@@ -32,7 +32,9 @@ import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class TemplateEndpoint extends AbstractEndpoint {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/AbstractListMediator.java
@@ -157,6 +157,10 @@ public abstract class AbstractListMediator extends AbstractMediator
         return mediators.add(m);
     }
 
+    public void addChild(int index, Mediator m) {
+        mediators.add(index, m);
+    }
+
     public boolean addAll(List<Mediator> c) {
         return mediators.addAll(c);
     }

--- a/modules/core/src/main/java/org/apache/synapse/rest/API.java
+++ b/modules/core/src/main/java/org/apache/synapse/rest/API.java
@@ -75,6 +75,11 @@ public class API extends AbstractRESTProcessor implements ManagedLifecycle, Aspe
 
     private AspectConfiguration aspectConfiguration;
 
+    /**
+     * Comment Texts List associated with the API
+     */
+    private List<String> commentsList = new ArrayList<String>();
+
     public API(String name, String context) {
         super(name);
         setContext(context);
@@ -164,6 +169,14 @@ public class API extends AbstractRESTProcessor implements ManagedLifecycle, Aspe
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    public List<String> getCommentsList() {
+        return commentsList;
+    }
+
+    public void setCommentsList(List<String> commentsList) {
+        this.commentsList = commentsList;
     }
 
     public void addResource(Resource resource) {

--- a/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
@@ -1,20 +1,19 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ * Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.synapse.util;

--- a/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
@@ -1,6 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.apache.synapse.util;
 
-import org.apache.axiom.om.*;
+import org.apache.axiom.om.OMComment;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.OMNode;
+import org.apache.axiom.om.OMAbstractFactory;
 
 import java.util.Iterator;
 import java.util.List;

--- a/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
@@ -5,28 +5,31 @@ import org.apache.axiom.om.*;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Contains the utils that are used to handle comments in synapse
+ *
+ */
 public class CommentListUtil {
-
 
     /**
      * Adds comments in Synapse to a list of comments
      *
-     * @param el
-     * @param commentList
+     * @param el    OMElement containing the comments
+     * @param commentList List to be which the comments should be added to
      */
     public static void addAllCommentChildrenToList(OMElement el, List<String> commentList) {
         Iterator it = el.getChildren();
 
-        while(it.hasNext()) {
-            OMNode child = (OMNode)it.next();
-            if (child instanceof OMComment && ((OMComment)child).getValue() != null) {
-                commentList.add(((OMComment)child).getValue());
+        while (it.hasNext()) {
+            OMNode child = (OMNode) it.next();
+            if (child instanceof OMComment && ((OMComment) child).getValue() != null) {
+                commentList.add(((OMComment) child).getValue());
             }
         }
     }
 
     /**
-     * Serialize String Comment entries from a List
+     * Serialize string comment entries from a List
      *
      * @param parent      OMElement to be updated
      * @param commentList List of comment entries to be serialized

--- a/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
@@ -1,0 +1,42 @@
+package org.apache.synapse.util;
+
+import org.apache.axiom.om.*;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class CommentListUtil {
+
+
+    /**
+     * Adds comments in Synapse to a list of comments
+     *
+     * @param el
+     * @param commentList
+     */
+    public static void addAllCommentChildrenToList(OMElement el, List<String> commentList) {
+        Iterator it = el.getChildren();
+
+        while(it.hasNext()) {
+            OMNode child = (OMNode)it.next();
+            if (child instanceof OMComment && ((OMComment)child).getValue() != null) {
+                commentList.add(((OMComment)child).getValue());
+            }
+        }
+    }
+
+    /**
+     * Serialize String Comment entries from a List
+     *
+     * @param parent      OMElement to be updated
+     * @param commentList List of comment entries to be serialized
+     */
+    public static void serializeComments(OMElement parent, List<String> commentList) {
+        OMFactory fac = OMAbstractFactory.getOMFactory();
+        for (String comment : commentList) {
+            OMComment commendNode = fac.createOMComment(parent, "comment");
+            commendNode.setValue(comment);
+            parent.addChild(commendNode);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CommentListUtil.java
@@ -39,7 +39,7 @@ public class CommentListUtil {
      * @param el    OMElement containing the comments
      * @param commentList List to be which the comments should be added to
      */
-    public static void addAllCommentChildrenToList(OMElement el, List<String> commentList) {
+    public static void populateComments(OMElement el, List<String> commentList) {
         Iterator it = el.getChildren();
 
         while (it.hasNext()) {


### PR DESCRIPTION
## Purpose
> Resolves [#3551](https://github.com/wso2/product-ei/issues/3551) & [#2474](https://github.com/wso2/product-ei/issues/2474)

## Goals
Introduces the ability to persist comments within 'proxy' and 'api' tags.