### PR TITLE
Add file property resolver

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.synapse.commons.resolvers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.util.FilePropertyLoader;
+
+/**
+ *  File Property resolver can be used to resolve file property variables in the synapse config.
+ */
+public class FilePropertyResolver implements Resolver {
+
+    private static final Log log = LogFactory.getLog(FilePropertyResolver.class);
+
+    private String input;
+
+    /**
+     * set environment variable which needs to resolved
+     **/
+    @Override
+    public void setVariable(String input) {
+        this.input = input;
+    }
+
+    /**
+     * file property variable is resolved in this function
+     * @return resolved value for the file property variable
+     */
+    @Override
+    public String resolve() {
+        FilePropertyLoader fileLoaderObject = FilePropertyLoader.getFileLoaderInstance();
+        fileLoaderObject.setFileValue(input);
+        String filePropertyValue = fileLoaderObject.getFileValue();
+
+        log.debug("resolving PropertiesFile value "+filePropertyValue);
+        if (filePropertyValue == null) {
+            throw new ResolverException("File Property variable could not be found");
+        }
+        return filePropertyValue;
+    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
@@ -24,13 +24,12 @@ import org.apache.synapse.commons.util.FilePropertyLoader;
  */
 public class FilePropertyResolver implements Resolver {
 
-    private static final Log log = LogFactory.getLog(FilePropertyResolver.class);
+    private static final Log LOG = LogFactory.getLog(FilePropertyResolver.class);
 
+    //input is the file property key value which needs to resolve
     private String input;
 
-    /**
-     * set environment variable which needs to resolved
-     **/
+    // set file property variable which needs to resolved
     @Override
     public void setVariable(String input) {
         this.input = input;
@@ -46,7 +45,7 @@ public class FilePropertyResolver implements Resolver {
         fileLoaderObject.setFileValue(input);
         String filePropertyValue = fileLoaderObject.getFileValue();
 
-        log.debug("resolving PropertiesFile value "+filePropertyValue);
+        LOG.debug("resolving PropertiesFile value "+filePropertyValue);
         if (filePropertyValue == null) {
             throw new ResolverException("File Property variable could not be found");
         }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/FilePropertyResolver.java
@@ -20,16 +20,22 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.util.FilePropertyLoader;
 
 /**
- *  File Property resolver can be used to resolve file property variables in the synapse config.
+ * File Property resolver can be used to resolve file property variables in the synapse config.
  */
 public class FilePropertyResolver implements Resolver {
 
     private static final Log LOG = LogFactory.getLog(FilePropertyResolver.class);
 
-    //input is the file property key value which needs to resolve
+    /**
+     * input is the file property key value which needs to resolve
+     */
     private String input;
 
-    // set file property variable which needs to resolved
+    /**
+     * set file property variable which needs to resolved
+     *
+     * @param input
+     */
     @Override
     public void setVariable(String input) {
         this.input = input;
@@ -37,18 +43,21 @@ public class FilePropertyResolver implements Resolver {
 
     /**
      * file property variable is resolved in this function
+     *
      * @return resolved value for the file property variable
      */
     @Override
     public String resolve() {
-        FilePropertyLoader fileLoaderObject = FilePropertyLoader.getFileLoaderInstance();
-        fileLoaderObject.setFileValue(input);
-        String filePropertyValue = fileLoaderObject.getFileValue();
+        FilePropertyLoader propertyLoader = FilePropertyLoader.getInstance();
+        String PropertyValue = propertyLoader.getValue(input);
 
-        LOG.debug("resolving PropertiesFile value "+filePropertyValue);
-        if (filePropertyValue == null) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Resolving File Property value " + PropertyValue);
+        }
+
+        if (PropertyValue == null) {
             throw new ResolverException("File Property variable could not be found");
         }
-        return filePropertyValue;
+        return PropertyValue;
     }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
@@ -33,7 +33,7 @@ public class ResolverFactory {
     private final Pattern rePattern = Pattern.compile("(\\$)([a-zA-Z0-9]+):([_a-zA-Z0-9]+)");
     private static final Log LOG = LogFactory.getLog(ResolverFactory.class);
     private static final String SYSTEM_VARIABLE_PREFIX = "$SYSTEM";
-    private static final String FILE_PROPERTY_VARIABLE_PREFIX = "$FILEPROPERTY";
+    private static final String FILE_PROPERTY_VARIABLE_PREFIX = "$FILE";
 
     private Map<String, Class<? extends Resolver>> resolverMap = new HashMap<>();
 
@@ -89,7 +89,7 @@ public class ResolverFactory {
                         resolverObject.setVariable(matcher.group(3));
                         return resolverObject;
                     } catch (IllegalAccessException | InstantiationException e) {
-                        throw new ResolverException("Resolver could not be found");
+                        throw new ResolverException("Resolver could not be initialized", e);
                     }
                 } else {
                     throw new ResolverException("Resolver could not be found");
@@ -105,7 +105,7 @@ public class ResolverFactory {
 
     private void registerResolvers() {
         resolverMap.put("system", SystemResolver.class);
-        resolverMap.put("fileproperty", FilePropertyResolver.class);
+        resolverMap.put("file", FilePropertyResolver.class);
     }
 
     private void registerExterns() {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
@@ -33,6 +33,7 @@ public class ResolverFactory {
     private final Pattern rePattern = Pattern.compile("(\\$)([a-zA-Z0-9]+):([_a-zA-Z0-9]+)");
     private static final Log log = LogFactory.getLog(ResolverFactory.class);
     private static final String SYSTEM_VARIABLE_PREFIX = "$SYSTEM";
+    private static final String FILE_PROPERTY_VARIABLE_PREFIX = "$FILEPROPERTY";
 
     private Map<String, Class<? extends Resolver>> resolverMap = new HashMap<>();
 
@@ -77,6 +78,23 @@ public class ResolverFactory {
                     throw new ResolverException("Resolver could not be found");
                 }
             }
+        } else if(input.startsWith(FILE_PROPERTY_VARIABLE_PREFIX)){
+            Matcher matcher = rePattern.matcher(input);
+            Resolver resolverObject = null;
+            if (matcher.find()){
+                Class<? extends Resolver> resolverClass = resolverMap.get(matcher.group(RESOLVER_INDEX).toLowerCase());
+                if (resolverClass != null) {
+                    try {
+                        resolverObject = resolverClass.newInstance();
+                        resolverObject.setVariable(matcher.group(3));
+                        return resolverObject;
+                    } catch (IllegalAccessException | InstantiationException e) {
+                        throw new ResolverException("Resolver could not be found");
+                    }
+                } else {
+                    throw new ResolverException("Resolver could not be found");
+                }
+            }
         }
 
         Resolver resolver = new DefaultResolver();
@@ -87,6 +105,7 @@ public class ResolverFactory {
 
     private void registerResolvers() {
         resolverMap.put("system", SystemResolver.class);
+        resolverMap.put("fileproperty", FilePropertyResolver.class);
     }
 
     private void registerExterns() {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/resolvers/ResolverFactory.java
@@ -31,7 +31,7 @@ public class ResolverFactory {
     private static final int RESOLVER_INDEX = 2;
     private static ResolverFactory resolverFactory = new ResolverFactory();
     private final Pattern rePattern = Pattern.compile("(\\$)([a-zA-Z0-9]+):([_a-zA-Z0-9]+)");
-    private static final Log log = LogFactory.getLog(ResolverFactory.class);
+    private static final Log LOG = LogFactory.getLog(ResolverFactory.class);
     private static final String SYSTEM_VARIABLE_PREFIX = "$SYSTEM";
     private static final String FILE_PROPERTY_VARIABLE_PREFIX = "$FILEPROPERTY";
 
@@ -116,13 +116,13 @@ public class ResolverFactory {
             className = packageList[packageList.length - 1];
             if (resolverMap.get(className.toLowerCase()) == null) {
                 resolverMap.put(className.toLowerCase(), resolver.getClass());
-                if (log.isDebugEnabled()) {
-                    log.debug("Added Resolver " + className + " to resolver factory ");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Added Resolver " + className + " to resolver factory ");
                 }
             }
             else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to Resolver " + className + " to resolver factory. Already exist");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to Resolver " + className + " to resolver factory. Already exist");
                 }
             }
         }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
@@ -33,7 +33,7 @@ import java.util.Properties;
  */
 public class FilePropertyLoader {
 
-    private static final Log log = LogFactory.getLog(FilePropertyLoader.class);
+    private static final Log LOG = LogFactory.getLog(FilePropertyLoader.class);
     private static final String CONF_LOCATION = "conf.location";
     private static final String SYNAPSE_PROPERTY_FILE = "synapse.properties";
     private static final String FILE_PROPERTY_PATH = "synapse.commons.file.properties.location";
@@ -116,12 +116,12 @@ public class FilePropertyLoader {
                         }
                         props.put(entry.getKey(), value);
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("Loaded factory properties from " + fileName + ": " + props);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Loaded factory properties from " + fileName + ": " + props);
                     }
                     return props;
                 } catch (IOException ex) {
-                    log.error("Failed to read " + fileName, ex);
+                    LOG.error("Failed to read " + fileName, ex);
                     return null;
                 } finally {
                     try {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,13 @@ public class FilePropertyLoader {
         String filePath = properties.getProperty(FILE_PROPERTY_PATH);
         String fileName = properties.getProperty(FILE_PROPERTY_FILENAME);
 
+        if ( null == fileName || fileName.isEmpty()) {
+            throw new SynapseCommonsException(FILE_PROPERTY_FILENAME + "is empty or null");
+        }
+        if ( null == filePath || filePath.isEmpty()) {
+            throw new SynapseCommonsException(FILE_PROPERTY_PATH + "is empty or null");
+        }
+
         if (("default").equals(filePath)) {
             filePath = System.getProperty(CONF_LOCATION);
         }
@@ -68,10 +75,9 @@ public class FilePropertyLoader {
                 Properties rawProps = new Properties();
                 propertyMap = new HashMap();
                 rawProps.load(in);
-                for (Iterator it = rawProps.entrySet().iterator(); it.hasNext(); ) {
-                    Map.Entry entry = (Map.Entry) it.next();
-                    String strValue = (String) entry.getValue();
-                    propertyMap.put(entry.getKey(), strValue);
+                for (Map.Entry<Object, Object> propertyEntry : rawProps.entrySet()) {
+                    String strValue = (String) propertyEntry.getValue();
+                    propertyMap.put(propertyEntry.getKey(), strValue);
                 }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Loaded factory properties from " + fileName + ": " + propertyMap);

--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.synapse.commons.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *  File Property loader can be used to load the file property variables.
+ */
+public class FilePropertyLoader {
+
+    private static final Log log = LogFactory.getLog(FilePropertyLoader.class);
+    private static final String CONF_LOCATION = "conf.location";
+    private static FilePropertyLoader fileLoaderInstance = new FilePropertyLoader();
+    private static Map fileProperty;
+    private static String fileValue;
+
+    private FilePropertyLoader(){}
+
+    public static FilePropertyLoader getFileLoaderInstance(){
+        return fileLoaderInstance;
+    }
+
+    public static Map getFileProperty() {
+        return fileProperty;
+    }
+
+    public static void setFileProperty(Map fileProperty) {
+        FilePropertyLoader.fileProperty = fileProperty;
+    }
+
+    public static String getFileValue() {
+        return fileValue;
+    }
+
+    public static void setFileValue(String input) {
+        FilePropertyLoader.fileValue = (String) getFileProperty().get(input);
+    }
+
+    public static void loadPropertiesFile(){
+        try {
+            fileProperty = readFileProperties("file.properties");
+
+            if (fileProperty != null) {
+                setFileProperty(fileProperty);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    static Map readFileProperties(String name) throws FileNotFoundException {
+
+        InputStream in = new FileInputStream(System.getProperty(CONF_LOCATION) + File.separator + name);
+
+        if (in == null) {
+            return null;
+        } else {
+            try {
+                Properties rawProps = new Properties();
+                Map props = new HashMap();
+                rawProps.load(in);
+                for (Iterator it = rawProps.entrySet().iterator(); it.hasNext(); ) {
+                    Map.Entry entry = (Map.Entry)it.next();
+                    String strValue = (String)entry.getValue();
+                    Object value;
+                    if (strValue.equals("true")) {
+                        value = Boolean.TRUE;
+                    } else if (strValue.equals("false")) {
+                        value = Boolean.FALSE;
+                    } else {
+                        try {
+                            value = Integer.valueOf(strValue);
+                        } catch (NumberFormatException ex) {
+                            value = strValue;
+                        }
+                    }
+                    props.put(entry.getKey(), value);
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Loaded factory properties from " + name + ": " + props);
+                }
+                return props;
+            } catch (IOException ex) {
+                log.error("Failed to read " + name, ex);
+                return null;
+            } finally {
+                try {
+                    in.close();
+                } catch (IOException ex) {
+                    // Ignore
+                }
+            }
+        }
+    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
@@ -17,10 +17,10 @@ package org.apache.synapse.commons.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.SynapseCommonsException;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.HashMap;
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- *  File Property loader can be used to load the file property variables.
+ * File Property loader can be used to load the file property variables.
  */
 public class FilePropertyLoader {
 
@@ -38,101 +38,49 @@ public class FilePropertyLoader {
     private static final String SYNAPSE_PROPERTY_FILE = "synapse.properties";
     private static final String FILE_PROPERTY_PATH = "synapse.commons.file.properties.location";
     private static final String FILE_PROPERTY_FILENAME = "synapse.commons.file.properties.file.name";
+    public Map propertyMap;
+
     private static FilePropertyLoader fileLoaderInstance = new FilePropertyLoader();
-    private static Map fileProperty;
-    private static String fileValue;
 
-    private FilePropertyLoader(){}
-
-    public static FilePropertyLoader getFileLoaderInstance(){
+    public static FilePropertyLoader getInstance() {
         return fileLoaderInstance;
     }
 
-    public static Map getFileProperty() {
-        return fileProperty;
+    public String getValue(String input) {
+        return (String) propertyMap.get(input);
     }
 
-    public static void setFileProperty(Map fileProperty) {
-        FilePropertyLoader.fileProperty = fileProperty;
-    }
-
-    public static String getFileValue() {
-        return fileValue;
-    }
-
-    public static void setFileValue(String input) {
-        FilePropertyLoader.fileValue = (String) getFileProperty().get(input);
-    }
-
-    public static void loadPropertiesFile(){
-        try {
-            fileProperty = readFileProperties();
-
-            if (fileProperty != null) {
-                setFileProperty(fileProperty);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    static Map readFileProperties() throws FileNotFoundException {
+    public void loadPropertiesFile() throws SynapseCommonsException {
 
         Properties properties = MiscellaneousUtil.loadProperties(SYNAPSE_PROPERTY_FILE);
         String filePath = properties.getProperty(FILE_PROPERTY_PATH);
         String fileName = properties.getProperty(FILE_PROPERTY_FILENAME);
 
-        if(filePath.equals("default")){
+        if (("default").equals(filePath)) {
             filePath = System.getProperty(CONF_LOCATION);
         }
 
-        File fileDir = new File(filePath + File.separator + fileName);
-        boolean isFileExists = fileDir.exists();
+        File file = new File(filePath + File.separator + fileName);
+        boolean isFileExists = file.exists();
 
         if (isFileExists) {
-            InputStream in = new FileInputStream(filePath + File.separator + fileName);
-
-            if (in == null) {
-                return null;
-            } else {
-                try {
-                    Properties rawProps = new Properties();
-                    Map props = new HashMap();
-                    rawProps.load(in);
-                    for (Iterator it = rawProps.entrySet().iterator(); it.hasNext(); ) {
-                        Map.Entry entry = (Map.Entry)it.next();
-                        String strValue = (String)entry.getValue();
-                        Object value;
-                        if (strValue.equals("true")) {
-                            value = Boolean.TRUE;
-                        } else if (strValue.equals("false")) {
-                            value = Boolean.FALSE;
-                        } else {
-                            try {
-                                value = Integer.valueOf(strValue);
-                            } catch (NumberFormatException ex) {
-                                value = strValue;
-                            }
-                        }
-                        props.put(entry.getKey(), value);
-                    }
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Loaded factory properties from " + fileName + ": " + props);
-                    }
-                    return props;
-                } catch (IOException ex) {
-                    LOG.error("Failed to read " + fileName, ex);
-                    return null;
-                } finally {
-                    try {
-                        in.close();
-                    } catch (IOException ex) {
-                        // Ignore
-                    }
+            try (InputStream in = new FileInputStream(filePath + File.separator + fileName)) {
+                Properties rawProps = new Properties();
+                propertyMap = new HashMap();
+                rawProps.load(in);
+                for (Iterator it = rawProps.entrySet().iterator(); it.hasNext(); ) {
+                    Map.Entry entry = (Map.Entry) it.next();
+                    String strValue = (String) entry.getValue();
+                    propertyMap.put(entry.getKey(), strValue);
                 }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Loaded factory properties from " + fileName + ": " + propertyMap);
+                }
+            } catch (IOException ex) {
+                throw new SynapseCommonsException("Failed to read " + fileName, ex);
             }
         } else {
-            return null;
+            throw new SynapseCommonsException(fileName + " file cannot found in " + filePath);
         }
     }
 }

--- a/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
@@ -19,18 +19,18 @@ package org.apache.synapse.commons.resolvers;
 
 import junit.framework.TestCase;
 import org.apache.synapse.commons.util.FilePropertyLoader;
-import java.util.HashMap;
-import java.util.Map;
 
 public class FilePropertyResolverTest extends TestCase {
 
+    /**
+     * Test file property resolve method
+     */
     public void testResolve() {
-        Map<String,String> fileProps = new HashMap<String,String>();
-        fileProps.put("testKey", "testValue");
-        FilePropertyLoader fileLoaderObject = FilePropertyLoader.getFileLoaderInstance();
-        fileLoaderObject.setFileProperty(fileProps);
-        fileLoaderObject.setFileValue("testKey");
-        String filePropertyValue = fileLoaderObject.getFileValue();
+        String inputValue = "testKey";
+        FilePropertyLoader propertyLoader = FilePropertyLoader.getInstance();
+        System.setProperty("conf.location", System.getProperty("user.dir") + "/src/test/resources/");
+        propertyLoader.loadPropertiesFile();
+        String filePropertyValue = propertyLoader.getValue(inputValue);
         assertEquals("Couldn't resolve the file property variable", "testValue", filePropertyValue);
     }
 }

--- a/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
+++ b/modules/commons/src/test/java/org/apache/synapse/commons/resolvers/FilePropertyResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.resolvers;
+
+import junit.framework.TestCase;
+import org.apache.synapse.commons.util.FilePropertyLoader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FilePropertyResolverTest extends TestCase {
+
+    public void testResolve() {
+        Map<String,String> fileProps = new HashMap<String,String>();
+        fileProps.put("testKey", "testValue");
+        FilePropertyLoader fileLoaderObject = FilePropertyLoader.getFileLoaderInstance();
+        fileLoaderObject.setFileProperty(fileProps);
+        fileLoaderObject.setFileValue("testKey");
+        String filePropertyValue = fileLoaderObject.getFileValue();
+        assertEquals("Couldn't resolve the file property variable", "testValue", filePropertyValue);
+    }
+}

--- a/modules/commons/src/test/resources/file.properties
+++ b/modules/commons/src/test/resources/file.properties
@@ -1,0 +1,1 @@
+testKey=testValue

--- a/modules/commons/src/test/resources/synapse.properties
+++ b/modules/commons/src/test/resources/synapse.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##############################################
+#
+# WARNING: Don't edit the file manually unless you are not using the deployment.toml file.
+#
+##############################################
+synapse.commons.file.properties.file.name = file.properties
+synapse.commons.file.properties.location = default

--- a/modules/core/src/main/java/org/apache/synapse/ServerManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerManager.java
@@ -28,7 +28,6 @@ import org.wso2.securevault.PasswordManager;
 import org.wso2.securevault.SecurityConstants;
 
 import javax.management.NotCompliantMBeanException;
-import java.io.IOException;
 import java.util.Date;
 
 /**

--- a/modules/core/src/main/java/org/apache/synapse/ServerManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerManager.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.commons.jmx.MBeanRegistrar;
+import org.apache.synapse.commons.util.FilePropertyLoader;
 import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.wso2.securevault.PasswordManager;
 import org.wso2.securevault.SecurityConstants;
@@ -107,6 +108,10 @@ public class ServerManager {
         doInit();
         initialized = true;
         RuntimeStatisticCollector.init();
+
+        //Loading file properties before synapse environment start
+        log.debug("Loading file property configurations");
+        FilePropertyLoader.loadPropertiesFile();
 
         return this.serverContextInformation.getServerState();
     }


### PR DESCRIPTION
## Purpose
This feature supports reading properties from a file and enables parameterizing the synapse configurations as key-value pairs that will be resolved using the file property resolver when deploying new artifacts.  

## Test environment
micro-integrator
