### PR TITLE
Fixed: issues in unit testing framework

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/CommonUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/CommonUtils.java
@@ -18,6 +18,15 @@
 
 package org.apache.synapse.unittest;
 
+import com.google.gson.JsonParser;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+import java.util.AbstractMap;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 /**
  * Class responsible for the common utilities in unit test.
  */
@@ -63,5 +72,44 @@ class CommonUtils {
             sb.append(Constants.NEW_LINE);
         }
         return sb.toString();
+    }
+
+    /**
+     * Check input string type JSON, XML or TEXT.
+     *
+     * @param inputString input message
+     * @return type of the input string and trimmed input string as a Map.Entry
+     */
+    static Map.Entry<String, String> checkInputStringFormat(String inputString) {
+        String inputStringFormat;
+        //trim the string
+        String trimedString = inputString.trim();
+
+        //remove CDATA tag from the string if exists
+        if (trimedString.startsWith("<![CDATA[")) {
+            trimedString = trimedString.substring(9);
+            int i = trimedString.indexOf("]]>");
+            if (i == -1) {
+                throw new IllegalStateException("argument starts with <![CDATA[ but cannot find pairing ]]>");
+            }
+            trimedString = trimedString.substring(0, i);
+        }
+
+        //check the input string format
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            builder.parse(new InputSource(new StringReader(trimedString)));
+            inputStringFormat = Constants.XML_FORMAT;
+        } catch (Exception e) {
+            try {
+                new JsonParser().parse(trimedString).getAsJsonObject();
+                inputStringFormat = Constants.JSON_FORMAT;
+            } catch (Exception exception) {
+                inputStringFormat = Constants.TEXT_FORMAT;
+            }
+        }
+
+        return new AbstractMap.SimpleEntry<>(inputStringFormat, trimedString);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/ConfigurationDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/ConfigurationDeployer.java
@@ -31,6 +31,7 @@ import org.apache.synapse.deployers.EndpointDeployer;
 import org.apache.synapse.deployers.LocalEntryDeployer;
 import org.apache.synapse.deployers.ProxyServiceDeployer;
 import org.apache.synapse.deployers.SequenceDeployer;
+import org.apache.synapse.deployers.TemplateDeployer;
 
 import java.util.AbstractMap;
 import java.util.Map;
@@ -161,6 +162,31 @@ class ConfigurationDeployer {
 
         //deploy synapse artifact
         String deployedArtifact = localEntryDeployer.deploySynapseArtifact(inputElement, fileName, null);
+
+        return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
+    }
+
+    /**
+     * Method of deploying template artifact in synapse.
+     *
+     * @param inputElement synapse configuration artifact as OMElement type
+     * @param fileName     name of the file
+     * @return response of the artifact deployment and the synapse configuration as a Map.Entry
+     */
+    Map.Entry<SynapseConfiguration, String> deployTemplateArtifact(OMElement inputElement, String fileName)
+            throws AxisFault {
+
+        //create new sequence deployer object
+        TemplateDeployer templateDeployer = new TemplateDeployer();
+
+        //create a synapse configuration and set all axis2 configuration to it
+        SynapseConfiguration synapseConfiguration = UnitTestingExecutor.getExecuteInstance().getSynapseConfiguration();
+
+        //initialize sequence deployer using created configuration context
+        templateDeployer.init(createConfigurationContext(synapseConfiguration));
+
+        //deploy synapse artifact
+        String deployedArtifact = templateDeployer.deploySynapseArtifact(inputElement, fileName, null);
 
         return new AbstractMap.SimpleEntry<>(synapseConfiguration, deployedArtifact);
     }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
