### PR TITLE
Make setCorrelationId method public

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -170,7 +170,7 @@ public class SourceHandler implements NHttpServerEventHandler {
         }
     }
 
-    private void setCorrelationId(NHttpServerConnection conn) {
+    public void setCorrelationId(NHttpServerConnection conn) {
         HttpContext httpContext = conn.getContext();
         String correlationHeaderName = PassThroughConfiguration.getInstance().getCorrelationHeaderName();
         Header[] correlationHeader = conn.getHttpRequest().getHeaders(correlationHeaderName);


### PR DESCRIPTION
$subject as this is used in inbound endpoints in carbon mediation.