### PR TITLE
Clearer Error Message logs for JSON Schema Validation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -318,9 +318,10 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
                     if (itrErrorMessages.hasNext()) {
                         ProcessingMessage processingMessage = itrErrorMessages.next();
                         String errorMessage = processingMessage.getMessage();
+                        String errorDetail = processingMessage.toString();
                         synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, errorMessage);
                         synCtx.setProperty(SynapseConstants.ERROR_DETAIL, "Error while validating Json message "
-                                + errorMessage);
+                                + errorDetail);
                     }
                     // invokes the "on-fail" sequence of mediator
                     return invokeOnFailSequence(synCtx);


### PR DESCRIPTION
## Purpose
To give a more detailed error message when using <property expression="get-property('ERROR_DETAIL')">


## Approach
Made changes to the way errors are set for the ERROR_DETAIL property in the message context
