### PR TITLE
Fixing access Logs not rotating when not having locale English

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
@@ -35,6 +35,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -251,7 +252,7 @@ public class AccessLogger {
                             Matcher matcher = pattern.matcher(line);
                             if (matcher.find()) {
                                 String date = matcher.group(1);
-                                SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STRING);
+                                SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STRING,Locale.ENGLISH);
                                 dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
                                 Date lastDateFromLog = dateFormat.parse(date);
                                 // if same day - write to the existing file


### PR DESCRIPTION
## Issue

product-apim:wso2/product-apim#7029

## Methodology
- Passing locale.ENGLISH when creating SimpleDateFormat object.
