### PR TITLE
Add getter for `componentIndex` variable.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/publishing/PublishingEvent.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/publishing/PublishingEvent.java
@@ -102,6 +102,10 @@ public class PublishingEvent {
 	public void setComponentName(String componentName) {
 		this.componentName = componentName;
 	}
+	
+	public Integer getComponentIndex() {
+		return componentIndex;
+	}
 
 	public long getStartTime() {
 		return startTime;


### PR DESCRIPTION
## Purpose
> The private `componentIndex` variable, should be available for other access.

## Goals
> Custom `event publishers` may need this data to illustrate the events.

## Approach
> A getter method added.