@@ -32,6 +32,7 @@ public class Constants {
     static final String TYPE_API = "api";
     static final String TYPE_ENDPOINT = "endpoint";
     static final String TYPE_LOCAL_ENTRY = "localEntry";
+    static final String TYPE_TEMPLATE = "template";
 
     //artifact key word constants
     static final String API_CONTEXT = "context";
@@ -131,4 +132,11 @@ public class Constants {
 
     //common constants
     static final String NEW_LINE = "\n";
+    static final String EMPTY_VALUE = "";
+
+    //input data formats
+    static final String XML_FORMAT = "XML";
+    static final String JSON_FORMAT = "JSON";
+    static final String TEXT_FORMAT = "TEXT";
+    static final String TEXT_NAMESPACE = "http://ws.apache.org/commons/ns/payload";
 }

--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
@@ -35,6 +35,7 @@ import org.apache.synapse.deployers.EndpointDeployer;
 import org.apache.synapse.deployers.LocalEntryDeployer;
 import org.apache.synapse.deployers.ProxyServiceDeployer;
 import org.apache.synapse.deployers.SequenceDeployer;
+import org.apache.synapse.deployers.TemplateDeployer;
 import org.apache.synapse.unittest.testcase.data.classes.SynapseTestCase;
 import org.apache.synapse.unittest.testcase.data.classes.TestCase;
 import org.apache.synapse.unittest.testcase.data.classes.TestCaseSummary;
@@ -52,7 +53,7 @@ import static org.apache.synapse.unittest.Constants.TYPE_ENDPOINT;
 import static org.apache.synapse.unittest.Constants.TYPE_LOCAL_ENTRY;
 import static org.apache.synapse.unittest.Constants.TYPE_PROXY;
 import static org.apache.synapse.unittest.Constants.TYPE_SEQUENCE;
-
+import static org.apache.synapse.unittest.Constants.TYPE_TEMPLATE;
 
 /**
  * Testing agent deploy receiving artifact data in relevant deployer and mediate test cases on it.
@@ -241,6 +242,12 @@ class TestingAgent {
                 synapseConfiguration = pairOfLocalEntryDeployment.getKey();
                 key = pairOfLocalEntryDeployment.getValue();
                 break;
+            case TYPE_TEMPLATE:
+                Map.Entry<SynapseConfiguration, String> pairOfTemplateDeployment =
+                        config.deployTemplateArtifact(artifact, artifactNameOrKey);
+                synapseConfiguration = pairOfTemplateDeployment.getKey();
+                key = pairOfTemplateDeployment.getValue();
+                break;
 
             default:
                 throw new IOException("Undefined operation type for <test-artifact> given in unit testing agent");
@@ -304,7 +311,6 @@ class TestingAgent {
 
                         testSuiteSummary.setMediationStatus(Constants.PASSED_KEY);
                         checkAssertionWithAPIMediation(invokedApiResult, currentTestCase, i, testSummary);
-
                         break;
 
                     default:
@@ -437,6 +443,12 @@ class TestingAgent {
                         LocalEntryDeployer localEntryDeployer = new LocalEntryDeployer();
                         localEntryDeployer.init(configurationContext);
                         localEntryDeployer.undeploySynapseArtifact(artifactName);
+                        break;
+
+                    case TYPE_TEMPLATE:
+                        TemplateDeployer templateDeployer = new TemplateDeployer();
+                        templateDeployer.init(configurationContext);
+                        templateDeployer.undeploySynapseArtifact(artifactName);
                         break;
 
                     default:

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
@@ -71,7 +71,11 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
         ScriptMediator mediator;
-        ClassLoader  classLoader = (ClassLoader) properties.get(SynapseConstants.SYNAPSE_LIB_LOADER);
+        ClassLoader  classLoader = null;
+        if (properties != null) {
+            classLoader = (ClassLoader) properties.get(SynapseConstants.SYNAPSE_LIB_LOADER);
+        }
+
         OMAttribute keyAtt = elem.getAttribute(new QName(XMLConfigConstants.NULL_NAMESPACE,
                 "key"));
         OMAttribute langAtt = elem.getAttribute(new QName(XMLConfigConstants.NULL_NAMESPACE,


### PR DESCRIPTION
## Purpose
> This PR is related to the fixing the following issues in synapse unit testing framework

- Add JSON, Text input payload support for sequence testing. (Issue: https://github.com/wso2/devstudio-tooling-ei/issues/716)
- Add support for template testing (Issue: https://github.com/wso2/devstudio-tooling-ei/issues/698)
- Fixed issue in script mediator deployment while testing. (Issue: https://github.com/wso2/micro-integrator/issues/1088)
- Fixed testing sequences with call mediator for `blocking=true` situations (Issues: https://github.com/wso2/devstudio-tooling-ei/issues/699, https://github.com/wso2/product-ei/issues/4976)
