### PR TITLE
Increase default grace time to 10 seconds

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -48,7 +48,7 @@ public class PassThroughConfiguration {
                                                          Runtime.getRuntime().availableProcessors();
     private static final int DEFAULT_MAX_ACTIVE_CON = -1;
     private static final int DEFAULT_LISTENER_SHUTDOWN_WAIT_TIME = 0;
-    private static final int DEFAULT_CONNECTION_GRACE_TIME = 3000;
+    private static final int DEFAULT_CONNECTION_GRACE_TIME = 10000;
     private Boolean isKeepAliveDisabled = null;
 
     //additional rest dispatch handlers


### PR DESCRIPTION
Related PR https://github.com/wso2/wso2-synapse/pull/1472

## Purpose
$subject to be more safe when getting connections from the pool to create new a connection.