### PR TITLE
Add Jaeger Tracing functionality

### DIFF
--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -193,11 +193,11 @@
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.namespace,
-                            javax.xml.namespace;
-                            version=0.0.0,
-                            !javax.xml.soap,
-                            javax.xml.soap; version=${javax.xml.soap.version},
-                            !org.apache.commons.io,
+							!javax.xml.soap,
+							!org.apache.commons.io,
+							javax.xml.namespace;
+							version=0.0.0,
+							javax.xml.soap; version=${javax.xml.soap.version},
                             org.apache.commons.io; version=0.0.0,
                             org.quartz.*;version="${quartz.version}",
                             *;resolution:=optional
@@ -427,7 +427,4 @@
 			<version>${org.wso2.json.version}</version>
 		</dependency>
     </dependencies>
-    <properties>
-        <version.orbit.rabbitmq>3.6.6.wso2v1</version.orbit.rabbitmq>
-    </properties>
 </project>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -190,10 +190,6 @@
                             org.apache.synapse.continuation.*,
                             org.apache.synapse.debug.*,
                             org.apache.synapse.messageflowtracer.*,
-
-							io.jaegertracing.*,
-							io.opentracing.*,
-							com.squareup.*
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.namespace,
@@ -204,16 +200,8 @@
                             !org.apache.commons.io,
                             org.apache.commons.io; version=0.0.0,
                             org.quartz.*;version="${quartz.version}",
-
-                            io.jaegertracing.*,
-                            io.opentracing.*,
-                            com.squareup.*
-
-                            *;resolution:=optional,
+                            *;resolution:=optional
                         </Import-Package>
-						<Private-Package>
-							org.apache.thrift; version="[0.11.0,1.0.0)"
-						</Private-Package>
 						<DynamicImport-Package>*</DynamicImport-Package>
 					</instructions>
 				</configuration>
@@ -410,7 +398,7 @@
         <!-- Jaeger Tracing -->
 		<dependency>
 			<groupId>org.wso2.orbit.io.jaeger</groupId>
-			<artifactId>jaegerclient</artifactId>
+			<artifactId>jaeger-client</artifactId>
 		</dependency>
 
         <dependency>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.apache.synapse</groupId>
 		<artifactId>Apache-Synapse</artifactId>
-		<version>2.1.7-wso2v138-SNAPSHOT</version>
+		<version>2.1.7-wso2v138</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -193,11 +193,11 @@
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.namespace,
-							!javax.xml.soap,
-							!org.apache.commons.io,
-							javax.xml.namespace;
-							version=0.0.0,
-							javax.xml.soap; version=${javax.xml.soap.version},
+                            !javax.xml.soap,
+                            !org.apache.commons.io,
+                            javax.xml.namespace;
+                            version=0.0.0,
+                            javax.xml.soap; version=${javax.xml.soap.version},
                             org.apache.commons.io; version=0.0.0,
                             org.quartz.*;version="${quartz.version}",
                             *;resolution:=optional

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.apache.synapse</groupId>
 		<artifactId>Apache-Synapse</artifactId>
-		<version>2.1.7-wso2v138</version>
+		<version>2.1.7-wso2v139-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.apache.synapse</groupId>
 		<artifactId>Apache-Synapse</artifactId>
-		<version>2.1.7-wso2v139</version>
+		<version>2.1.7-wso2v140-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.apache.synapse</groupId>
 		<artifactId>Apache-Synapse</artifactId>
-		<version>2.1.7-wso2v139-SNAPSHOT</version>
+		<version>2.1.7-wso2v139</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CallbackStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CallbackStatisticCollector.java
@@ -52,7 +52,7 @@ public class CallbackStatisticCollector extends RuntimeStatisticCollector {
 
             if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleAddCallback(messageContext, callbackId);
+					.handleAddCallback(messageContext, callbackId);
 			}
 		}
 	}
