### PR TITLE
Modified to honor keep-alive timeout and allow a grace time for closing connections

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -25,7 +25,12 @@ public class PassThroughConstants {
     public static final String CONNECTION_POOL = "CONNECTION_POOL";
     public static final String TUNNEL_HANDLER = "TUNNEL_HANDLER";
     public static final String CONNECTION_INIT_TIME = "CONNECTION_INIT_TIME";
-    public static final String CONNECTION_RELEASE_TIME = "CONNECTION_RELEASE_TIME";
+    // The time at which the connection is removed from the connection pool.
+    // This is calculated using the keep alive timeout or connection idle time.
+    public static final String CONNECTION_EXPIRY_TIME = "CONNECTION_EXPIRY_TIME";
+    // The time after which the connection will be closed by the backend.
+    // This time is mentioned as an HTTP header in the response from the backend.
+    public static final String CONNECTION_KEEP_ALIVE_TIME_OUT = "CONNECTION_KEEP_ALIVE_TIME_OUT";
 
     public static final String TRUE = "TRUE";
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -36,12 +36,12 @@ import java.util.Map;
  * This class represents a response coming from the target server.
  */
 public class TargetResponse {
-    // private Log log = LogFactory.getLog(TargetResponse.class);
+     private Log log = LogFactory.getLog(TargetResponse.class);
     /** To pipe the incoming data through */
     private Pipe pipe = null;
     /** Headers of the response */
     private Map<String, String> headers = new HashMap<String, String>();
-    /** Excess headers of the response */ 
+    /** Excess headers of the response */
     private Map excessHeaders = new MultiValueMap();
     /** The status of the response */
     private int status = HttpStatus.SC_OK;
@@ -65,6 +65,10 @@ public class TargetResponse {
     /** logger for correlation.log */
     private static final Log correlationLog = LogFactory.getLog(PassThroughConstants.CORRELATION_LOGGER);
 
+    // Constants for honoring keep-alive header coming from backend
+    private static final String KEEP_ALIVE_HEADER = "Keep-Alive";
+    private static final String KEEP_ALIVE_TIMEOUT = "timeout=";
+
     public TargetResponse(TargetConfiguration targetConfiguration,
                           HttpResponse response,
                           NHttpClientConnection conn,
@@ -85,14 +89,23 @@ public class TargetResponse {
             	if(this.headers.containsKey(header.getName())) {
             		addExcessHeader(header);
             	} else {
-            		this.headers.put(header.getName(), header.getValue());
-            	}
-             }        
-        }   
+                    this.headers.put(header.getName(), header.getValue());
+                }
+                // If the keep-alive header is set
+                if (header.getName().equalsIgnoreCase(KEEP_ALIVE_HEADER)) {
+                    // Retrieve the keep-alive timeout
+                    String keepAlive = header.getValue();
+                    if (keepAlive != null && keepAlive.contains(KEEP_ALIVE_TIMEOUT)) {
+                        conn.getContext().setAttribute(PassThroughConstants.CONNECTION_KEEP_ALIVE_TIME_OUT,
+                                getKeepAliveTimeout(keepAlive));
+                    }
+                }
+            }
+        }
 
         this.expectResponseBody = expectResponseBody;
         this.forceShutdownConnectionOnComplete = forceShutdownConnectionOnComplete;
