### PR TITLE
Remove javafx.util.Pair to support open jdk

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/Assertor.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/Assertor.java
@@ -18,7 +18,6 @@
 
 package org.apache.synapse.unittest;
 
-import javafx.util.Pair;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -30,6 +29,7 @@ import org.apache.synapse.unittest.testcase.data.classes.AssertNotNull;
 import org.apache.synapse.unittest.testcase.data.classes.TestCase;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +56,7 @@ class Assertor {
      * @param mediateMsgCtxt  message context used for the mediation
      * @return true if assertion is success otherwise false
      */
-    static Pair<Boolean, String> doAssertionSequence(TestCase currentTestCase,
+    static Map.Entry<Boolean, String> doAssertionSequence(TestCase currentTestCase,
                                                      MessageContext mediateMsgCtxt, int testCaseNumber) {
 
         boolean isSequenceAssertComplete = false;
@@ -68,13 +68,13 @@ class Assertor {
         List<AssertNotNull> assertNotNulls = currentTestCase.getAssertNotNull();
 
         if (!assertEquals.isEmpty()) {
-            Pair<Boolean, String> assertSequence = startAssertEqualsForSequence(assertEquals, mediateMsgCtxt);
+            Map.Entry<Boolean, String> assertSequence = startAssertEqualsForSequence(assertEquals, mediateMsgCtxt);
             isAssertEqualComplete = assertSequence.getKey();
             assertMessage = assertSequence.getValue();
         }
 
         if (!assertNotNulls.isEmpty() && assertMessage == null) {
-            Pair<Boolean, String> assertSequence = startAssertNotNullsForSequence(assertNotNulls, mediateMsgCtxt);
+            Map.Entry<Boolean, String> assertSequence = startAssertNotNullsForSequence(assertNotNulls, mediateMsgCtxt);
             isAssertNotNullComplete = assertSequence.getKey();
             assertMessage = assertSequence.getValue();
         }
@@ -87,7 +87,7 @@ class Assertor {
             log.error("Unit testing failed for test case - " + testCaseNumber);
         }
 
-        return new Pair<>(isSequenceAssertComplete, assertMessage);
+        return new AbstractMap.SimpleEntry<>(isSequenceAssertComplete, assertMessage);
     }
 
     /**
@@ -98,7 +98,7 @@ class Assertor {
      * @param testCaseNumber  asserting test case number
      * @return true if assertion is success otherwise false
      */
-    static Pair<Boolean, String> doAssertionService(TestCase currentTestCase,
+    static Map.Entry<Boolean, String> doAssertionService(TestCase currentTestCase,
                                                     HttpResponse response, int testCaseNumber) {
 
         boolean isServiceAssertComplete = false;
@@ -114,14 +114,14 @@ class Assertor {
             Header[] responseHeaders = response.getAllHeaders();
 
             if (!assertEquals.isEmpty()) {
-                Pair<Boolean, String> assertService
+                Map.Entry<Boolean, String> assertService
                         = startAssertEqualsForServices(assertEquals, responseAsString, responseHeaders);
                 isAssertEqualComplete = assertService.getKey();
                 assertMessage = assertService.getValue();
             }
 
             if (!assertNotNulls.isEmpty() && assertMessage == null) {
-                Pair<Boolean, String> assertService
+                Map.Entry<Boolean, String> assertService
                         = startAssertNotNullsForServices(assertNotNulls, responseAsString, responseHeaders);
                 isAssertNotNullComplete = assertService.getKey();
                 assertMessage = assertService.getValue();
@@ -138,7 +138,7 @@ class Assertor {
             log.error("Unit testing failed for test case - " + testCaseNumber);
         }
 
-        return new Pair<>(isServiceAssertComplete, assertMessage);
+        return new AbstractMap.SimpleEntry<>(isServiceAssertComplete, assertMessage);
     }
 
 
@@ -147,9 +147,9 @@ class Assertor {
      *
      * @param assertEquals   array of assertEquals
      * @param messageContext message context
-     * @return Pair<Boolean, String> which has status of assertEquals and message if any error occurred
+     * @return Map.Entry<Boolean, String> which has status of assertEquals and message if any error occurred
      */
-    private static Pair<Boolean, String> startAssertEqualsForSequence(List<AssertEqual> assertEquals,
+    private static Map.Entry<Boolean, String> startAssertEqualsForSequence(List<AssertEqual> assertEquals,
                                                                       MessageContext messageContext) {
 
         log.info("AssertEquals - assert property for sequences started");
@@ -221,7 +221,7 @@ class Assertor {
         }
 
         log.info("AssertEquals assertion success - " + !isAssertEqualFailed);
-        return new Pair<>(!isAssertEqualFailed, messageOfAssertEqual);
+        return new AbstractMap.SimpleEntry<>(!isAssertEqualFailed, messageOfAssertEqual);
     }
 
     /**
@@ -229,9 +229,9 @@ class Assertor {
      *
      * @param assertNotNull  array of assertNotNull
      * @param messageContext message context
-     * @return Pair<Boolean, String> which has status of assertNotNull and message if any error occurred
+     * @return Map.Entry<Boolean, String> which has status of assertNotNull and message if any error occurred
      */
-    private static Pair<Boolean, String> startAssertNotNullsForSequence(List<AssertNotNull> assertNotNull,
+    private static Map.Entry<Boolean, String> startAssertNotNullsForSequence(List<AssertNotNull> assertNotNull,
                                                                         MessageContext messageContext) {
 
         log.info("Assert Not Null - assert property for sequences started");
@@ -302,7 +302,7 @@ class Assertor {
         }
 
         log.info("AssertNotNull assertion success - " + !isAssertNotNullFailed);
-        return new Pair<>(!isAssertNotNullFailed, messageOfAssertNotNull);
+        return new AbstractMap.SimpleEntry<>(!isAssertNotNullFailed, messageOfAssertNotNull);
     }
 
     /**
@@ -311,9 +311,9 @@ class Assertor {
      * @param assertEquals array of assertEquals
      * @param response     service response body
      * @param headers      service response headers
-     * @return Pair<Boolean, String> which has status of assertEquals and message if any error occurred
+     * @return Map.Entry<Boolean, String> which has status of assertEquals and message if any error occurred
      */
-    private static Pair<Boolean, String> startAssertEqualsForServices(
+    private static Map.Entry<Boolean, String> startAssertEqualsForServices(
             List<AssertEqual> assertEquals, String response, Header[] headers) {
 
         log.info("Assert Equals - assert property for services started");
@@ -371,7 +371,7 @@ class Assertor {
         }
 
         log.info("AssertEquals assertion success - " + !isAssertEqualFailed);
-        return new Pair<>(!isAssertEqualFailed, messageOfAssertEqual);
+        return new AbstractMap.SimpleEntry<>(!isAssertEqualFailed, messageOfAssertEqual);
     }
 
     /**
@@ -380,9 +380,9 @@ class Assertor {
      * @param assertNotNull array of assertNotNull
      * @param response      service response body
      * @param headers       service response headers
-     * @return Pair<Boolean, String> which has status of assertNotNull and message if any error occurred
+     * @return Map.Entry<Boolean, String> which has status of assertNotNull and message if any error occurred
      */
-    private static Pair<Boolean, String> startAssertNotNullsForServices(
+    private static Map.Entry<Boolean, String> startAssertNotNullsForServices(
             List<AssertNotNull> assertNotNull, String response, Header[] headers) {
 
         log.info("Assert Not Null - assert property for services started");
@@ -437,6 +437,6 @@ class Assertor {
         }
 
         log.info("AssertNotNull assertion success - " + !isAssertNotNullFailed);
-        return new Pair<>(!isAssertNotNullFailed, messageOfAssertNotNull);
+        return new AbstractMap.SimpleEntry<>(!isAssertNotNullFailed, messageOfAssertNotNull);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/ConfigurationDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/ConfigurationDeployer.java
@@ -17,7 +17,6 @@
  */
 package org.apache.synapse.unittest;
 
-import javafx.util.Pair;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
@@ -33,6 +32,9 @@ import org.apache.synapse.deployers.APIDeployer;
 import org.apache.synapse.deployers.EndpointDeployer;
 import org.apache.synapse.deployers.LocalEntryDeployer;
 
+import java.util.AbstractMap;
+import java.util.Map;
+
 /**
  * Util class for deploying synapse artifacts to the synapse engine.
  */
@@ -43,9 +45,9 @@ class ConfigurationDeployer {
      *
      * @param inputElement synapse configuration artifact as OMElement type
      * @param fileName     name of the file
-     * @return response of the artifact deployment and the synapse configuration as a Pair<>
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
      */
-    Pair<SynapseConfiguration, String> deploySequenceArtifact(OMElement inputElement, String fileName)
+    Map.Entry<SynapseConfiguration, String> deploySequenceArtifact(OMElement inputElement, String fileName)
             throws AxisFault {
 
         //create new sequence deployer object
@@ -67,7 +69,7 @@ class ConfigurationDeployer {
         //deploy synapse artifact
         String deployedArtifact = sequenceDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
-        return new Pair<>(synapseConfiguration, deployedArtifact);
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }
 
     /**
@@ -75,9 +77,9 @@ class ConfigurationDeployer {
      *
      * @param inputElement synapse configuration artifact as OMElement type
      * @param fileName     name of the file
-     * @return response of the artifact deployment and the synapse configuration as a Pair<>
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
      */
-    Pair<SynapseConfiguration, String> deployProxyArtifact(OMElement inputElement, String fileName)
+    Map.Entry<SynapseConfiguration, String> deployProxyArtifact(OMElement inputElement, String fileName)
             throws AxisFault {
 
         //create new proxy service deployer object
@@ -98,7 +100,7 @@ class ConfigurationDeployer {
         //deploy synapse artifact
         String deployedArtifact = proxyServiceDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
-        return new Pair<>(synapseConfiguration, deployedArtifact);
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }
 
     /**
@@ -106,9 +108,9 @@ class ConfigurationDeployer {
      *
      * @param inputElement synapse configuration artifact as OMElement type
      * @param fileName     name of the file
-     * @return response of the artifact deployment and the synapse configuration as a Pair<>
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
      */
-    Pair<SynapseConfiguration, String> deployApiArtifact(OMElement inputElement, String fileName)
+    Map.Entry<SynapseConfiguration, String> deployApiArtifact(OMElement inputElement, String fileName)
             throws AxisFault {
 
         //create new API deployer object
@@ -130,7 +132,7 @@ class ConfigurationDeployer {
         //deploy synapse artifact
         String deployedArtifact = apiResourceDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
-        return new Pair<>(synapseConfiguration, deployedArtifact);
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }
 
     /**
@@ -138,9 +140,9 @@ class ConfigurationDeployer {
      *
      * @param inputElement synapse configuration artifact as OMElement type
      * @param fileName     name of the file
-     * @return response of the artifact deployment and the synapse configuration as a Pair<>
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
      */
-    Pair<SynapseConfiguration, String> deployEndpointArtifact(OMElement inputElement, String fileName)
+    Map.Entry<SynapseConfiguration, String> deployEndpointArtifact(OMElement inputElement, String fileName)
             throws AxisFault {
 
         //create new sequence deployer object
@@ -162,7 +164,7 @@ class ConfigurationDeployer {
         //deploy synapse artifact
         String deployedArtifact = endpointDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
-        return new Pair<>(synapseConfiguration, deployedArtifact);
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }
 
     /**
@@ -170,9 +172,9 @@ class ConfigurationDeployer {
      *
      * @param inputElement synapse configuration artifact as OMElement type
      * @param fileName     name of the file
-     * @return response of the artifact deployment and the synapse configuration as a Pair<>
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
      */
-    Pair<SynapseConfiguration, String> deployLocalEntryArtifact(OMElement inputElement, String fileName)
+    Map.Entry<SynapseConfiguration, String> deployLocalEntryArtifact(OMElement inputElement, String fileName)
             throws AxisFault {
 
         //create new sequence deployer object
@@ -194,6 +196,6 @@ class ConfigurationDeployer {
         //deploy synapse artifact
         String deployedArtifact = localEntryDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
-        return new Pair<>(synapseConfiguration, deployedArtifact);
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/MockServiceCreator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/MockServiceCreator.java
@@ -20,7 +20,6 @@ package org.apache.synapse.unittest;
 
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import javafx.util.Pair;
 import org.apache.log4j.Logger;
 import org.apache.synapse.commons.emulator.core.Emulator;
 import org.apache.synapse.commons.emulator.core.EmulatorType;
@@ -31,6 +30,7 @@ import org.apache.synapse.unittest.testcase.data.classes.ServiceResource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.synapse.commons.emulator.http.dsl.dto.consumer.IncomingMessage.request;
 import static org.apache.synapse.commons.emulator.http.dsl.dto.consumer.OutgoingMessage.response;
@@ -102,8 +102,8 @@ class MockServiceCreator {
 
         String serviceResponsePayload = resource.getResponsePayload();
 
-        List<Pair<String, String>> requestHeaders = new ArrayList<>();
-        List<Pair<String, String>> responseHeaders = new ArrayList<>();
+        List<Map.Entry<String, String>> requestHeaders = new ArrayList<>();
+        List<Map.Entry<String, String>> responseHeaders = new ArrayList<>();
 
         if (resource.getRequestHeaders() != null) {
             requestHeaders = resource.getRequestHeaders();
@@ -119,7 +119,7 @@ class MockServiceCreator {
                 //adding headers of request
                 IncomingMessage incomingMessage =
                         request().withMethod(HttpMethod.GET).withPath(serviceSubContext);
-                for (Pair<String, String> header : requestHeaders) {
+                for (Map.Entry<String, String> header : requestHeaders) {
                     incomingMessage.withHeader(header.getKey(), header.getValue());
                 }
                 emulator.when(incomingMessage);
@@ -127,7 +127,7 @@ class MockServiceCreator {
                 //adding headers of response
                 OutgoingMessage outGoingMessage =
                         response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
-                for (Pair<String, String> header : responseHeaders) {
+                for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }
 
@@ -138,7 +138,7 @@ class MockServiceCreator {
                 //adding headers of request
                 incomingMessage = request().withMethod(HttpMethod.POST)
                         .withBody(serviceRequestPayload).withPath(serviceSubContext);
-                for (Pair<String, String> header : requestHeaders) {
+                for (Map.Entry<String, String> header : requestHeaders) {
                     incomingMessage.withHeader(header.getKey(), header.getValue());
                 }
                 emulator.when(incomingMessage);
@@ -146,7 +146,7 @@ class MockServiceCreator {
                 //adding headers of response
                 outGoingMessage =
                         response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
-                for (Pair<String, String> header : responseHeaders) {
+                for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }
 
@@ -156,7 +156,7 @@ class MockServiceCreator {
             default:
                 //adding headers of request
                 incomingMessage = request().withMethod(HttpMethod.GET).withPath(serviceSubContext);
-                for (Pair<String, String> header : requestHeaders) {
+                for (Map.Entry<String, String> header : requestHeaders) {
                     incomingMessage.withHeader(header.getKey(), header.getValue());
                 }
                 emulator.when(incomingMessage);
@@ -164,7 +164,7 @@ class MockServiceCreator {
                 //adding headers of response
                 outGoingMessage =
                         response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
-                for (Pair<String, String> header : responseHeaders) {
+                for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }
 

--- a/modules/core/src/main/java/org/apache/synapse/unittest/RequestHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/RequestHandler.java
@@ -20,7 +20,6 @@ package org.apache.synapse.unittest;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import javafx.util.Pair;
 import org.apache.log4j.Logger;
 import org.apache.synapse.unittest.testcase.data.classes.SynapseTestCase;
 import org.apache.synapse.unittest.testcase.data.holders.ArtifactData;
@@ -34,6 +33,8 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.AbstractMap;
+import java.util.Map;
 
 /**
  * Class is implements with Runnable.
@@ -152,8 +153,8 @@ public class RequestHandler implements Runnable {
     private void runTestingAgent(SynapseTestCase synapseTestCase) {
 
         TestingAgent agent = new TestingAgent();
-        Pair<Boolean, String> supportiveArtifactDeployment = new Pair<>(false, null);
-        Pair<Boolean, String> testArtifactDeployment = new Pair<>(false, null);
+        Map.Entry<Boolean, String> supportiveArtifactDeployment = new AbstractMap.SimpleEntry<>(false, null);
+        Map.Entry<Boolean, String> testArtifactDeployment = new AbstractMap.SimpleEntry<>(false, null);
 
         //get results of supportive-artifact deployment if exists
         if (synapseTestCase.getArtifacts().getSupportiveArtifactCount() > 0) {
@@ -180,7 +181,7 @@ public class RequestHandler implements Runnable {
 
             log.info("Synapse testing agent ready to mediate test cases through deployments");
             //performs test cases through the deployed synapse configuration
-            Pair<JsonObject, String> testCasesMediated = agent.processTestCases(synapseTestCase);
+            Map.Entry<JsonObject, String> testCasesMediated = agent.processTestCases(synapseTestCase);
 
             //check mediation or invoke is success or failed
             if (testCasesMediated.getValue() == null) {

--- a/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.synapse.unittest;
 
-import javafx.util.Pair;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.log4j.Logger;
@@ -34,6 +33,7 @@ import org.apache.synapse.unittest.testcase.data.holders.MockServiceData;
 import org.apache.synapse.unittest.testcase.data.holders.TestCaseData;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -514,7 +514,7 @@ class SynapseTestcaseDataReader {
 
             if (serviceRequestHeaders != null) {
                 Iterator<?> iterateHeaders = serviceRequestHeaders.getChildElements();
-                ArrayList<Pair<String, String>> headers = new ArrayList<>();
+                ArrayList<Map.Entry<String, String>> headers = new ArrayList<>();
 
                 while (iterateHeaders.hasNext()) {
                     OMElement mockServiceRequestHeader = (OMElement) (iterateHeaders.next());
@@ -523,7 +523,7 @@ class SynapseTestcaseDataReader {
                     String headerValue =
                             mockServiceRequestHeader.getAttributeValue(new QName(SERVICE_RESOURCE_HEADER_VALUE));
 
-                    headers.add(new Pair<>(headerName, headerValue));
+                    headers.add(new AbstractMap.SimpleEntry<>(headerName, headerValue));
                 }
 
                 mockService.setRequestHeaders(headers);
@@ -559,7 +559,7 @@ class SynapseTestcaseDataReader {
 
             if (serviceResponseHeaders != null) {
                 Iterator<?> iterateHeaders = serviceResponseHeaders.getChildElements();
-                ArrayList<Pair<String, String>> headers = new ArrayList<>();
+                ArrayList<Map.Entry<String, String>> headers = new ArrayList<>();
 
                 while (iterateHeaders.hasNext()) {
                     OMElement mockServiceResponseHeader = (OMElement) (iterateHeaders.next());
@@ -568,7 +568,7 @@ class SynapseTestcaseDataReader {
                     String headerValue =
                             mockServiceResponseHeader.getAttributeValue(new QName(SERVICE_RESOURCE_HEADER_VALUE));
 
-                    headers.add(new Pair<>(headerName, headerValue));
+                    headers.add(new AbstractMap.SimpleEntry<>(headerName, headerValue));
                 }
 
                 mockService.setResponseHeaders(headers);

--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
@@ -18,7 +18,6 @@
 
 package org.apache.synapse.unittest;
 
-import javafx.util.Pair;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMDocument;
 import org.apache.axiom.om.OMElement;
@@ -45,6 +44,7 @@ import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
 import org.apache.synapse.unittest.testcase.data.classes.TestCase;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -87,9 +87,9 @@ public class TestCasesMediator {
      * @param currentTestCase current test case
      * @param synConfig       synapse configuration used to deploy sequenceDeployer
      * @param key             key of the sequence deployer
-     * @return result of mediation and message context as a Pair<>
+     * @return result of mediation and message context as a Map.Entry
      */
-    static Pair<Boolean, MessageContext> sequenceMediate(TestCase currentTestCase, SynapseConfiguration synConfig,
+    static Map.Entry<Boolean, MessageContext> sequenceMediate(TestCase currentTestCase, SynapseConfiguration synConfig,
                                                          String key) {
         Mediator sequenceMediator = synConfig.getSequence(key);
         MessageContext msgCtxt = createSynapseMessageContext(currentTestCase.getInputPayload(), synConfig);
@@ -101,7 +101,7 @@ public class TestCasesMediator {
                     .mediate(setInputMessageProperties(msgCtxt, currentTestCase.getPropertyMap()));
         }
 
-        return new Pair<>(mediationResult, msgCtxt);
+        return new AbstractMap.SimpleEntry<>(mediationResult, msgCtxt);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
@@ -20,7 +20,6 @@ package org.apache.synapse.unittest;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import javafx.util.Pair;
 import org.apache.axiom.om.OMElement;
 import org.apache.http.HttpResponse;
 import org.apache.log4j.Logger;
@@ -30,7 +29,9 @@ import org.apache.synapse.unittest.testcase.data.classes.SynapseTestCase;
 import org.apache.synapse.unittest.testcase.data.classes.TestCase;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Map;
 import javax.xml.namespace.QName;
 
 import static org.apache.synapse.unittest.Constants.API_CONTEXT;
@@ -62,7 +63,7 @@ class TestingAgent {
      * @param synapseTestCase test cases data received from client
      * @return Result of the deployment and exception status
      */
-    Pair<Boolean, String> processTestArtifact(SynapseTestCase synapseTestCase) {
+    Map.Entry<Boolean, String> processTestArtifact(SynapseTestCase synapseTestCase) {
         artifactType = synapseTestCase.getArtifacts().getTestArtifact().getArtifactType();
         proxyTransportMethod = synapseTestCase.getArtifacts().getTestArtifact().getTransportMethod();
         String artifactNameOrKey = synapseTestCase.getArtifacts().getTestArtifact().getArtifactNameOrKey();
@@ -75,7 +76,7 @@ class TestingAgent {
             switch (artifactType) {
 
                 case TYPE_SEQUENCE:
-                    Pair<SynapseConfiguration, String> pairOfSequenceDeployment =
+                    Map.Entry<SynapseConfiguration, String> pairOfSequenceDeployment =
                             config.deploySequenceArtifact(artifact, artifactNameOrKey);
                     synapseConfiguration = pairOfSequenceDeployment.getKey();
                     key = pairOfSequenceDeployment.getValue();
@@ -89,7 +90,7 @@ class TestingAgent {
                     break;
 
                 case TYPE_PROXY:
-                    Pair<SynapseConfiguration, String> pairOfProxyDeployment =
+                    Map.Entry<SynapseConfiguration, String> pairOfProxyDeployment =
                             config.deployProxyArtifact(artifact, artifactNameOrKey);
                     synapseConfiguration = pairOfProxyDeployment.getKey();
                     key = pairOfProxyDeployment.getValue();
@@ -103,7 +104,7 @@ class TestingAgent {
                     break;
 
                 case TYPE_API:
-                    Pair<SynapseConfiguration, String> pairofApiDeployment =
+                    Map.Entry<SynapseConfiguration, String> pairofApiDeployment =
                             config.deployApiArtifact(artifact, artifactNameOrKey);
                     synapseConfiguration = pairofApiDeployment.getKey();
                     key = pairofApiDeployment.getValue();
@@ -126,7 +127,7 @@ class TestingAgent {
             exception = e.toString();
         }
 
-        return new Pair<>(isArtifactDeployed, exception);
+        return new AbstractMap.SimpleEntry<>(isArtifactDeployed, exception);
     }
 
     /**
@@ -135,7 +136,7 @@ class TestingAgent {
      * @param synapseTestCase test cases data received from client
      * @return Result of the deployment and exception status
      */
-    Pair<Boolean, String> processSupportiveArtifacts(SynapseTestCase synapseTestCase) {
+    Map.Entry<Boolean, String> processSupportiveArtifacts(SynapseTestCase synapseTestCase) {
         boolean isArtifactDeployed = true;
 
         for (int x = 0; x < synapseTestCase.getArtifacts().getSupportiveArtifactCount(); x++) {
@@ -155,7 +156,7 @@ class TestingAgent {
             }
         }
 
-        return new Pair<>(isArtifactDeployed, exception);
+        return new AbstractMap.SimpleEntry<>(isArtifactDeployed, exception);
     }
 
     /**
@@ -174,35 +175,35 @@ class TestingAgent {
 
         switch (supportiveArtifactType) {
             case TYPE_SEQUENCE:
-                Pair<SynapseConfiguration, String> pairOfSequenceDeployment =
+                Map.Entry<SynapseConfiguration, String> pairOfSequenceDeployment =
                         config.deploySequenceArtifact(artifact, artifactNameOrKey);
                 synapseConfiguration = pairOfSequenceDeployment.getKey();
                 key = pairOfSequenceDeployment.getValue();
                 break;
 
             case TYPE_PROXY:
-                Pair<SynapseConfiguration, String> pairofProxyDeployment =
+                Map.Entry<SynapseConfiguration, String> pairofProxyDeployment =
                         config.deployProxyArtifact(artifact, artifactNameOrKey);
                 synapseConfiguration = pairofProxyDeployment.getKey();
                 key = pairofProxyDeployment.getValue();
                 break;
 
             case TYPE_API:
-                Pair<SynapseConfiguration, String> pairofApiDeployment =
+                Map.Entry<SynapseConfiguration, String> pairofApiDeployment =
                         config.deployApiArtifact(artifact, artifactNameOrKey);
                 synapseConfiguration = pairofApiDeployment.getKey();
                 key = pairofApiDeployment.getValue();
                 break;
 
             case TYPE_ENDPOINT:
-                Pair<SynapseConfiguration, String> pairOfEndpointDeployment =
+                Map.Entry<SynapseConfiguration, String> pairOfEndpointDeployment =
                         config.deployEndpointArtifact(artifact, artifactNameOrKey);
                 synapseConfiguration = pairOfEndpointDeployment.getKey();
                 key = pairOfEndpointDeployment.getValue();
                 break;
 
             case TYPE_LOCAL_ENTRY:
-                Pair<SynapseConfiguration, String> pairOfLocalEntryDeployment =
+                Map.Entry<SynapseConfiguration, String> pairOfLocalEntryDeployment =
                         config.deployLocalEntryArtifact(artifact, artifactNameOrKey);
                 synapseConfiguration = pairOfLocalEntryDeployment.getKey();
                 key = pairOfLocalEntryDeployment.getValue();
@@ -227,7 +228,7 @@ class TestingAgent {
      * @param synapseTestCase test cases data received from client
      * @return Result of the mediation and exception status
      */
-    Pair<JsonObject, String> processTestCases(SynapseTestCase synapseTestCase) {
+    Map.Entry<JsonObject, String> processTestCases(SynapseTestCase synapseTestCase) {
         boolean isAssert = false;
         JsonObject resultOfTestCases = new JsonObject();
         int testCaseCount = synapseTestCase.getTestCases().getTestCaseCount();
@@ -241,14 +242,14 @@ class TestingAgent {
 
                 switch (artifactType) {
                     case TYPE_SEQUENCE:
-                        Pair<Boolean, MessageContext> mediateResult =
+                        Map.Entry<Boolean, MessageContext> mediateResult =
                                 TestCasesMediator.sequenceMediate(currentTestCase, synapseConfiguration, key);
 
                         Boolean mediationResult = mediateResult.getKey();
                         MessageContext resultedMessageContext = mediateResult.getValue();
 
                         //check whether mediation is success or not
-                        Pair<Boolean, String> assertSeqResult = checkAssertionWithSequenceMediation
+                        Map.Entry<Boolean, String> assertSeqResult = checkAssertionWithSequenceMediation
                                 (mediationResult, resultedMessageContext, currentTestCase, i);
                         isAssert = assertSeqResult.getKey();
                         exception = assertSeqResult.getValue();
@@ -258,7 +259,7 @@ class TestingAgent {
                         HttpResponse invokedProxyResult = TestCasesMediator
                                 .proxyServiceExecutor(currentTestCase, proxyTransportMethod, key);
 
-                        Pair<Boolean, String> assertProxyResult =
+                        Map.Entry<Boolean, String> assertProxyResult =
                                 checkAssertionWithProxyMediation(invokedProxyResult, currentTestCase, i);
                         isAssert = assertProxyResult.getKey();
                         exception = assertProxyResult.getValue();
@@ -270,7 +271,7 @@ class TestingAgent {
                         HttpResponse invokedApiResult = TestCasesMediator.apiResourceExecutor
                                 (currentTestCase, context, resourceMethod);
 
-                        Pair<Boolean, String> assertAPIResult =
+                        Map.Entry<Boolean, String> assertAPIResult =
                                 checkAssertionWithAPIMediation(invokedApiResult, currentTestCase, i);
                         isAssert = assertAPIResult.getKey();
                         exception = assertAPIResult.getValue();
@@ -288,7 +289,7 @@ class TestingAgent {
         }
 
         //check all test cases are success
-        return new Pair<>(checkAllTestCasesCorrect(resultOfTestCases), exception);
+        return new AbstractMap.SimpleEntry<>(checkAllTestCasesCorrect(resultOfTestCases), exception);
     }
 
     /**
@@ -299,12 +300,12 @@ class TestingAgent {
      * @param currentTestCase        current running test case data
      * @return result of assertion or mediation result
      */
-    private Pair<Boolean, String> checkAssertionWithSequenceMediation(
+    private Map.Entry<Boolean, String> checkAssertionWithSequenceMediation(
             boolean mediationResult, MessageContext resultedMessageContext, TestCase currentTestCase, int index) {
         boolean isAssert = false;
         String assertMessage;
         if (mediationResult) {
-            Pair<Boolean, String> assertOfSequence = Assertor.doAssertionSequence(currentTestCase, resultedMessageContext, index + 1);
+            Map.Entry<Boolean, String> assertOfSequence = Assertor.doAssertionSequence(currentTestCase, resultedMessageContext, index + 1);
             isAssert = assertOfSequence.getKey();
             assertMessage = assertOfSequence.getValue();
 
@@ -313,7 +314,7 @@ class TestingAgent {
             log.error("Sequence mediation failed");
         }
 
-        return new Pair<>(isAssert, assertMessage);
+        return new AbstractMap.SimpleEntry<>(isAssert, assertMessage);
     }
 
     /**
@@ -323,12 +324,12 @@ class TestingAgent {
      * @param currentTestCase    current running test case data
      * @return result of assertion or invoke result
      */
-    private Pair<Boolean, String> checkAssertionWithProxyMediation(HttpResponse invokedProxyResult,
+    private Map.Entry<Boolean, String> checkAssertionWithProxyMediation(HttpResponse invokedProxyResult,
                                                                    TestCase currentTestCase, int index) {
         boolean isAssert = false;
         String assertMessage;
         if (invokedProxyResult != null) {
-            Pair<Boolean, String> assertOfProxy = Assertor.doAssertionService
+            Map.Entry<Boolean, String> assertOfProxy = Assertor.doAssertionService
                     (currentTestCase, invokedProxyResult, index + 1);
 
             isAssert = assertOfProxy.getKey();
@@ -338,7 +339,7 @@ class TestingAgent {
             log.error("Proxy service invoke failed");
         }
 
-        return new Pair<>(isAssert, assertMessage);
+        return new AbstractMap.SimpleEntry<>(isAssert, assertMessage);
     }
 
     /**
@@ -348,12 +349,12 @@ class TestingAgent {
      * @param currentTestCase  current running test case data
      * @return result of assertion or invoke result
      */
-    private Pair<Boolean, String> checkAssertionWithAPIMediation(HttpResponse invokedApiResult,
+    private Map.Entry<Boolean, String> checkAssertionWithAPIMediation(HttpResponse invokedApiResult,
                                                                  TestCase currentTestCase, int index) {
         boolean isAssert = false;
         String assertMessage;
         if (invokedApiResult != null) {
-            Pair<Boolean, String> assertOfApi = Assertor.doAssertionService
+            Map.Entry<Boolean, String> assertOfApi = Assertor.doAssertionService
                     (currentTestCase, invokedApiResult, index + 1);
 
             isAssert = assertOfApi.getKey();
@@ -363,7 +364,7 @@ class TestingAgent {
             log.error("API resource invoke failed");
         }
 
-        return new Pair<>(isAssert, assertMessage);
+        return new AbstractMap.SimpleEntry<>(isAssert, assertMessage);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/ServiceResource.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/ServiceResource.java
@@ -18,9 +18,8 @@
 
 package org.apache.synapse.unittest.testcase.data.classes;
 
-import javafx.util.Pair;
-
 import java.util.List;
+import java.util.Map;
 
 public class ServiceResource {
 
@@ -28,8 +27,8 @@ public class ServiceResource {
     private String method;
     private String requestPayload;
     private String responsePayload;
-    private List<Pair<String,String>> requestHeaders;
-    private List<Pair<String,String>> responseHeaders;
+    private List<Map.Entry<String,String>> requestHeaders;
+    private List<Map.Entry<String,String>> responseHeaders;
 
     /**
      * Get mock service sub-context.
@@ -72,7 +71,7 @@ public class ServiceResource {
      *
      * @return mock service request headers as in descriptor data
      */
-    public List<Pair<String, String>> getRequestHeaders() {
+    public List<Map.Entry<String, String>> getRequestHeaders() {
         return requestHeaders;
     }
 
@@ -81,7 +80,7 @@ public class ServiceResource {
      *
      * @return mock service response headers as in descriptor data
      */
-    public List<Pair<String, String>> getResponseHeaders() {
+    public List<Map.Entry<String, String>> getResponseHeaders() {
         return responseHeaders;
     }
 
@@ -117,7 +116,7 @@ public class ServiceResource {
      *
      * @param requestHeaders service request headers
      */
-    public void setRequestHeaders(List<Pair<String, String>> requestHeaders) {
+    public void setRequestHeaders(List<Map.Entry<String, String>> requestHeaders) {
         this.requestHeaders = requestHeaders;
     }
 
@@ -126,7 +125,7 @@ public class ServiceResource {
      *
      * @param responseHeaders service request headers
      */
-    public void setResponseHeaders(List<Pair<String, String>> responseHeaders) {
+    public void setResponseHeaders(List<Map.Entry<String, String>> responseHeaders) {
         this.responseHeaders = responseHeaders;
     }
 


### PR DESCRIPTION
## Purpose
Remove **javafx.util.Pair** from the source and replace it with **Map.Entry** due to unsupported type in OpenJDK.