@@ -79,7 +79,7 @@ public class CallbackStatisticCollector extends RuntimeStatisticCollector {
 
             if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleCallbackCompletionEvent(oldMessageContext, callbackId);
+					.handleCallbackCompletionEvent(oldMessageContext, callbackId);
 			}
 		}
 	}
@@ -105,7 +105,7 @@ public class CallbackStatisticCollector extends RuntimeStatisticCollector {
 
             if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleUpdateParentsForCallback(oldMessageContext, callbackId);
+					.handleUpdateParentsForCallback(oldMessageContext, callbackId);
 			}
 		}
 	}
@@ -131,7 +131,7 @@ public class CallbackStatisticCollector extends RuntimeStatisticCollector {
 
 			if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleReportCallbackHandlingCompletion(synapseOutMsgCtx, callbackId);
+					.handleReportCallbackHandlingCompletion(synapseOutMsgCtx, callbackId);
 			}
 
 		}

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CloseEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CloseEventCollector.java
@@ -77,7 +77,7 @@ public class CloseEventCollector extends RuntimeStatisticCollector {
 
 			if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler().
-						handleCloseEntryEvent(statisticDataUnit, messageContext);
+					handleCloseEntryEvent(statisticDataUnit, messageContext);
 			}
 
 		}
@@ -106,7 +106,7 @@ public class CloseEventCollector extends RuntimeStatisticCollector {
 
             if (isOpenTracingEnabled()) {
 				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleCloseFlowForcefully(dataUnit, messageContext);
+					.handleCloseFlowForcefully(dataUnit, messageContext);
 			}
 
         }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -109,8 +109,8 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
             addEventAndIncrementCount(messageContext, openEvent);
 
             if (isOpenTracingEnabled()) {
-				OpenTracingManagerHolder.getOpenTracingManager().getHandler()
-						.handleOpenEntryEvent(statisticDataUnit, messageContext);
+            	OpenTracingManagerHolder.getOpenTracingManager().getHandler()
+		            .handleOpenEntryEvent(statisticDataUnit, messageContext);
 			}
 
 			return statisticDataUnit.getCurrentIndex();

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -93,9 +93,6 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 			if (aspectConfiguration != null) {
 				statisticDataUnit.setComponentId(aspectConfiguration.getUniqueId());
 				statisticDataUnit.setHashCode(aspectConfiguration.getHashCode());
-				statisticDataUnit.artifactHolderStackString =
-                        ArtifactHolderStore.getStackString(
-                                aspectConfiguration.getUniqueId()); // TODO Remove
 			}
 			int parentIndex = StatisticDataCollectionHelper
 					.getParentFlowPosition(messageContext, statisticDataUnit.getCurrentIndex());
@@ -290,9 +287,6 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 		if(aspectConfiguration != null) {
 			statisticDataUnit.setComponentId(aspectConfiguration.getUniqueId());
 			statisticDataUnit.setHashCode(aspectConfiguration.getHashCode());
-            statisticDataUnit.artifactHolderStackString =
-                    ArtifactHolderStore.getStackString(
-                            aspectConfiguration.getUniqueId()); // TODO Remove
 		}
 		int parentIndex = StatisticDataCollectionHelper
 				.getParentFlowPosition(messageContext, statisticDataUnit.getCurrentIndex());

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -59,7 +59,6 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 
 		// Enable statistics, if user enabled for all artifacts
 		if (!isCollectingStatistics) {
-//			isCollectingStatistics = isCollectingStatistics || RuntimeStatisticCollector.isCollectingAllStatistics();
 			isCollectingStatistics = isCollectingStatistics || RuntimeStatisticCollector.isCollectingAllStatistics();
 		}
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -146,9 +146,6 @@ public abstract class RuntimeStatisticCollector {
                         StatisticsConstants.JAEGER_SENDER_AGENT_PORT, DEFAULT_JAEGER_SENDER_AGENT_PORT);
 
         // Jaeger Reporter Configurations
