### PR TITLE
Fix class not found for org.apache.commons.dbcp.BasicDataSource

### DIFF
--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -99,6 +99,14 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-dbcp.wso2</groupId>
+            <artifactId>commons-dbcp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-pool.wso2</groupId>
+            <artifactId>commons-pool</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -144,6 +152,10 @@
                                 <bundleDef>com.google.guava:guava:${google.guava.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
                             </bundles>
+                            <importBundles>
+                                <importBundleDef>commons-dbcp.wso2:commons-dbcp</importBundleDef>
+                                <importBundleDef>commons-pool.wso2:commons-pool</importBundleDef>
+                            </importBundles>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,11 @@
             <version>${commons.dbcp.version}</version>
          </dependency>
          <dependency>
+            <groupId>commons-dbcp.wso2</groupId>
+            <artifactId>commons-dbcp</artifactId>
+            <version>${commons.dbcp.wso2.version}</version>
+         </dependency>
+         <dependency>
             <groupId>commons-pool</groupId>
             <artifactId>commons-pool</artifactId>
             <version>${commons.pool.version}</version>
@@ -1127,6 +1132,11 @@
               <artifactId>netty-codec-http</artifactId>
               <version>${io.netty.version}</version>
           </dependency>
+          <dependency>
+              <groupId>commons-pool.wso2</groupId>
+              <artifactId>commons-pool</artifactId>
+              <version>${commons.pool.wso2.version}</version>
+          </dependency>
       </dependencies>
    </dependencyManagement>
     <reporting>
@@ -1239,7 +1249,9 @@
       <!-- Synapse and related components -->
       <synapse.version>${project.version}</synapse.version>
       <commons.dbcp.version>1.2.2</commons.dbcp.version>
+      <commons.dbcp.wso2.version>1.4.0.wso2v1</commons.dbcp.wso2.version>
       <commons.pool.version>1.3</commons.pool.version>
+      <commons.pool.wso2.version>1.5.0.wso2v1</commons.pool.wso2.version>
       <commons.vfs.version>2.2-wso2v6</commons.vfs.version>
       <truezip.version>6.6</truezip.version>
       <commons.net.version>3.4</commons.net.version>


### PR DESCRIPTION
## Purpose
Fix class not found for org.apache.commons.dbcp.BasicDataSource while running smoke tests in Micro integrator.