### PR TITLE
Add messages processor states to task store in Micro Integrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # ignore target directories
 target/
+modules/transports/core/vfs/repository/conf/*.properties
 
 ## various other file types we don't want to have in the repository:
 .DS_Store

--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -21,8 +21,9 @@ package org.apache.synapse;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMNamespace;
-import javax.xml.namespace.QName;
+
 import java.util.regex.Pattern;
+import javax.xml.namespace.QName;
 
 /**
  * Global constants for the Apache Synapse project
@@ -578,5 +579,8 @@ public final class SynapseConstants {
 
     // Common property for all artifacts
     public static final String ARTIFACT_NAME = "ARTIFACT_NAME";
+
+    // Registry mode used in WSO2 Micro Integrator.
+    public static final boolean IS_NON_REGISTRY_MODE = Boolean.parseBoolean(System.getProperty("NonRegistryMode"));
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/startup/quartz/QuartzTaskManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/quartz/QuartzTaskManager.java
@@ -19,12 +19,6 @@ package org.apache.synapse.startup.quartz;
  *  under the License.
  */
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Callable;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -49,6 +43,12 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.impl.StdSchedulerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
 
 public class QuartzTaskManager implements TaskManager {
     private static final Log logger = LogFactory.getLog(QuartzTaskManager.class.getName());
@@ -440,6 +440,21 @@ public class QuartzTaskManager implements TaskManager {
         synchronized (lock) {
             this.configProperties.putAll(properties);
         }
+    }
+
+    @Override
+    public void setMessageProcessorState(String name, String state) {
+        // do nothing
+    }
+
+    @Override
+    public String getMessageProcessorState(String name) {
+        return null;
+    }
+
+    @Override
+    public void removeMessageProcessorState(String name) {
+        // do nothing
     }
 
     private void assertInitialized() {

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskManager.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskManager.java
@@ -57,6 +57,12 @@ public interface TaskManager {
 
     public void setConfigurationProperties(Properties properties);
 
+	void setMessageProcessorState(String name, String state);
+
+	String getMessageProcessorState(String name);
+
+	void removeMessageProcessorState(String name);
+
 	/**
 	 * Adds a new Observer to the list of observers of this task manager.
 	 *


### PR DESCRIPTION
With the fix for https://github.com/wso2/product-ei/issues/872, a new property is introduced and was written in registry to maintain the message processor states. 

However in Micro Integrator, we use a RDBMS based task store and to remove the registry sharing , we can write the same to that store and retrieve it. Hence introducing this fix . 

Fixes : https://github.com/wso2/micro-integrator/issues/1071