### PR TITLE
fix: set fileLocking variable properly in VFSOutTransportInfo

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
@@ -126,9 +126,9 @@ public class VFSOutTransportInfo implements OutTransportInfo {
         if (properties.containsKey(VFSConstants.TRANSPORT_FILE_LOCKING)) {
             String strFileLocking = properties.get(VFSConstants.TRANSPORT_FILE_LOCKING);
             if (VFSConstants.TRANSPORT_FILE_LOCKING_ENABLED.equals(strFileLocking)) {
-                fileLocking = true;
+                this.fileLocking = true;
             } else if (VFSConstants.TRANSPORT_FILE_LOCKING_DISABLED.equals(strFileLocking)) {
-                fileLocking = false;
+                this.fileLocking = false;
             }
         } else {
             this.fileLocking = fileLocking;


### PR DESCRIPTION
Solves https://github.com/wso2/product-ei/issues/4595 but using the address URI as follows 
```xml
<address uri="vfs:ftp://admin:admin@10.100.1.247:2121/test/test.txt?sftpPathFromRoot=true&amp;transport.vfs.Locking=enable"/>
```
(not using the property `<property name="transport.vfs.Locking" value="enable"/>`)