### PR TITLE
Check setCharacterEncoding property to append charset encoding to outgoing request

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -51,6 +51,9 @@ public class PassThroughConstants {
     public static final String SERIALIZED_BYTES = "SerializedBytes";
 
     public static final String CONTENT_TYPE = "CONTENT_TYPE";
+    // This property can be used to remove character encode. By default character encoding is enabled in the ESB profile.
+    // If this property is set to 'false', the 'CHARACTER_SET_ENCODING' property cannot be used.
+    public static final String SET_CHARACTER_ENCODING = "setCharacterEncoding";
 
     public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
     public static final String CONTENT_TYPE_MULTIPART_RELATED = "multipart/related";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -600,15 +600,15 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                             contentTypeValueInMsgCtx.contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_FORM_DATA))) {
 
                        // adding charset only if charset is not available,
-                       if (contentTypeValueInMsgCtx.indexOf(HTTPConstants.CHAR_SET_ENCODING) == -1
-                           && format != null) {
+                       if (format != null && contentTypeValueInMsgCtx.indexOf(HTTPConstants.CHAR_SET_ENCODING) == -1 &&
+                           !"false".equals(msgContext.getProperty(PassThroughConstants.SET_CHARACTER_ENCODING))) {
 							String encoding = format.getCharSetEncoding();
 							if (encoding != null) {
 								sourceResponse.removeHeader(HTTP.CONTENT_TYPE);
 								contentTypeValueInMsgCtx += "; charset=" + encoding;
 							}
 						}
-                	   
+
                        sourceResponse.addHeader(HTTP.CONTENT_TYPE, contentTypeValueInMsgCtx);
                        isContentTypeSetFromMsgCtx = true;
                    }


### PR DESCRIPTION
## Purpose

setCharacterEncoding property should be checked before appending charset encoding to outgoing request

## Approach

Prior to append charset encoding, setCharacterEncoding property will be checked. If the property is false, charset encoding will not be appended.