### PR TITLE
Fix [EI-4073] null-pointer in header mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
@@ -55,6 +55,7 @@ public class HeaderMediator extends AbstractMediator {
 
     public static final int ACTION_SET = 0;
     public static final int ACTION_REMOVE = 1;
+    private static final String EMPTY_STRING = "";
 
     /** The qName of the header @see HeaderType */
     private QName qName = null;
@@ -98,7 +99,12 @@ public class HeaderMediator extends AbstractMediator {
             expression.stringValueOf(synCtx));        
         
         if (scope == null || XMLConfigConstants.SCOPE_DEFAULT.equals(scope)) {
-            if (action == ACTION_SET) {            	
+            if (action == ACTION_SET) {
+
+                if (value == null) {
+                    value = EMPTY_STRING;
+                    log.warn("Setting SOAP header : " + qName + " to empty as evaluated value is null");
+                }
 
 	    	    if (synLog.isTraceOrDebugEnabled()) {
 	    	        synLog.traceOrDebug("Set SOAP header : " + qName + " to : " + value);
@@ -171,7 +177,11 @@ public class HeaderMediator extends AbstractMediator {
         } else if (XMLConfigConstants.SCOPE_TRANSPORT.equals(scope)) {        	
         	String headerName = qName.getLocalPart();
             if (action == ACTION_SET) {
-            	
+                if (value == null) {
+                    value = EMPTY_STRING;
+                    log.warn("Setting HTTP header : " + headerName + " to empty as evaluated value is null");
+                }
+
 			    if (synLog.isTraceOrDebugEnabled()) {
 			        synLog.traceOrDebug("Set HTTP header : " + headerName + " to : " + value);
 			    }


### PR DESCRIPTION
## Purpose

Fixes: wso2/product-ei#4073

## Approach

set an empty string as the header when evaluated value for it via an expression becomes `null` and print a `WARN` message. 

## Automation tests

Not needed as this is a fix for a null-pointer 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