-    }    
+    }
 
     /**
      * Starts the response
@@ -100,7 +113,7 @@ public class TargetResponse {
      */
     public void start(NHttpClientConnection conn) {
         TargetContext.updateState(conn, ProtocolState.RESPONSE_HEAD);
-        
+
         if (expectResponseBody) {
             pipe
                 = new Pipe(conn, targetConfiguration.getBufferFactory().getBuffer(), "target", targetConfiguration);
@@ -112,13 +125,13 @@ public class TargetResponse {
                 entity.setChunked(true);
             }
             response.setEntity(entity);
-        } else {            
+        } else {
             if (!connStrategy.keepAlive(response, conn.getContext()) || forceShutdownConnectionOnComplete) {
                 try {
                     // this is a connection we should not re-use
                     TargetContext.updateState(conn, ProtocolState.CLOSING);
                     targetConfiguration.getConnections().shutdownConnection(conn);
-                                       
+
                 } catch (Exception ignore) {
 
                 }
@@ -139,9 +152,9 @@ public class TargetResponse {
      * @return number of bites read
      */
     public int read(NHttpClientConnection conn, ContentDecoder decoder) throws IOException {
-    	
+
     	int bytes=0;
-    	
+
     	if(pipe != null){
     		bytes = pipe.produce(decoder);
     	}
@@ -161,7 +174,7 @@ public class TargetResponse {
             } else {
                 if (conn instanceof LoggingNHttpClientConnection) {
                     ((LoggingNHttpClientConnection) conn).setReleaseConn(true);
-                } 
+                }
             }
         }
         return bytes;
@@ -178,7 +191,7 @@ public class TargetResponse {
     public Map getExcessHeaders() {
     	return this.excessHeaders;
     }
-    
+
     public void addExcessHeader(Header h) {
     	this.excessHeaders.put(h.getName(), h.getValue());
     }
@@ -205,5 +218,27 @@ public class TargetResponse {
 
     public ProtocolVersion getVersion() {
         return version;
+    }
+
+    /**
+     * Retrieve the keep-alive timeout value
+     * @param keepAlive header value which has timeout in seconds
+     * @return keep-alive timeout in milliseconds
+     */
+    private int getKeepAliveTimeout(String keepAlive) {
+        int keepAliveTimeout = -1;
+        String timeout = keepAlive.split(KEEP_ALIVE_TIMEOUT)[1];
+        // If header has more than one property
+        int commaIndex = timeout.indexOf(',');
+        if (commaIndex != -1) {
+            timeout = timeout.substring(0, commaIndex);
+        }
+
+        try {
+            keepAliveTimeout = Integer.parseInt(timeout) * 1000;
+        } catch (NumberFormatException e) {
+            log.error("Error parsing value " + timeout + " as connection keep-alive timeout.", e);
+        }
+        return keepAliveTimeout;
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -227,7 +227,14 @@ public class TargetResponse {
      */
     private int getKeepAliveTimeout(String keepAlive) {
         int keepAliveTimeout = -1;
-        String timeout = keepAlive.split(KEEP_ALIVE_TIMEOUT)[1];
+        String timeout;
+
+        try {
+            timeout = keepAlive.split(KEEP_ALIVE_TIMEOUT)[1];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            log.error("Value is not specified in KeepAlive Timeout header.");
+            return -1;
+        }
         // If header has more than one property
         int commaIndex = timeout.indexOf(',');
         if (commaIndex != -1) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/ConnectionTimeoutConfiguration.java
@@ -34,10 +34,12 @@ public class ConnectionTimeoutConfiguration {
 
     private int connectionIdleTime;
     private int maximumConnectionLifeSpan;
+    private int connectionGraceTime;
 
-    public ConnectionTimeoutConfiguration(int connectionIdleTime, int maximumConnectionLifeSpan) {
+    public ConnectionTimeoutConfiguration(int connectionIdleTime, int maximumConnectionLifeSpan, int connectionGraceTime) {
         this.connectionIdleTime = connectionIdleTime;
         this.maximumConnectionLifeSpan = maximumConnectionLifeSpan;
+        this.connectionGraceTime = connectionGraceTime;
     }
 
     public int getConnectionIdleTime() {
@@ -46,5 +48,9 @@ public class ConnectionTimeoutConfiguration {
 
     public int getMaximumConnectionLifeSpane() {
         return maximumConnectionLifeSpan;
+    }
+
+    public int getConnectionGraceTime() {
+        return connectionGraceTime;
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -86,6 +86,12 @@ public interface PassThroughConfigPNames {
     public String CONNECTION_IDLE_TIME = "transport.sender.connection.idle.time";
 
     /**
+     * Defines the time allocated to avoid a connection being used
+     * at the moment it is being closed or timed out in milliseconds
+     */
+    public String CONNECTION_GRACE_TIME = "transport.sender.connection.grace.time";
+
+    /**
      * Defines the time interval for maximum connection lifespan.
      */
     public String MAXIMUM_CONNECTION_LIFESPAN = "transport.sender.connection.maximum.lifespan";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.synapse.transport.passthru.config;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 
 import java.io.File;
@@ -47,6 +48,7 @@ public class PassThroughConfiguration {
                                                          Runtime.getRuntime().availableProcessors();
     private static final int DEFAULT_MAX_ACTIVE_CON = -1;
     private static final int DEFAULT_LISTENER_SHUTDOWN_WAIT_TIME = 0;
+    private static final int DEFAULT_CONNECTION_GRACE_TIME = 3000;
     private Boolean isKeepAliveDisabled = null;
 
     //additional rest dispatch handlers
@@ -143,10 +145,34 @@ public class PassThroughConfiguration {
     }
 
     public int getConnectionIdleTime() {
-        return getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, Integer.MAX_VALUE);
+
+        int idleTime;
+        // Giving higher priority for grace time if it is configured, than for the configured idle time
+        if (isIntPropertyConfigured(PassThroughConfigPNames.CONNECTION_GRACE_TIME)) {
+            idleTime = getDefaultConnectionIdleTime();
+        } else {
+            // Setting idle time if it is configured, if not, using the default grace time to calculate idle time
+            idleTime = getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, getDefaultConnectionIdleTime());
+        }
+
+        if (idleTime < 0) {
+            return 0;
+        }
+        return idleTime;
     }
     public int getMaximumConnectionLifespan() {
         return getIntProperty(PassThroughConfigPNames.MAXIMUM_CONNECTION_LIFESPAN, Integer.MAX_VALUE);
+    }
+    public int getConnectionGraceTime() {
+        return getIntProperty(PassThroughConfigPNames.CONNECTION_GRACE_TIME, DEFAULT_CONNECTION_GRACE_TIME);
+    }
+
+    /**
+     * For the default value, grace time is reduced to avoid connection being used at the moment it is being closed
+     * @return default connection idle time
+     */
+    private int getDefaultConnectionIdleTime(){
+        return getIntProperty(HttpConnectionParams.SO_TIMEOUT, 60000) - getConnectionGraceTime();
     }
 
     public String getCorrelationHeaderName() {
@@ -241,6 +267,35 @@ public class PassThroughConfiguration {
         }
 
         return def;
+    }
+
+    /**
+     * Return true if user has configured an int property that tunes pass-through http transport
+     * @param name  name of the system/config property
+     * @return      true if property is configured
+     */
+    private boolean isIntPropertyConfigured(String name) {
+
+        String val = System.getProperty(name);
+        if (val == null) {
+            val = props.getProperty(name);
+        }
+
+        if (val != null) {
+            try {
+                Integer.parseInt(val);
+            } catch (NumberFormatException e) {
+                log.warn("Incorrect pass-through http tuning property value. " + name +
+                        " must be an integer");
+                return false;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Using configured pass-through http tuning property value for : " + name);
+            }
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -149,10 +149,10 @@ public class PassThroughConfiguration {
         int idleTime;
         // Giving higher priority for grace time if it is configured, than for the configured idle time
         if (isIntPropertyConfigured(PassThroughConfigPNames.CONNECTION_GRACE_TIME)) {
-            idleTime = getDefaultConnectionIdleTime();
+            idleTime = getIdleTimeFromGraceTime();
         } else {
             // Setting idle time if it is configured, if not, using the default grace time to calculate idle time
-            idleTime = getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, getDefaultConnectionIdleTime());
+            idleTime = getIntProperty(PassThroughConfigPNames.CONNECTION_IDLE_TIME, getIdleTimeFromGraceTime());
         }
 
         if (idleTime < 0) {
@@ -171,7 +171,7 @@ public class PassThroughConfiguration {
      * For the default value, grace time is reduced to avoid connection being used at the moment it is being closed
      * @return default connection idle time
      */
-    private int getDefaultConnectionIdleTime(){
+    private int getIdleTimeFromGraceTime(){
         return getIntProperty(HttpConnectionParams.SO_TIMEOUT, 60000) - getConnectionGraceTime();
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
@@ -77,7 +77,7 @@ public class TargetConfiguration extends BaseConfiguration {
                         new RequestExpectContinue()
          });
         this.connectionTimeoutConfiguration = new ConnectionTimeoutConfiguration(conf.getConnectionIdleTime(),
-                                                                                 conf.getMaximumConnectionLifespan());
+                conf.getMaximumConnectionLifespan(), conf.getConnectionGraceTime());
         this.proxyAuthenticator = proxyAuthenticator;
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
@@ -25,6 +25,8 @@ import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.synapse.transport.passthru.ConnectCallback;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.TargetContext;
+import org.apache.synapse.transport.passthru.config.ConnectionTimeoutConfiguration;
+import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 
 import java.io.IOException;
@@ -56,6 +58,8 @@ public class TargetConnections {
     /** callback invoked when a connection is made */
     private ConnectCallback callback = null;
 
+    private ConnectionTimeoutConfiguration connectionTimeoutConfiguration;
+
     /**
      * Create a TargetConnections with the given IO-Reactor
      *
@@ -70,6 +74,10 @@ public class TargetConnections {
         this.maxConnections = targetConfiguration.getMaxConnections();
         this.ioReactor = ioReactor;
         this.callback = callback;
+
+        connectionTimeoutConfiguration = new ConnectionTimeoutConfiguration(PassThroughConfiguration.getInstance().
+                getConnectionIdleTime(), PassThroughConfiguration.getInstance().getMaximumConnectionLifespan(),
+                PassThroughConfiguration.getInstance().getConnectionGraceTime());
     }
 
     /**
@@ -196,7 +204,7 @@ public class TargetConnections {
             HostConnections pool = poolMap.get(route);
 
             if (pool == null) {
-                pool = new HostConnections(route, maxConnections);
+                pool = new HostConnections(route, maxConnections, connectionTimeoutConfiguration);
                 poolMap.put(route, pool);
             }
             return pool;


### PR DESCRIPTION
## Purpose
Modified to consider and apply the `keep-alive` timeout value sent from a backend when closing connections. Furthermore, added a configurable `grace time` property to avoid connections being utilized at the moment it is being closed.

##Related Issues
https://github.com/wso2/product-ei/issues/2613
https://github.com/wso2/product-apim/issues/7001

Fixes: https://github.com/wso2/product-ei/issues/4863