### PR TITLE
Add NO_KEEPALIVE property to send method

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -342,6 +342,8 @@ public class BlockingMsgSender {
                 axisInMsgCtx.getProperty(HTTPConstants.ERROR_HTTP_STATUS_CODES));
         axisOutMsgCtx.setProperty(SynapseConstants.DISABLE_CHUNKING,
                 axisInMsgCtx.getProperty(SynapseConstants.DISABLE_CHUNKING));
+        axisOutMsgCtx.setProperty(SynapseConstants.NO_KEEPALIVE,
+                axisInMsgCtx.getProperty(SynapseConstants.NO_KEEPALIVE));
         // Fill MessageContext
         BlockingMsgSenderUtils.fillMessageContext(endpointDefinition, axisOutMsgCtx, synapseInMsgCtx);
         if (JsonUtil.hasAJsonPayload(axisInMsgCtx)) {


### PR DESCRIPTION
## Purpose
> The NO_KEEPALIVE property was not working properly in the EI server for the blocking calls and the issue [1] was raised to fix this issue. However there was a new send method introduced for the BlockingMsgSender [2], and in this method, the property is not included. This PR adds NO_KEEPALIVE property to the newly introduced send method.

[1] https://github.com/wso2/product-ei/issues/3195
[2] https://github.com/wso2/wso2-synapse/pull/1089

