### PR TITLE
Add an env scope to the get-property and property mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
@@ -51,6 +51,8 @@ public class XMLConfigConstants {
     public static final String SCOPE_REGISTRY = "registry";
     /** The scope name for system properties */
     public static final String SCOPE_SYSTEM = "system";
+    /** The scope name for environment variables */
+    public static final String SCOPE_ENVIRONMENT = "env";
     public static final String KEY = "key";
     public static final String LOCATION = "location";
     public static final String RECEIVE = "receive";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/GetPropertyFunction.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/GetPropertyFunction.java
@@ -108,7 +108,8 @@ public class GetPropertyFunction implements Function , XPathFunction {
                         !XMLConfigConstants.SCOPE_TRANSPORT.equals(argOne) &&
                             !XMLConfigConstants.SCOPE_REGISTRY.equals(argOne) &&
                             !XMLConfigConstants.SCOPE_FUNC.equals(argOne) &&
-                            !XMLConfigConstants.SCOPE_SYSTEM.equals(argOne)) {
+                            !XMLConfigConstants.SCOPE_SYSTEM.equals(argOne) &&
+                            !XMLConfigConstants.SCOPE_ENVIRONMENT.equals(argOne)) {
                         return evaluate(XMLConfigConstants.SCOPE_DEFAULT, args.get(0),
                             args.get(1), context.getNavigator());
                     } else {
@@ -345,6 +346,17 @@ public class GetPropertyFunction implements Function , XPathFunction {
             } else {
                 if (traceOrDebugOn) {
                     traceOrDebug(traceOn, "System property " + key + " not found");
+                }
+                return NULL_STRING;
+            }
+
+        } else if (XMLConfigConstants.SCOPE_ENVIRONMENT.equals(scope)) {
+            String propVal = System.getenv(key);
+            if (propVal != null) {
+                return propVal;
+            } else {
+                if (traceOrDebugOn) {
+                    traceOrDebug(traceOn, "Environment property " + key + " not found");
                 }
                 return NULL_STRING;
             }

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
@@ -56,18 +56,18 @@ import org.jaxen.JaxenException;
 import org.jaxen.UnresolvableException;
 import org.jaxen.util.SingletonList;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
 
 
@@ -179,9 +179,10 @@ public class SynapseXPath extends SynapsePath {
 	 // for get-property() method
 	 if (XMLConfigConstants.SCOPE_REGISTRY.equals(propertyScope)
 			|| XMLConfigConstants.SCOPE_SYSTEM.equals(propertyScope)
-			|| XMLConfigConstants.SCOPE_TRANSPORT.equals(propertyScope)) {
-	    contentAware = false;
-	    return;
+             || XMLConfigConstants.SCOPE_TRANSPORT.equals(propertyScope)
+             || XMLConfigConstants.SCOPE_SYSTEM.equals(propertyScope)) {
+         contentAware = false;
+         return;
 	 }
 
         if(xpathString.contains("$trp") || xpathString.contains("$ctx") || xpathString.contains("$axis2")){


### PR DESCRIPTION

## Purpose
Give the support for "get-property('env','vari')" expression for
the property mediator.

Fix: https://github.com/wso2/product-ei/issues/4760
