### PR TITLE
Fix EI-4354 Remove Call Template's Content Awareness

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
@@ -154,6 +154,12 @@ public class InvokeMediator extends AbstractMediator implements
 		return false;
 	}
 
+	@Override
+	public boolean isContentAware() {
+		//parameters with expression will  be evaluated by relevant mediators in the template
+		return false;
+	}
+
     public boolean mediate(MessageContext synCtx, ContinuationState continuationState) {
         SynapseLog synLog = getLog(synCtx);
 


### PR DESCRIPTION
## Purpose

The mediator invoking call template `invokeMediator` is always content aware, which causes message to be built unnecessarily even if all parameters are just values. Once we make it false, parameters are evaluated at the required mediators in the template. 

## Goals

Fixes: https://github.com/wso2/product-ei/issues/4354