### PR TITLE
[EI 6.4.0] - [MTOM] - Fix MTOM when DISABLE_CHUNKING or FORCE_HTTP_1_0 are true

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/PassThroughTransportUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/PassThroughTransportUtils.java
@@ -359,6 +359,8 @@ public class PassThroughTransportUtils {
     	}else{
     		format = new OMOutputFormat();
     	}
+        // Keep the formatter information to prevent multipart boundary override (this will be the content writing to header)
+        msgContext.setProperty(PassThroughConstants.MESSAGE_OUTPUT_FORMAT, format);
      
         msgContext.setDoingMTOM(TransportUtils.doWriteMTOM(msgContext));
         msgContext.setDoingSwA(TransportUtils.doWriteSwA(msgContext));

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
@@ -222,8 +222,6 @@ public class TargetRequestFactory {
         
         if (formatter != null) {
             String contentType= formatter.getContentType(msgCtx, format, msgCtx.getSoapAction());
-          //keep the formatter information to prevent multipart boundary override (this will be the content writing to header)
-            msgCtx.setProperty(PassThroughConstants.MESSAGE_OUTPUT_FORMAT, format);
             return contentType;
             
         } else {


### PR DESCRIPTION
## Purpose
Allow WSO2 to send MTOM optimized messages when either or both the DISABLE_CHUNKING or FORCE_HTTP_1_0 properties are set.

## Goals
Working MTOM messages

## Approach
Move the cache of the OMOutputFormat object next to it's creation. Currently, the OMOutputFormat object is cached when the HTTP header is written. It was working fine when the header was always written before the content was created, but pull request https://github.com/wso2/wso2-synapse/pull/1137 did invert the logic.

The OMOutputFormat object should alwas be cached when it is created, since it's an internal logic to the PassThroughTransportUtils class. Right now, there's a tight coupling between the logic of PassThroughTransportUtils and TargetRequestFactory, which result in these kind of bugs.

Before applying the fix, the request would have the same boundary value for the body of the http request, but a different value in the http header. This request will be rejected by any SOAP implementation.

Sample request before the fix :
```
POST /MyWebService
Content-Type: multipart/related; boundary="MIMEBoundary_bbd44478eafffbb97f241501edf120c80e80c1e21243aeaa"; type="application/xop+xml"; start="<0.0bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa@apache.org>"; start-info="text
SOAPAction: "http://tempuri.org"
[...]

--MIMEBoundary_1bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa
Content-Type: application/xop+xml; charset=UTF-8; type="text/xml
Content-Transfer-Encoding: binary
Content-ID: <0.abd44478eafffbb97f241501edf120c80e80c1e21243aeaa@apache.org>

<?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body/></soapenv:Envelope>
--MIMEBoundary_1bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa--
```

Sample request after the fix:
```
POST /MyWebService
Content-Type: multipart/related; boundary="MIMEBoundary_1bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa"; type="application/xop+xml"; start="<0.abd44478eafffbb97f241501edf120c80e80c1e21243aeaa@apache.org>"; start-info="text
SOAPAction: "http://tempuri.org"
[...]

--MIMEBoundary_1bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa
Content-Type: application/xop+xml; charset=UTF-8; type="text/xml
Content-Transfer-Encoding: binary
Content-ID: <0.abd44478eafffbb97f241501edf120c80e80c1e21243aeaa@apache.org>

<?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body/></soapenv:Envelope>
--MIMEBoundary_1bd44478eafffbb911c7e501edf120c8d7a0c1e21243aeaa--
```
