### PR TITLE
Fix call mediator blocking timeout configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
@@ -239,11 +239,13 @@ public class BlockingMsgSenderUtils {
         // set the SEND_TIMEOUT for transport sender
         if (endpoint.getEffectiveTimeout() > 0) {
             if (!endpoint.isDynamicTimeoutEndpoint()) {
-                axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getEffectiveTimeout());
-                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) endpoint.getEffectiveTimeout());
+                long effectiveTimeout = endpoint.getEffectiveTimeout();
+                axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, effectiveTimeout);
+                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) effectiveTimeout);
             } else {
-                axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.evaluateDynamicEndpointTimeout(synapseInMsgCtx));
-                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) endpoint.evaluateDynamicEndpointTimeout(synapseInMsgCtx));
+                long dynamicTimeout = endpoint.evaluateDynamicEndpointTimeout(synapseInMsgCtx);
+                axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, dynamicTimeout);
+                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) dynamicTimeout);
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
@@ -240,8 +240,10 @@ public class BlockingMsgSenderUtils {
         if (endpoint.getEffectiveTimeout() > 0) {
             if (!endpoint.isDynamicTimeoutEndpoint()) {
                 axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.getEffectiveTimeout());
+                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) endpoint.getEffectiveTimeout());
             } else {
                 axisOutMsgCtx.setProperty(SynapseConstants.SEND_TIMEOUT, endpoint.evaluateDynamicEndpointTimeout(synapseInMsgCtx));
+                axisOutMsgCtx.setProperty(HTTPConstants.SO_TIMEOUT, (int) endpoint.evaluateDynamicEndpointTimeout(synapseInMsgCtx));
             }
         }
 


### PR DESCRIPTION
## Purpose
When using the call mediator in blocking mode, the timeout configuration of the endpoint is ignored and the default axis2 timeout (30 seconds) is used instead.

It is possible to modify the default value by editing axis2_blocking_client.xml file to add the parameter SO_TIMEOUT to the http/https transport, but it will be configured globally.

## Goals
Fix the timeout handling so that we can configure the timeout value dynamically per endpoint.

## Approach
By default, the timeout configuration of the endpoint is passed to the outbound axis2 message context with a property named SEND_TIMEOUT. That value does not seems to be used in any meaningfull way by any code.

Instead, Axis2 is looking for the SO_TIMEOUT parameter, as can be seen in [AbstractHTTPSender.java#L525](https://github.com/wso2/wso2-axis2/blob/master/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java#L525). The value is documented in http://axis.apache.org/axis2/java/core/docs/http-transport.html#timeout_config.

This commit add the SO_TIMEOUT property to the outbound axis2 message context.
