### PR TITLE
Implement graceful shutdown for passthrough transport

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -59,6 +59,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.impl.nio.reactor.DefaultListeningIOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
 import org.apache.http.nio.reactor.IOReactorExceptionHandler;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.synapse.transport.http.conn.Scheme;
 import org.apache.synapse.transport.http.conn.ServerConnFactory;
 import org.apache.synapse.transport.nhttp.config.ServerConnFactoryBuilder;
@@ -420,13 +421,26 @@ public class PassThroughHttpListener implements TransportListener {
         log.info("Stopping Pass-through " + namePrefix + " Listener..");
         try {
             int wait = PassThroughConfiguration.getInstance().getListenerShutdownWaitTime();
+            boolean isGracefulShutdownEnabled = Boolean.parseBoolean(
+                    System.getProperty("gracefulShutdown", "true"));
+            long so_timeout = PassThroughConfiguration.getInstance()
+                    .getIntProperty(HttpConnectionParams.SO_TIMEOUT, Pipe.DEFAULT_TIME_OUT_VALUE);
+            passThroughListeningIOReactorManager.pauseIOReactor(operatingPort);
             if (wait > 0) {
-                passThroughListeningIOReactorManager.pauseIOReactor(operatingPort);
                 log.info("Waiting " + wait/1000 + " seconds to cleanup active connections...");
                 Thread.sleep(wait);
                 passThroughListeningIOReactorManager.shutdownIOReactor(operatingPort, wait);
             } else {
-                passThroughListeningIOReactorManager.shutdownIOReactor(operatingPort);
+                if (isGracefulShutdownEnabled) {
+                    if (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {
+                        log.info("Waiting to cleanup active " + namePrefix + " connections : " +
+                                sourceConfiguration.getMetrics().getUnServedRequestCount());
+                    }
+                    passThroughListeningIOReactorManager.shutdownIOReactor(
+                            operatingPort, sourceConfiguration, so_timeout);
+                } else {
+                    passThroughListeningIOReactorManager.shutdownIOReactor(operatingPort);
+                }
             }
             serviceTracker.stop();
             handler.stop();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -421,21 +421,17 @@ public class PassThroughHttpListener implements TransportListener {
         log.info("Stopping Pass-through " + namePrefix + " Listener..");
         try {
             int wait = PassThroughConfiguration.getInstance().getListenerShutdownWaitTime();
-            boolean isGracefulShutdownEnabled = Boolean.parseBoolean(
-                    System.getProperty("gracefulShutdown", "true"));
-            long so_timeout = PassThroughConfiguration.getInstance()
-                    .getIntProperty(HttpConnectionParams.SO_TIMEOUT, Pipe.DEFAULT_TIME_OUT_VALUE);
             passThroughListeningIOReactorManager.pauseIOReactor(operatingPort);
             if (wait > 0) {
                 log.info("Waiting " + wait/1000 + " seconds to cleanup active connections...");
                 Thread.sleep(wait);
                 passThroughListeningIOReactorManager.shutdownIOReactor(operatingPort, wait);
             } else {
+                boolean isGracefulShutdownEnabled = Boolean.parseBoolean(
+                        System.getProperty("gracefulShutdown", "true"));
                 if (isGracefulShutdownEnabled) {
-                    if (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {
-                        log.info("Waiting to cleanup active " + namePrefix + " connections : " +
-                                sourceConfiguration.getMetrics().getUnServedRequestCount());
-                    }
+                    long so_timeout = PassThroughConfiguration.getInstance()
+                            .getIntProperty(HttpConnectionParams.SO_TIMEOUT, Pipe.DEFAULT_TIME_OUT_VALUE);
                     passThroughListeningIOReactorManager.shutdownIOReactor(
                             operatingPort, sourceConfiguration, so_timeout);
                 } else {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class Pipe {
 
-    private static final int DEFAULT_TIME_OUT_VALUE = 180000;
+    public static final int DEFAULT_TIME_OUT_VALUE = 180000;
 
     /** IOControl of the reader */
     private IOControl producerIoControl;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
@@ -448,10 +448,11 @@ public class PassThroughListeningIOReactorManager {
      * @throws IOException Exception throwing when Shutdown
      */
     public void shutdownIOReactor(int port, SourceConfiguration sourceConfiguration, long timeout)
-            throws IOException {
+            throws IOException, InterruptedException {
         long startTime = System.currentTimeMillis();
         long timeoutTime = startTime + timeout;
         while (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {
+            Thread.sleep(1000);
             if (System.currentTimeMillis() > timeoutTime) {
                 log.info("Shutting down listener since Socket Timeout exceeded");
                 break;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
@@ -449,6 +449,10 @@ public class PassThroughListeningIOReactorManager {
      */
     public void shutdownIOReactor(int port, SourceConfiguration sourceConfiguration, long timeout)
             throws IOException, InterruptedException {
+        if (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {
+            log.info("Waiting to cleanup active connections on port " + port + ": " +
+                    sourceConfiguration.getMetrics().getUnServedRequestCount());
+        }
         long startTime = System.currentTimeMillis();
         long timeoutTime = startTime + timeout;
         while (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/PassThroughListeningIOReactorManager.java
@@ -439,12 +439,31 @@ public class PassThroughListeningIOReactorManager {
         return null;
     }
 
-
+    /**
+     * ShutdownIOReactor which is registered by HTTPListener running on given port
+     *
+     * @param port                Port of  axis2 PTT Listener
+     * @param sourceConfiguration Source Configuration from Source handler
+     * @param timeout             Maximum timeout value for shutdown
+     * @throws IOException Exception throwing when Shutdown
+     */
+    public void shutdownIOReactor(int port, SourceConfiguration sourceConfiguration, long timeout)
+            throws IOException {
+        long startTime = System.currentTimeMillis();
+        long timeoutTime = startTime + timeout;
+        while (sourceConfiguration.getMetrics().getUnServedRequestCount() > 0) {
+            if (System.currentTimeMillis() > timeoutTime) {
+                log.info("Shutting down listener since Socket Timeout exceeded");
+                break;
+            }
+        }
+        shutdownIOReactor(port);
+    }
 
     /**
      * ShutdownIOReactor which is registered by HTTPListener running on given port
      *
-     * @param port Port of  axis2 PTT Listener
+     * @param port Port of axis2 PTT Listener
      * @throws IOException Exception throwing when Shutdown
      */
     public void shutdownIOReactor(int port) throws IOException {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/ConnectionsView.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/ConnectionsView.java
@@ -61,6 +61,8 @@ public class ConnectionsView implements ConnectionsViewMBean {
     private AtomicInteger shortTermOpenedConnections = new AtomicInteger(0);
     private AtomicInteger longTermOpenedConnections = new AtomicInteger(0);
 
+    private AtomicInteger unservedRequests = new AtomicInteger(0);
+
     // The array length must be equal to the number of buckets
     private AtomicInteger[] requestSizeCounters = new AtomicInteger[6];
     private AtomicInteger[] responseSizeCounters = new AtomicInteger[6];
@@ -131,6 +133,26 @@ public class ConnectionsView implements ConnectionsViewMBean {
 
     protected void disconnected() {
         activeConnections.decrementAndGet();
+    }
+
+    protected void requestReceived() {
+        unservedRequests.incrementAndGet();
+    }
+
+    protected void requestServed() {
+        unservedRequests.decrementAndGet();
+    }
+
+    protected void timeoutOccured() {
+        unservedRequests.decrementAndGet();
+    }
+
+    protected void exceptionOccured() {
+        unservedRequests.decrementAndGet();
+    }
+
+    public int getUnServedRequests() {
+        return unservedRequests.get();
     }
 
     protected void notifyMessageSize(long size, boolean isRequest) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/PassThroughTransportMetricsCollector.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/PassThroughTransportMetricsCollector.java
@@ -57,6 +57,22 @@ public class PassThroughTransportMetricsCollector extends MetricsCollector {
         view.disconnected();
     }
 
+    public void requestReceived() {
+        view.requestReceived();
+    }
+
+    public void requestServed() {
+        view.requestServed();
+    }
+
+    public void timeoutOccured() {
+        view.timeoutOccured();
+    }
+
+    public void exceptionOccured() {
+        view.exceptionOccured();
+    }
+
     @Override
     public void notifyReceivedMessageSize(long l) {
         super.notifyReceivedMessageSize(l);
@@ -75,6 +91,10 @@ public class PassThroughTransportMetricsCollector extends MetricsCollector {
 
     public int getActiveConnectionCount() {
         return view.getActiveConnections();
+    }
+
+    public int getUnServedRequestCount() {
+        return view.getUnServedRequests();
     }
 }
 


### PR DESCRIPTION
## Purpose
Currently Passthrough transport does not support Graceful Shutdown. (ie Accepted requests will not be served properly if the shutdown is triggered.)

Resolves https://github.com/wso2/product-ei/issues/4717

## Approach
There are some metrics collected in Passthrough Transport when request responses are handled. A new metric is introduced in the PassThroughTransportMetricsCollector which will keep count of the current active requests that are being served by the server. When the shutdown is triggered, the server will stop accepting new requests and will wait until the accepted requests are served.

![Graceful shutdown explanation (1)](https://user-images.githubusercontent.com/17047910/75150939-8c766100-572b-11ea-9af5-b6f2b4f383d7.png)

- When a request is accepted, it will increment the metric inside _requestReceived_ method.
- When a request with a body comes, and if an error occurs when reading the stream, the metric will be decremented inside _inputReady_ method.
- When a no entity response is sent, the metric will get decremented in _responseReady_ method.
- When a response with entity is sent, the metric will get decremented in _outputReady_ method.
- When a connection timeout occurs from client to ESB server, the metric will get decremented in _timeout_ method. 

With the implementation of this feature, the server might take sometime to shutdown if there are any active requests that are not served. The server will shutdown **with a worse case time of a value that is equal to the Socket Timeout** that is defined in the passthru-http.properties.

If anyone wish to disable this feature due to development purposes, they may start the server with a System property : **-DgracefulShutdown=false**. The server will always have graceful shutdown enabled by default.




