### PR TITLE
Fixes the issue of tasks not getting removed when member count reduced

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/MessageProcessorDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/MessageProcessorDeployer.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.config.xml.MessageProcessorFactory;
 import org.apache.synapse.config.xml.MessageProcessorSerializer;
-import org.apache.synapse.config.xml.MessageStoreSerializer;
 import org.apache.synapse.config.xml.MultiXMLConfigurationBuilder;
 import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.processor.impl.AbstractMessageProcessor;
@@ -106,7 +105,7 @@ public class    MessageProcessorDeployer extends AbstractSynapseArtifactDeployer
             MessageProcessor existingMp = getSynapseConfiguration().getMessageProcessors().
                     get(existingArtifactName);
             if (existingMp instanceof AbstractMessageProcessor) {
-                ((AbstractMessageProcessor) existingMp).destroy(true);
+                ((AbstractMessageProcessor) existingMp).destroy(true, true);
             } else {
                 existingMp.destroy();
             }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/AbstractMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/AbstractMessageProcessor.java
@@ -19,10 +19,6 @@
 
 package org.apache.synapse.message.processor.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
@@ -30,6 +26,10 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.message.MessageConsumer;
 import org.apache.synapse.message.processor.MessageProcessor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Class <code>AbstractMessageProcessor</code> is handles Message processing of the messages
@@ -189,4 +189,13 @@ public abstract class AbstractMessageProcessor implements MessageProcessor {
      * @param preserveState determine whether to preserve the artifacts state or not
      */
     public void destroy(boolean preserveState){}
+
+    /**
+     * Destroy the artifacts.
+     *
+     * @param preserveState whether to preserve state in registry.
+     * @param isUpdate      whether this is triggered in artifact update flow.
+     */
+    public void destroy(boolean preserveState, boolean isUpdate) {
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
@@ -18,11 +18,6 @@
  */
 package org.apache.synapse.message.processor.impl;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Callable;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
@@ -41,6 +36,11 @@ import org.apache.synapse.task.Task;
 import org.apache.synapse.task.TaskDescription;
 import org.apache.synapse.task.TaskManager;
 import org.apache.synapse.task.TaskManagerObserver;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
 
 
 /**
@@ -310,10 +310,21 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 
 	@Override
 	public void destroy(boolean preserveState) {
+		destroy(preserveState, false);
+	}
+
+	@Override
+	public void destroy(boolean preserveState , boolean isArtifactUpdate) {
 
 		if (!preserveState) {
-			stop();
 			deleteMessageProcessorState();
+		}
+		if (isArtifactUpdate || !preserveState) {
+			/*
+			All the tasks need to be stopped during artifact update and re deployed so that the changes in member
+			count is captured.
+			*/
+			stop();
 		}
 		/*
 		 * If the Task is scheduled with an interval value < 1000 ms, it is


### PR DESCRIPTION
Fixes https://github.com/wso2/micro-integrator/issues/1303

When the synapse artifacts are updated ( for mp ) we are not removing the previously deployed tasks, hence the changes in the member count is not captured  and if the previous count is higher, the extra tasks still remains in the system.

