### PR TITLE
Add support for removing default content-type in blocking mode

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -344,6 +344,8 @@ public class BlockingMsgSender {
                 axisInMsgCtx.getProperty(SynapseConstants.DISABLE_CHUNKING));
         axisOutMsgCtx.setProperty(SynapseConstants.NO_KEEPALIVE,
                 axisInMsgCtx.getProperty(SynapseConstants.NO_KEEPALIVE));
+        axisOutMsgCtx.setProperty(SynapseConstants.NO_DEFAULT_CONTENT_TYPE,
+                axisInMsgCtx.getProperty(SynapseConstants.NO_DEFAULT_CONTENT_TYPE));
         // Fill MessageContext
         BlockingMsgSenderUtils.fillMessageContext(endpointDefinition, axisOutMsgCtx, synapseInMsgCtx);
         if (JsonUtil.hasAJsonPayload(axisInMsgCtx)) {


### PR DESCRIPTION
## Purpose
The support for removing the default Content-Type from the header which was missing in the new send method implementation of blocking mode. This change is to reintroduce the support for the property
`<property name="NoDefaultContentType" value="true" scope="axis2"/>`.

Related issue - wso2/product-ei/issues/4330
