### PR TITLE
Fix wso2/product-ei/issues/4961

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -174,6 +174,7 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
             }
 
             if (callback != null) {
+                messageCtx.removeProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN);
                 org.apache.synapse.MessageContext SynapseOutMsgCtx = callback.getSynapseOutMsgCtx();
                 ConcurrencyThrottlingUtils.decrementConcurrencyThrottleAccessController(SynapseOutMsgCtx);
 
@@ -196,10 +197,13 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
                 }
             } else {
                 // TODO invoke a generic synapse error handler for this message
-                log.warn("Synapse received a response for the request with message Id : " +
-                        messageID + " and correlation_id : " + messageCtx.getProperty(PassThroughConstants
-                        .CORRELATION_ID) + " But a callback is not registered (anymore) to process " +
-                        "this response");
+                if (!PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER
+                        .equals(messageCtx.getProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN))) {
+                    log.warn("Synapse received a response for the request with message Id : " + messageID
+                            + " and correlation_id : " + messageCtx.getProperty(PassThroughConstants.CORRELATION_ID)
+                            + " But a callback is not registered (anymore) to process " + "this response");
+                }
+                messageCtx.removeProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN);
             }
 
         } else if (!messageCtx.isPropertyTrue(NhttpConstants.SC_ACCEPTED)){

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -146,7 +146,8 @@ public class DeliveryAgent {
                 }
                 if (queue.size() == maxWaitingMessages) {
                     MessageContext msgCtx = queue.poll();
-
+                    msgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                            PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                     targetErrorHandler.handleError(msgCtx,
                             ErrorCodes.CONNECTION_TIMEOUT,
                             "Error connecting to the back end",
@@ -185,6 +186,8 @@ public class DeliveryAgent {
 			MessageContext msgCtx = queue.poll();
 
 			if (msgCtx != null) {
+                msgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
 				targetErrorHandler.handleError(msgCtx, errorCode,
 				                               "Error connecting to the back end", null,
 				                               ProtocolState.REQUEST_READY);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -222,6 +222,8 @@ public class PassThroughConstants {
 
     public static final String ORIGINAL_HTTP_SC = "ORIGINAL_STATUS_CODE";
     public static final String ORIGINAL_HTTP_REASON_PHRASE = "HTTP_REASON_PHRASE";
+    public static final String INTERNAL_EXCEPTION_ORIGIN = "_INTERNAL_EXCEPTION_ORIGIN";
+    public static final String INTERNAL_ORIGIN_ERROR_HANDLER = "TARGET_ERROR_HANDLER";
 
 
     public static final String MESSAGE_SIZE_VALIDATION_SUM = "MESSAGE_SIZE_VALIDATION_SUM";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetErrorHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetErrorHandler.java
@@ -137,6 +137,8 @@ public class TargetErrorHandler {
                     faultMessageContext.setProperty(PassThroughConstants.NO_ENTITY_BODY, true);
                     faultMessageContext.setProperty(PassThroughConstants.CORRELATION_ID,
                             mc.getProperty(PassThroughConstants.CORRELATION_ID));
+                    faultMessageContext.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                            mc.getProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN));
                     mr.receive(faultMessageContext);
 
                 } catch (AxisFault af) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -184,6 +184,8 @@ public class TargetHandler implements NHttpClientEventHandler {
 
             MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.SND_IO_ERROR,
                         "Error in Sender",
@@ -197,6 +199,8 @@ public class TargetHandler implements NHttpClientEventHandler {
 
             MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.SND_HTTP_ERROR,
                         "Error in Sender",
@@ -244,6 +248,8 @@ public class TargetHandler implements NHttpClientEventHandler {
             informWriterError(conn);
 
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.SND_HTTP_ERROR,
                         "Error in Sender",
@@ -258,6 +264,8 @@ public class TargetHandler implements NHttpClientEventHandler {
             informWriterError(conn);
 
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.SND_HTTP_ERROR,
                         "Error in Sender",
@@ -590,6 +598,8 @@ public class TargetHandler implements NHttpClientEventHandler {
         if (isFault) {
             MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.CONNECTION_CLOSED,
                         "Error in Sender",
@@ -663,6 +673,8 @@ public class TargetHandler implements NHttpClientEventHandler {
                     logHttpRequestErrorInCorrelationLog(conn, "Timeout in " + state);
                 }
                 if (requestMsgCtx != null) {
+                    requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                            PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                     targetErrorHandler.handleError(requestMsgCtx,
                             ErrorCodes.CONNECTION_TIMEOUT,
                             "Error in Sender",
@@ -720,6 +732,8 @@ public class TargetHandler implements NHttpClientEventHandler {
         TargetContext.updateState(conn, ProtocolState.CLOSED);
         targetConfiguration.getConnections().shutdownConnection(conn, true);
         if (requestMsgCtx != null) {
+            requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                    PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
             targetErrorHandler.handleError(requestMsgCtx,
                     ErrorCodes.SND_INVALID_STATE,
                     "Error in Sender",
@@ -773,6 +787,8 @@ public class TargetHandler implements NHttpClientEventHandler {
                 logHttpRequestErrorInCorrelationLog(conn, "IO Exception in " + state.name());
             }
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.SND_IO_ERROR,
                         "Error in Sender",
@@ -788,6 +804,8 @@ public class TargetHandler implements NHttpClientEventHandler {
                 logHttpRequestErrorInCorrelationLog(conn, "HTTP Exception in " + state.name());
             }
             if (requestMsgCtx != null) {
+                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
                 targetErrorHandler.handleError(requestMsgCtx,
                         ErrorCodes.PROTOCOL_VIOLATION,
                         "Error in Sender",


### PR DESCRIPTION
## Purpose
When the socket timeout exceeds in the REQUEST_DONE state TargetHandler invokes the targetErrorHandler and it invokes the SynapseCallbackRecievers receive method. But when this
happens the call back is already removed from the map. So the SynapseCallbackReciver prints the
 "Synapse received a response for the request with ... But a callback is not registered (anymore) to process this response" log.
This can occur at any time where targetErrorHandler invokes the SynapseCallbackRecievers receive method.
Fix this issue by differentiating the path by adding a state when SynapseCallbackReciever is invoked by targetErrorHandler

## Goals
Fixes: https://github.com/wso2/product-ei/issues/4961

