### PR TITLE
Same issue with ESBJAVA-4940: Adding a property to let the user control…

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonFormatter.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/json/JsonFormatter.java
@@ -104,7 +104,17 @@ public final class JsonFormatter implements MessageFormatter {
         if (contentType == null) {
             contentType = (String) messageContext.getProperty(Constants.Configuration.MESSAGE_TYPE);
         }
-        if (encoding != null) {
+        String setEncoding = (String) messageContext
+                .getProperty(org.apache.synapse.commons.json.Constants.SET_CONTENT_TYPE_CHARACTER_ENCODING);
+        // If the encoding taken from the OMOutputFormat is not null, "setCharacterEncoding" property is not false,
+        // and ContentType doesn't already contain a character encoding
+        // we append the encoding taken from OMOutputFormat.
+        // The default value for encoding coming from OMOutputFormat is UTF-8.
+        // The last condition is to avoid two character encodings being appended in case ContentType
+        // already contains a character encoding.
+        // This fixes ESBJAVA-4940 and "setCharacterEncoding" property was introduced for this.
+        if (encoding != null && !"false".equals(setEncoding)
+                && contentType != null && !contentType.contains("charset")) {
             contentType += "; charset=" + encoding;
         }
         return contentType;


### PR DESCRIPTION
… whether synapse should append default charset encoding(UTF-8) to outgoing request #670

## Purpose
> To resolve unintended and automatic 'charset' appending bug to an outgoing request.