### PR TITLE
Add secure vault support for proxy services

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
@@ -1531,9 +1531,6 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
             ((ManagedLifecycle) registry).init(se);
         }
 
-        //we initialize xpath extensions here since synapse environment is available
-        initXpathExtensions(se);
-
         initCarbonTenantConfigurator(se);
 
         //initialize endpoints
@@ -2145,35 +2142,6 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
 
     public void setAllowHotUpdate(boolean allowHotUpdate) {
         this.allowHotUpdate = allowHotUpdate;
-    }
-
-    /**
-     * This method initializes Xpath Extensions available through synapse.properties file
-     * Xpath Extensions can be defined in Variable Context Extensions + Function Context Extensions
-     * synapse.xpath.var.extensions --> Variable Extensions
-     * synapse.xpath.func.extensions --> Function Extensions
-     *
-     * @param synapseEnvironment SynapseEnvironment
-     */
-    private void initXpathExtensions(SynapseEnvironment synapseEnvironment) {
-        Axis2SynapseEnvironment axis2SynapseEnvironment = (Axis2SynapseEnvironment) synapseEnvironment;
-
-        /*Initialize Function Context extensions for xpath
-        */
-        List<SynapseXpathFunctionContextProvider> functionExtensions =
-                XpathExtensionUtil.getRegisteredFunctionExtensions();
-        for (SynapseXpathFunctionContextProvider functionExtension : functionExtensions) {
-            axis2SynapseEnvironment.setXpathFunctionExtensions(functionExtension);
-        }
-
-        /*Initialize Variable Context extensions for xpath
-        */
-        List<SynapseXpathVariableResolver> variableExtensions =
-                XpathExtensionUtil.getRegisteredVariableExtensions();
-        for (SynapseXpathVariableResolver variableExtension : variableExtensions) {
-            axis2SynapseEnvironment.setXpathVariableExtensions(variableExtension);
-        }
-
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Fixes: https://github.com/wso2/product-ei/issues/4093

Users can use the secure-vault password alias (Eg. 'MAIL.LISTENER.PASSWORD') in proxy definition as shown below,

`<parameter name="mail.pop3.password">{vault-lookup('MAIL.LISTENER.PASSWORD')}</parameter>`

## Approach
> When a proxy service is being deployed we process the configured parameters and add to axisService. Before adding the parameters to axisService we check for secure vault expression (wso2:vault-lookup) and resolve if it is configured. Then the resolved value is added to the axisService.

This PR should be merged after merging https://github.com/wso2/carbon-mediation/pull/1353  and updating the mediation version.