### PR TITLE
Set tenant info when a new thread handles mediation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
@@ -27,6 +27,7 @@ import org.apache.synapse.FaultHandler;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.carbonext.TenantInfoConfigurator;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 
 /**
@@ -84,6 +85,11 @@ public class SynapseMessageReceiver implements MessageReceiver {
 
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_REST, mc.isDoingREST());
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_SOAP11, mc.isSOAP11());
+
+        TenantInfoConfigurator configurator = synCtx.getEnvironment().getTenantInfoConfigurator();
+        if (configurator != null) {
+            configurator.extractTenantInfo(synCtx);
+        }
 
         try {
             // set response state for the request incoming via main sequence or API

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.carbonext.TenantInfoConfigurator;
 import org.apache.synapse.debug.SynapseDebugManager;
 
 /**
@@ -70,6 +71,11 @@ public class MediatorWorker implements Runnable {
      */
     public void run() {
         try {
+            //Set tenant info when different thread executes the mediation
+            TenantInfoConfigurator configurator = synCtx.getEnvironment().getTenantInfoConfigurator();
+            if (configurator != null) {
+                configurator.applyTenantInfo(synCtx);
+            }
 
             if (synCtx.getEnvironment().isDebuggerEnabled()) {
                 SynapseDebugManager debugManager = synCtx.getEnvironment().getSynapseDebugManager();


### PR DESCRIPTION
Fix wso2/product-ei#4506

Upgrading the wso2/product-ei#3077 . In the previous fix, tenant details will only be set if that is available in the message context. If not, it will set the default super tenant details.

With the new fix, tenant details will be extracted from the thread and set them as message context properties. This property will be used to update thread-local variables in the newly created thread.