### PR TITLE
Revert "Fixed latency calculation"

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/LatencyCollector.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/LatencyCollector.java
@@ -95,7 +95,7 @@ public class LatencyCollector {
             long tResDeparture = (Long) o4;
 
             backendLatency = (tResArrival - tReqDeparture);
-            latency = (tResDeparture - tReqArrival) + backendLatency;
+            latency = (tResDeparture - tReqArrival) - backendLatency;
         }
         o1 = context.getAttribute(PassThroughConstants.REQ_FROM_CLIENT_READ_START_TIME);
         o2 = context.getAttribute(PassThroughConstants.REQ_FROM_CLIENT_READ_END_TIME);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/LatencyView.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/LatencyView.java
@@ -151,7 +151,7 @@ public class LatencyView implements LatencyViewMBean {
     private void notifyTimes(long reqArrival, long reqDeparture,
                              long resArrival, long resDeparture) {
         long latencyBe = (resArrival - reqDeparture);
-        long latency = (resDeparture - reqArrival) + latencyBe;
+        long latency = (resDeparture - reqArrival) - latencyBe;
         lastLatency.update(latency);
         lastLatencyBe.update(latencyBe);
     }


### PR DESCRIPTION
Reverts wso2/wso2-synapse#1455

Actually what we are measuring here is the mediation latency so we need to remove the latency added from backend.