### PR TITLE
Add response status-code for unit test mock services

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
@@ -79,6 +79,7 @@ public class Constants {
     static final String SERVICE_RESOURCE_REQUEST = "request";
     static final String SERVICE_RESOURCE_RESPONSE = "response";
     static final String SERVICE_RESOURCE_PAYLOAD = "payload";
+    static final String SERVICE_RESOURCE_RESPONSE_CODE = "status-code";
     static final String SERVICE_RESOURCE_HEADERS = "headers";
     static final String SERVICE_RESOURCE_HEADER_NAME = "name";
     static final String SERVICE_RESOURCE_HEADER_VALUE = "value";

--- a/modules/core/src/main/java/org/apache/synapse/unittest/MockServiceCreator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/MockServiceCreator.java
@@ -93,6 +93,9 @@ class MockServiceCreator {
      * @param emulator HttpConsumerContext emulator object
      */
     private static void routeThroughResourceMethod(ServiceResource resource, HttpConsumerContext emulator) {
+        int serviceResponseStatusCode = resource.getStatusCode();
+        HttpResponseStatus responseStatus = HttpResponseStatus.valueOf(serviceResponseStatusCode);
+
         String serviceMethod = resource.getMethod();
         String serviceSubContext = resource.getSubContext();
         String serviceRequestPayload = "";
@@ -126,7 +129,7 @@ class MockServiceCreator {
 
                 //adding headers of response
                 OutgoingMessage outGoingMessage =
-                        response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
+                        response().withBody(serviceResponsePayload).withStatusCode(responseStatus);
                 for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }
@@ -145,7 +148,7 @@ class MockServiceCreator {
 
                 //adding headers of response
                 outGoingMessage =
-                        response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
+                        response().withBody(serviceResponsePayload).withStatusCode(responseStatus);
                 for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }
@@ -163,7 +166,7 @@ class MockServiceCreator {
 
                 //adding headers of response
                 outGoingMessage =
-                        response().withBody(serviceResponsePayload).withStatusCode(HttpResponseStatus.OK);
+                        response().withBody(serviceResponsePayload).withStatusCode(responseStatus);
                 for (Map.Entry<String, String> header : responseHeaders) {
                     outGoingMessage.withHeader(header.getKey(), header.getValue());
                 }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
@@ -66,6 +66,7 @@ import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_METHOD;
 import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_PAYLOAD;
 import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_REQUEST;
 import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_RESPONSE;
+import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_RESPONSE_CODE;
 import static org.apache.synapse.unittest.Constants.SERVICE_RESOURCE_SUBCONTEXT;
 import static org.apache.synapse.unittest.Constants.SUPPORTIVE_ARTIFACTS;
 import static org.apache.synapse.unittest.Constants.TEST_ARTIFACT;
@@ -542,6 +543,15 @@ class SynapseTestcaseDataReader {
         OMElement serviceResponseNode = serviceResourceNode.getFirstChildWithName(qualifiedServiceResponse);
 
         if (serviceResponseNode != null) {
+            QName qualifiedServiceResponseStatusCode =
+                    new QName("", SERVICE_RESOURCE_RESPONSE_CODE, "");
+            OMElement serviceResponseStatusCodeNode =
+                    serviceResponseNode.getFirstChildWithName(qualifiedServiceResponseStatusCode);
+            if (serviceResponseStatusCodeNode != null) {
+                String serviceResponseStatusCode = serviceResponseStatusCodeNode.getText();
+                mockService.setStatusCode(Integer.parseInt(serviceResponseStatusCode));
+            }
+
             QName qualifiedServiceResponsePayload =
                     new QName("", SERVICE_RESOURCE_PAYLOAD, "");
             OMElement serviceResponsePayloadNode =

--- a/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/ServiceResource.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/ServiceResource.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 public class ServiceResource {
 
+    private int statusCode;
     private String subContext;
     private String method;
     private String requestPayload;
@@ -85,6 +86,15 @@ public class ServiceResource {
     }
 
     /**
+     * Get mock service response status code.
+     *
+     * @return mock service response status code as in descriptor data
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    /**
      * Add mock service type inside the ArrayList.
      *
      * @param method service type as in descriptor data
@@ -132,9 +142,18 @@ public class ServiceResource {
     /**
      * Set mock service sub-context.
      *
-     * @return mock service sub-context as in descriptor data
+     * @param subContext service sub-context as in descriptor data
      */
     public void setSubContext(String subContext) {
         this.subContext = subContext;
+    }
+
+    /**
+     * Set mock service response status code.
+     *
+     * @param statusCode service response status code as in descriptor data
+     */
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
     }
 }


### PR DESCRIPTION
## Purpose
> Add response status code for the mock services in the unit testing framework. Previously it sent 200 status code for every mock service. 