-        String logSpans =
-                SynapsePropertiesLoader.getPropertyValue(
-                        StatisticsConstants.JAEGER_REPORTER_LOG_SPANS, String.valueOf(false));
         String reporterMaxQueueSize =
                 SynapsePropertiesLoader.getPropertyValue(
                         StatisticsConstants.JAEGER_REPORTER_MAX_QUEUE_SIZE, DEFAULT_JAEGER_REPORTER_MAX_QUEUE_SIZE);
@@ -157,7 +154,8 @@ public abstract class RuntimeStatisticCollector {
                         StatisticsConstants.JAEGER_REPORTER_FLUSH_INTERVAL, DEFAULT_JAEGER_REPORTER_FLUSH_INTERVAL);
 
         int senderAgentPortInt = Integer.parseInt(senderAgentPort);
-        boolean logSpansBoolean = Boolean.parseBoolean(logSpans);
+        boolean logSpans =
+            SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.JAEGER_REPORTER_LOG_SPANS, false);
         int reporterMaxQueueSizeInt = Integer.parseInt(reporterMaxQueueSize);
         int reporterFlushIntervalInt = Integer.parseInt(reporterFlushInterval);
 
@@ -165,7 +163,7 @@ public abstract class RuntimeStatisticCollector {
                 samplerManagerHostPort,
                 senderAgentHost,
                 senderAgentPortInt,
-                logSpansBoolean,
+                logSpans,
                 reporterMaxQueueSizeInt,
                 reporterFlushIntervalInt);
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -69,13 +69,10 @@ public abstract class RuntimeStatisticCollector {
      * Initialize statistics collection when ESB starts.
      */
     public static void init() {
-        isMediationFlowStatisticsEnabled = Boolean.parseBoolean(
-                SynapsePropertiesLoader.getPropertyValue(
-                        StatisticsConstants.STATISTICS_ENABLE,
-                        String.valueOf(false)));
-        isOpenTracingEnabled = Boolean.parseBoolean(
-                SynapsePropertiesLoader
-                        .getPropertyValue(StatisticsConstants.OPENTRACING_ENABLE, String.valueOf(false)));
+        isMediationFlowStatisticsEnabled =
+            SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.STATISTICS_ENABLE, false);
+        isOpenTracingEnabled =
+            SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.OPENTRACING_ENABLE, false);
         isStatisticsEnabled = isMediationFlowStatisticsEnabled || isOpenTracingEnabled;
         if (isStatisticsEnabled) {
             if (log.isDebugEnabled()) {
@@ -90,22 +87,22 @@ public abstract class RuntimeStatisticCollector {
                     StatisticsConstants.FLOW_STATISTICS_EVENT_CONSUME_TIME,
                     StatisticsConstants.FLOW_STATISTICS_DEFAULT_EVENT_CONSUME_INTERVAL));
 
-            isCollectingPayloads = Boolean.parseBoolean(SynapsePropertiesLoader.getPropertyValue(
-                    StatisticsConstants.COLLECT_MESSAGE_PAYLOADS, String.valueOf(false)));
+            isCollectingPayloads =
+                SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.COLLECT_MESSAGE_PAYLOADS, false);
 
             if (!isCollectingPayloads && log.isDebugEnabled()) {
                 log.debug("Payload collecting is not enabled in \'synapse.properties\' file.");
             }
 
-            isCollectingProperties = Boolean.parseBoolean(SynapsePropertiesLoader.getPropertyValue(
-                    StatisticsConstants.COLLECT_MESSAGE_PROPERTIES, String.valueOf(false)));
+            isCollectingProperties =
+                SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.COLLECT_MESSAGE_PROPERTIES, false);
 
             if (!isCollectingProperties && log.isDebugEnabled()) {
                 log.debug("Property collecting is not enabled in \'synapse.properties\' file.");
             }
 
