### PR TITLE
Fix NullPointer issue with tooling debugger

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/debug/SynapseDebugManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/debug/SynapseDebugManager.java
@@ -1090,8 +1090,8 @@ public class SynapseDebugManager implements Observer {
         result.put(SynapseDebugCommandConstants.AXIS2_PROPERTY_MESSAGE_ID,
                 synCtx.getMessageID() != null ? synCtx.getMessageID() : "");
         result.put(SynapseDebugCommandConstants.AXIS2_PROPERTY_DIRECTION, synCtx.isResponse() ? "response" : "request");
-        if (((String) ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty("messageType"))
-                .contains("json")) {
+        Object messageTypeProperty = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty("messageType");
+        if (messageTypeProperty != null && ((String) messageTypeProperty).contains("json")) {
             InputStream jsonPayloadStream = JsonUtil
                     .getJsonPayload(((Axis2MessageContext) synCtx).getAxis2MessageContext());
             if (jsonPayloadStream != null) {


### PR DESCRIPTION
## Purpose
Fix the NullPointer issue comes when there is no 'messageType' property set from the synapse configuration, while debugging via tooling.
