### PR TITLE
Fix group support with property mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -426,6 +426,8 @@ public class PropertyMediator extends AbstractMediator {
                             value + " for group :" + group;
                     synLog.traceOrDebug(msg);
                 }
+                //Returns an empty string as the number of capturing groups in this matcher's pattern is not satisfied.
+                return "";
             }
             
         } else {


### PR DESCRIPTION
## Purpose
Fix the issue of returning matched value even though the number of capturing groups in this matcher's pattern is not satisfied.

This is regarding the issue mentioned in https://stackoverflow.com/questions/56845736/how-to-use-pattern-and-group-in-property-mediator-to-validate/57001186#57001186