### PR TITLE
Make CallMediator content aware in blocking mode

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -339,9 +339,13 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
         }
     }
 
+    /**
+     * Setting return blocking makes CallMediator access the message’s content in blocking mode when mediating messages
+     * Fixes product-ei #1805, #3015
+     */
     @Override
     public boolean isContentAware() {
-        return false;
+        return blocking;
     }
 
     public boolean isBlocking() {


### PR DESCRIPTION
## Purpose
> Fixes [product-ei/issues/1805](https://github.com/wso2/product-ei/issues/1805) and [product-ei/issues/3015](https://github.com/wso2/product-ei/issues/3015) 

## Approach
> Making CallMediator access the message’s content in blocking mode when mediating messages.
Issues [#1805](https://github.com/wso2/product-ei/issues/1805) and [#3015](https://github.com/wso2/product-ei/issues/3015) can be overcome by adding a log full. Issue [#1805](https://github.com/wso2/product-ei/issues/1805) occurs because the json stream is not set in the MessageContext before the call mediator in blocking mode tries to call the JsonFormatter. Because we set the JSON stream in MessageContext only when building the message. Same as this, in issue [#3015](https://github.com/wso2/product-ei/issues/3015) the xml payload is set in the MessageContext only when building the message.