### PR TITLE
Improve code to not resolve hostname or ip unless required

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ServerSSLSetupHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ServerSSLSetupHandler.java
@@ -75,24 +75,24 @@ public class ServerSSLSetupHandler implements SSLSetupHandler {
     public void verify(
             final IOSession iosession,
             final SSLSession sslsession) throws SSLException {
-        SocketAddress remoteAddress = iosession.getRemoteAddress();
-        String address;
-        if (remoteAddress instanceof InetSocketAddress) {
-            InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
-            InetAddress internetAddress = inetSocketAddress.getAddress();
-            if (internetAddress != null) {
-                address = internetAddress.getHostAddress();
-            } else {
-                address = inetSocketAddress.getHostName();
-            }
-        } else {
-            address = remoteAddress.toString();
-        }
 
         if (verificationManager != null) {
             try {
                 verificationManager.verifyRevocationStatus(sslsession.getPeerCertificateChain());
             } catch (CertificateVerificationException e) {
+                SocketAddress remoteAddress = iosession.getRemoteAddress();
+                String address;
+                if (remoteAddress instanceof InetSocketAddress) {
+                    InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
+                    InetAddress internetAddress = inetSocketAddress.getAddress();
+                    if (internetAddress != null) {
+                        address = internetAddress.getHostAddress();
+                    } else {
+                        address = inetSocketAddress.getHostName();
+                    }
+                } else {
+                    address = remoteAddress.toString();
+                }
                 throw new SSLException("Certificate Chain Validation failed for host : " + address, e);
             }
         }


### PR DESCRIPTION
## Purpose
> This is an improvement of https://github.com/wso2/wso2-synapse/pull/1430
We can further improve this code to not retrieve the hostname or ip until it is really required. The address is only used for the logging purpose when an exception occurs. But for all the requests we resolve the hostname or ip. 
We can move this logic to catch block. So that it only gets executed when it really required.
