### PR TITLE
Fix http access log entries getting printed with wrong timezone offset value

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessTimeUtil.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessTimeUtil.java
@@ -58,7 +58,7 @@ public class AccessTimeUtil {
      */
     public static String getTimeZone() {
         try {
-            int offset = TimeZone.getDefault().getRawOffset();
+            int offset = TimeZone.getDefault().getOffset(System.currentTimeMillis());
             return calculateTimeZoneOffset(offset);
         } catch (Exception e) {
             return "";


### PR DESCRIPTION
## Purpose
> Fix HTTP access log entries getting printed with wrong timezone offset value