-            isCollectingAllStatistics = Boolean.parseBoolean(SynapsePropertiesLoader.getPropertyValue(
-                    StatisticsConstants.COLLECT_ALL_STATISTICS, String.valueOf(false)));
+            isCollectingAllStatistics =
+                SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.COLLECT_ALL_STATISTICS, false);
 
             eventExpireTime =
                     SynapseConfigUtils.getGlobalTimeoutInterval() + SynapseConfigUtils.getTimeoutHandlerInterval() +

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -79,7 +79,11 @@ public abstract class RuntimeStatisticCollector {
         isStatisticsEnabled = isMediationFlowStatisticsEnabled || isOpenTracingEnabled;
         if (isStatisticsEnabled) {
             if (log.isDebugEnabled()) {
-                log.debug("Mediation statistics collection is enabled.");
+                if (isMediationFlowStatisticsEnabled) {
+                    log.debug("Mediation statistics collection is enabled.");
+                } else if (isOpenTracingEnabled) {
+                    log.debug("OpenTracing is enabled.");
+                }
             }
 
             Long eventConsumerTime = Long.parseLong(SynapsePropertiesLoader.getPropertyValue(
@@ -109,7 +113,9 @@ public abstract class RuntimeStatisticCollector {
             log.info("Statistics Entry Expiration time set to " + eventExpireTime + " milliseconds");
             new MediationFlowController();
 
-            initOpenTracing(isCollectingPayloads, isCollectingProperties);
+            if (isOpenTracingEnabled) {
+                initOpenTracing(isCollectingPayloads, isCollectingProperties);
+            }
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Statistics is not enabled in \'synapse.properties\' file.");
@@ -164,7 +170,7 @@ public abstract class RuntimeStatisticCollector {
                 senderAgentPortInt,
                 logSpansBoolean,
                 reporterMaxQueueSizeInt,
-                reporterFlushIntervalInt); // TODO discuss about config at the end
+                reporterFlushIntervalInt);
 
         OpenTracingManagerHolder.setCollectingFlags(isCollectingPayloads, isCollectingProperties);
     }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
@@ -103,8 +103,6 @@ public class StatisticDataUnit extends BasicStatisticDataUnit {
 	 */
 	private Map<String, Object> transportPropertyMap;
 
-	public String artifactHolderStackString; // TODO Remove
-
 	public String getPayload() {
 		return payload;
 	}

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/stores/ArtifactHolderStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/stores/ArtifactHolderStore.java
@@ -47,8 +47,7 @@ public class ArtifactHolderStore {
     public static synchronized void addStructuringElementStack(String componentUniqueId,
                                                                ArtifactHolder artifactHolderReference) {
         if (artifactHolderReference != null) {
-            Stack<StructuringElement> stackCopy =
-                    getCopiedStack(componentUniqueId, artifactHolderReference.getStack());
+            Stack<StructuringElement> stackCopy = getCopiedStack(componentUniqueId, artifactHolderReference.getStack());
             structuringElementStacks.put(componentUniqueId, stackCopy);
         }
     }
@@ -78,27 +77,5 @@ public class ArtifactHolderStore {
             }
         }
         return stackCopy;
-    }
-
-    public static synchronized String getStackString(String componentUniqueId) {
-        if (componentUniqueId == null) {
-            return "null";
-        }
-        return getStackString(structuringElementStacks.get(componentUniqueId));
-    }
-
-    private static String getStackString(Stack<StructuringElement> stack) {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (stack != null) {
-            stringBuilder.append("[");
-            for (StructuringElement structuringElement : stack) {
-                stringBuilder.append(structuringElement.toString());
-                stringBuilder.append(" ,");
-            }
-            stringBuilder.append("]");
-        } else {
-            stringBuilder.append("null");
-        }
-        return stringBuilder.toString();
     }
 }

--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/coverage-report/pom.xml
+++ b/modules/coverage-report/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/org.apache.synapse.samples.feature/pom.xml
+++ b/modules/features/org.apache.synapse.samples.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.samples.feature/pom.xml
+++ b/modules/features/org.apache.synapse.samples.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.samples.feature/pom.xml
+++ b/modules/features/org.apache.synapse.samples.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.samples.feature/pom.xml
+++ b/modules/features/org.apache.synapse.samples.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.fix.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.vfs.smb.feature/pom.xml
@@ -19,7 +19,7 @@
 
     <parent>
         <artifactId>synapse-features</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <groupId>org.apache.synapse</groupId>
     </parent>
 

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -155,6 +155,7 @@
                                 <!--<bundleDef>org.wso2.orbit.joda-time:joda-time:${joda-time.version}</bundleDef>-->
                                 <bundleDef>com.google.guava:guava:${google.guava.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
+                                <bundleDef>org.wso2.orbit.io.jaeger:jaeger-client</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>commons-dbcp.wso2:commons-dbcp</importBundleDef>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>synapse-features</artifactId>
         <groupId>org.apache.synapse</groupId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>synapse-features</artifactId>
         <groupId>org.apache.synapse</groupId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>synapse-features</artifactId>
         <groupId>org.apache.synapse</groupId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>synapse-features</artifactId>
         <groupId>org.apache.synapse</groupId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>HEAD</tag>
+      <tag>v2.1.7-wso2v138</tag>
   </scm>
 
     <build>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>v2.1.7-wso2v139</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>HEAD</tag>
+      <tag>v2.1.7-wso2v139</tag>
   </scm>
 
     <build>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>v2.1.7-wso2v138</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138</version>
+        <version>2.1.7-wso2v139-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v138-SNAPSHOT</version>
+        <version>2.1.7-wso2v138</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139-SNAPSHOT</version>
+        <version>2.1.7-wso2v139</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>2.1.7-wso2v139</version>
+        <version>2.1.7-wso2v140-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.synapse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    </parent>
    <groupId>org.apache.synapse</groupId>
    <artifactId>Apache-Synapse</artifactId>
-   <version>2.1.7-wso2v138</version>
+   <version>2.1.7-wso2v139-SNAPSHOT</version>
    <name>Apache Synapse</name>
    <description>Apache Synapse</description>
    <packaging>pom</packaging>
@@ -69,7 +69,7 @@
       <connection>scm:git:https://github.com/wso2/wso2-synapse.git</connection>
       <developerConnection>scm:git:https://github.com/wso2/wso2-synapse.git</developerConnection>
       <url>https://github.com/wso2/wso2-synapse.git/</url>
-      <tag>v2.1.7-wso2v138</tag>
+      <tag>HEAD</tag>
    </scm>
    <organization>
       <name>Apache Software Foundation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    </parent>
    <groupId>org.apache.synapse</groupId>
    <artifactId>Apache-Synapse</artifactId>
-   <version>2.1.7-wso2v139-SNAPSHOT</version>
+   <version>2.1.7-wso2v139</version>
    <name>Apache Synapse</name>
    <description>Apache Synapse</description>
    <packaging>pom</packaging>
@@ -69,7 +69,7 @@
       <connection>scm:git:https://github.com/wso2/wso2-synapse.git</connection>
       <developerConnection>scm:git:https://github.com/wso2/wso2-synapse.git</developerConnection>
       <url>https://github.com/wso2/wso2-synapse.git/</url>
-      <tag>HEAD</tag>
+      <tag>v2.1.7-wso2v139</tag>
    </scm>
    <organization>
       <name>Apache Software Foundation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    </parent>
    <groupId>org.apache.synapse</groupId>
    <artifactId>Apache-Synapse</artifactId>
-   <version>2.1.7-wso2v138-SNAPSHOT</version>
+   <version>2.1.7-wso2v138</version>
    <name>Apache Synapse</name>
    <description>Apache Synapse</description>
    <packaging>pom</packaging>
@@ -69,7 +69,7 @@
       <connection>scm:git:https://github.com/wso2/wso2-synapse.git</connection>
       <developerConnection>scm:git:https://github.com/wso2/wso2-synapse.git</developerConnection>
       <url>https://github.com/wso2/wso2-synapse.git/</url>
-      <tag>HEAD</tag>
+      <tag>v2.1.7-wso2v138</tag>
    </scm>
    <organization>
       <name>Apache Software Foundation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1015,6 +1015,12 @@
               <artifactId>libphonenumber</artifactId>
               <version>${com.googlecode.libphonenumber.version}</version>
          </dependency>
+          <!--Jaeger Tracing-->
+          <dependency>
+              <groupId>org.wso2.orbit.io.jaeger</groupId>
+              <artifactId>jaeger-client</artifactId>
+              <version>${jaeger-client.version}</version>
+          </dependency>
           <!--Mockito Dependency-->
           <dependency>
               <groupId>org.powermock</groupId>
@@ -1141,11 +1147,6 @@
               <groupId>org.antlr.wso2</groupId>
               <artifactId>antlr-runtime</artifactId>
               <version>${antlr.wso2.version}</version>
-          </dependency>
-          <dependency>
-              <groupId>org.wso2.orbit.io.jaeger</groupId>
-              <artifactId>jaegerclient</artifactId>
-              <version>${jaegerclient.version}</version>
           </dependency>
       </dependencies>
    </dependencyManagement>
@@ -1321,8 +1322,6 @@
       <commons_io.version>2.0</commons_io.version>
       <commons-cli.version>1.0</commons-cli.version>
       <jline.version>0.9.94</jline.version>
-       <!-- Jaeger Tracing -->
-       <jaegerclient.version>0.32.0.wso2v2</jaegerclient.version>
       <!-- dependencies of Synapse extensions module -->
       <saxon-HE.version>9.5.1-8</saxon-HE.version>
       <wso2commons.version>1.2</wso2commons.version>
@@ -1362,6 +1361,7 @@
        <system.rules.version>1.17.0</system.rules.version>
        <io.netty.version>4.0.30.Final</io.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
+       <jaeger-client.version>0.32.0.wso2v1</jaeger-client.version>
    </properties>
    <developers>
       <!-- If you are a committer and your name is not listed here, please include/edit -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    </parent>
    <groupId>org.apache.synapse</groupId>
    <artifactId>Apache-Synapse</artifactId>
-   <version>2.1.7-wso2v139</version>
+   <version>2.1.7-wso2v140-SNAPSHOT</version>
    <name>Apache Synapse</name>
    <description>Apache Synapse</description>
    <packaging>pom</packaging>
@@ -69,7 +69,7 @@
       <connection>scm:git:https://github.com/wso2/wso2-synapse.git</connection>
       <developerConnection>scm:git:https://github.com/wso2/wso2-synapse.git</developerConnection>
       <url>https://github.com/wso2/wso2-synapse.git/</url>
-      <tag>v2.1.7-wso2v139</tag>
+      <tag>HEAD</tag>
    </scm>
    <organization>
       <name>Apache Software Foundation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1361,6 +1361,7 @@
        <system.rules.version>1.17.0</system.rules.version>
        <io.netty.version>4.0.30.Final</io.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
+       <version.orbit.rabbitmq>3.6.6.wso2v1</version.orbit.rabbitmq>
        <jaeger-client.version>0.32.0.wso2v1</jaeger-client.version>
    </properties>
    <developers>


### PR DESCRIPTION
## Purpose
> Introducing Jaeger Tracing capability for Synapse. Jaeger is a well-known tracing implementation, based on the OpenTracing standard. Resolves: https://github.com/wso2/product-ei/issues/4856

**Note**: The PR should not be merged until [this PR](https://github.com/wso2/orbit/pull/400) is merged and an Orbit release is done. 

## Goals
> Providing support for OpenTracing with Jaeger.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-mediation/pull/1364