### PR TITLE
Fixes Json message being logged as XML when log mediator used.

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonUtil.java
@@ -62,7 +62,7 @@ import java.util.Properties;
 public final class JsonUtil {
     private static Log logger = LogFactory.getLog(JsonUtil.class.getName());
 
-    private static final String ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM = "org.apache.synapse.commons.json.JsonInputStream";
+    public static final String ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM = "org.apache.synapse.commons.json.JsonInputStream";
     private static final String ORG_APACHE_SYNAPSE_COMMONS_JSON_IS_JSON_OBJECT = "org.apache.synapse.commons.json.JsonInputStream.IsJsonObject";
 
     private static final QName JSON_OBJECT = new QName("jsonObject");

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
@@ -30,8 +30,10 @@ import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
+import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.continuation.ContinuationStackManager;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.util.MessageHelper;
@@ -139,6 +141,11 @@ public class ForEachMediator extends AbstractMediator implements ManagedLifecycl
             try {
                 iteratedMsgCtx = getIteratedMessage(synCtx, processingEnvelope,
                                                     (OMNode) element);
+
+                //Removes the json stream property from the iterated context.
+                ((Axis2MessageContext) iteratedMsgCtx).getAxis2MessageContext().
+                        removeProperty(JsonUtil.ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM);
+
             } catch (AxisFault axisFault) {
                 handleException("Error creating an iterated copy of the message", axisFault, synCtx);
             }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -202,13 +202,10 @@ public class LogMediator extends AbstractMediator {
         sb.append(getSimpleLogMessage(synCtx));
         try {
             org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-            // If there is a XML element which store sourced JSON payload, synCtx.getEnvelope() will not be null.
-            // So need to check it also to avoid log in JSON format i.e. {"value" : "test"}
-            if (synCtx.getEnvelope() != null) {
-                sb.append(separator).append("Envelope: ").append(synCtx.getEnvelope());
-            }
-            else if (JsonUtil.hasAJsonPayload(a2mc)) {
+            if (JsonUtil.hasAJsonPayload(a2mc)) {
                 sb.append(separator).append("Payload: ").append(JsonUtil.jsonPayloadToString(a2mc));
+            } else if (synCtx.getEnvelope() != null) {
+                sb.append(separator).append("Envelope: ").append(synCtx.getEnvelope());
             }
         } catch (Exception e) {
             SOAPEnvelope envelope = synCtx.isSOAP11() ? OMAbstractFactory.getSOAP11Factory().getDefaultEnvelope()


### PR DESCRIPTION
Fixes https://github.com/wso2/product-ei/issues/3775.

In Earlier versions of ESB, it was logged as json and after EI 6.2.0 only this behavior was changed.

This has happened due to the fix https://github.com/wso2/wso2-synapse/pull/768/files which was intended to fix https://wso2.org/jira/browse/ESBJAVA-5202.

This PR basically reverts the fix https://github.com/wso2/wso2-synapse/pull/768/files and fixes the original issue mentioned in  https://wso2.org/jira/browse/ESBJAVA-5202. 

The issue in  https://wso2.org/jira/browse/ESBJAVA-5202. has happened since we have not removed the original json stream from context and after iterating we weren't overriding it as a solution for it this PR removes the json stream from the original context in foreach mediator since we don't support native json in for each.

