### PR TITLE
Implement native JSON support for Header mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/HeaderMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/HeaderMediatorFactory.java
@@ -36,7 +36,7 @@ import java.util.Properties;
  * <p>
  * Configuration syntax to set a header:
  *   <pre>
- *      &lt;header name="qname" (value="literal" | expression="xpath") [scope=("default" | "transport")]/&gt;
+ *      &lt;header name="qname" (value="literal" | expression="xpath|jsonpath") [scope=("default" | "transport")]/&gt;
  *   </pre>
  *
  * Configuration syntax to remove a header:
@@ -132,9 +132,9 @@ public class HeaderMediatorFactory extends AbstractMediatorFactory  {
 
         } else if (exprn != null && exprn.getAttributeValue() != null) {
             try {
-                headerMediator.setExpression(SynapseXPathFactory.getSynapseXPath(elem, ATT_EXPRN));
+                headerMediator.setExpression(SynapsePathFactory.getSynapsePath(elem, ATT_EXPRN));
             } catch (JaxenException je) {
-                handleException("Invalid XPath expression : " + exprn.getAttributeValue());
+                handleException("Invalid XPath/JSONPath expression : " + exprn.getAttributeValue());
             }
         } else if (headerMediator.isImplicit()) { // we have an implicit, non standard header
             Iterator i = elem.getChildElements();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/HeaderMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/HeaderMediatorSerializer.java
@@ -72,7 +72,7 @@ public class HeaderMediatorSerializer extends AbstractMediatorSerializer {
 
             } else if (mediator.getExpression() != null) {
 
-                SynapseXPathSerializer.serializeXPath(
+                SynapsePathSerializer.serializePath(
                     mediator.getExpression(), header, "expression");
 
             } else if (!mediator.isImplicit()) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
@@ -32,10 +32,10 @@ import org.apache.axis2.addressing.RelatesTo;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseLog;
+import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
-import org.apache.synapse.util.xpath.SynapseXPath;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ public class HeaderMediator extends AbstractMediator {
     /** Optional embedded XML content of the header element */
     private List<OMElement> embeddedXmlContent = new ArrayList<OMElement>();
     /** An expression which should be evaluated, and the result set as the header value */
-    private SynapseXPath expression = null;
+    private SynapsePath expression = null;
     
     /** The scope which decides which header to update: SOAP or HTTP */
     private String scope = null; // null defaults to the SOAP header. 
@@ -325,7 +325,7 @@ public class HeaderMediator extends AbstractMediator {
         this.value = value;
     }
 
-    public SynapseXPath getExpression() {
+    public SynapsePath getExpression() {
         return expression;
     }
 
@@ -347,7 +347,7 @@ public class HeaderMediator extends AbstractMediator {
         return getQName() == null;
     }
 
-    public void setExpression(SynapseXPath expression) {
+    public void setExpression(SynapsePath expression) {
         this.expression = expression;
     }
 

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/HeaderMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/HeaderMediatorSerializationTest.java
@@ -34,14 +34,29 @@ public class HeaderMediatorSerializationTest extends AbstractTestCase {
         headerMediatorSerializer = new HeaderMediatorSerializer();
     }
 
-    public void testHeaderMediatorSerializationSenarioOne() throws Exception {
-        String inputXml = "<header xmlns=\"http://ws.apache.org/ns/synapse\" name=\"To\" value=\"http://127.0.0.1:10001/services/Services\"/>";
+    public void testHeaderMediatorSerializationScenarioOne() throws Exception {
+        String inputXml = "<header xmlns=\"http://ws.apache.org/ns/synapse\" name=\"To\" " +
+                "value=\"http://127.0.0.1:10001/services/Services\"/>";
         assertTrue(serialization(inputXml, headerMediatorFactory, headerMediatorSerializer));
         assertTrue(serialization(inputXml, headerMediatorSerializer));
     }
 
-    public void testHeaderMediatorSerializationSenarioTwo() throws Exception {
+    public void testHeaderMediatorSerializationScenarioTwo() throws Exception {
         String inputXml = "<header xmlns=\"http://ws.apache.org/ns/synapse\" name=\"To\" action=\"remove\"/>";
+        assertTrue(serialization(inputXml, headerMediatorFactory, headerMediatorSerializer));
+        assertTrue(serialization(inputXml, headerMediatorSerializer));
+    }
+
+    public void testHeaderMediatorSerializationScenarioThree() throws Exception {
+        String inputXml = "<header xmlns=\"http://ws.apache.org/ns/synapse\" name=\"To\" " +
+                "expression=\"fn:concat('http://localhost:9764/services/Axis2SampleService_',get-property('epr'))\"/>";
+        assertTrue(serialization(inputXml, headerMediatorFactory, headerMediatorSerializer));
+        assertTrue(serialization(inputXml, headerMediatorSerializer));
+    }
+
+    public void testHeaderMediatorSerializationScenarioFour() throws Exception {
+        String inputXml = "<header xmlns:t=\"https://www.test.com\" xmlns=\"http://ws.apache.org/ns/synapse\" " +
+                "name=\"t:PlaceHolder\" expression=\"json-eval($.stockquote)\"/>";
         assertTrue(serialization(inputXml, headerMediatorFactory, headerMediatorSerializer));
         assertTrue(serialization(inputXml, headerMediatorSerializer));
     }

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/HeaderMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/HeaderMediatorTest.java
@@ -58,11 +58,11 @@ public class HeaderMediatorTest extends TestCase {
         assertTrue(synCtx.getTo() == null);
     }
 
-    public void testSimpleHTTPHeaderSetAndRemove() throws Exception {    
-    	Map transportHeaders;     	
+    public void testSimpleHTTPHeaderSetAndRemove() throws Exception {
+    	Map transportHeaders;
     	String httpHeaderName = "content-type";
     	String httpHeaderValue = "application/json";
-    	
+
         HeaderMediator headerMediator = new HeaderMediator();
         headerMediator.setQName(new QName(httpHeaderName));
         headerMediator.setValue(httpHeaderValue);
@@ -71,7 +71,7 @@ public class HeaderMediatorTest extends TestCase {
         // invoke transformation, with static enveope
         MessageContext synCtx = TestUtils.createLightweightSynapseMessageContext("<empty/>");
         headerMediator.mediate(synCtx);
-        
+
         org.apache.axis2.context.MessageContext axisCtx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
         transportHeaders = (Map) axisCtx.getProperty(
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
@@ -81,13 +81,13 @@ public class HeaderMediatorTest extends TestCase {
         // set the header mediator as a remove-header
         headerMediator.setAction(HeaderMediator.ACTION_REMOVE);
         headerMediator.mediate(synCtx);
-                
+
         transportHeaders = (Map) axisCtx.getProperty(
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-        
+
         assertNull(transportHeaders.get(httpHeaderName));
-    }    
-    
+    }
+
     public void testSimpleHeaderXPathSetAndRemove() throws Exception {
 
         HeaderMediator headerMediator = new HeaderMediator();
@@ -126,18 +126,29 @@ public class HeaderMediatorTest extends TestCase {
     }
 
     public void testEmbeddedXml() throws Exception {
-        String simpleHeader =  "<header name=\"m:simpleHeader\" value=\"Simple Header\" xmlns:m=\"http://org.synapse.example\"/>";
-        String complexHeader = "<header><m:complexHeader xmlns:m=\"http://org.synapse.example\"><property key=\"k1\" value=\"v1\"/><property key=\"k2\" value=\"v2\"/></m:complexHeader></header>";
-        String removeHeader = "<header name=\"m:complexHeader\" action=\"remove\" xmlns:m=\"http://org.synapse.example\"/>";
+        String simpleHeader =  "<header name=\"m:simpleHeader\" " +
+                "value=\"Simple Header\" xmlns:m=\"http://org.synapse.example\"/>";
+        String complexHeader = "<header><m:complexHeader xmlns:m=\"http://org.synapse.example\"><property key=\"k1\" " +
+                "value=\"v1\"/><property key=\"k2\" value=\"v2\"/></m:complexHeader></header>";
+        String removeHeader = "<header name=\"m:complexHeader\" " +
+                "action=\"remove\" xmlns:m=\"http://org.synapse.example\"/>";
+
+        String simpleJSONPathHeader = "<header name=\"m:simpleHeader\" value=\"json-eval($.simpleHeader)\" " +
+                "xmlns:m=\"http://org.synapse.example\"/>";
 
         HeaderMediatorFactory fac = new HeaderMediatorFactory();
         try {
             // Adding headers.
             MessageContext synCtx = TestUtils.getTestContext("<empty/>");
-            HeaderMediator headerMediator = (HeaderMediator) fac.createMediator(AXIOMUtil.stringToOM(simpleHeader), new Properties());
+            HeaderMediator headerMediator = (HeaderMediator) fac.createMediator(AXIOMUtil.stringToOM(simpleHeader),
+                    new Properties());
             headerMediator.mediate(synCtx);
             headerMediator = (HeaderMediator) fac.createMediator(AXIOMUtil.stringToOM(complexHeader), new Properties());
             headerMediator.mediate(synCtx);
+            headerMediator = (HeaderMediator) fac.createMediator(AXIOMUtil.stringToOM(simpleJSONPathHeader),
+                    new Properties());
+            headerMediator.mediate(synCtx);
+
             // Removing headers.
             headerMediator = (HeaderMediator) fac.createMediator(AXIOMUtil.stringToOM(removeHeader), new Properties());
             headerMediator.mediate(synCtx);


### PR DESCRIPTION
Related to https://github.com/wso2/product-ei/issues/4121

## Purpose
Adding native JSON support for Header mediator. This is done with regard to completing native JSON support for all the relevant mediators.

Reference : Architecture email "Implementing native JSON support for Synapse mediators"