### PR TITLE
Add support for dynamic names in property mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyMediatorFactory.java
@@ -23,7 +23,10 @@ import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.builtin.PropertyMediator;
+import org.apache.synapse.util.xpath.SynapseJsonPath;
+import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 
 import javax.xml.namespace.QName;
@@ -71,7 +74,29 @@ public class PropertyMediatorFactory extends AbstractMediatorFactory {
             log.error(msg);
             throw new SynapseException(msg);
         }
-        
+
+        //check the property name dynamic or not
+        String nameAttributeValue = name.getAttributeValue();
+        if (isDynamicName(nameAttributeValue)) {
+            try {
+                String nameExpression = nameAttributeValue.substring(1, nameAttributeValue.length() - 1);
+                if(nameExpression.startsWith("json-eval(")) {
+                    new SynapseJsonPath(nameExpression.substring(10, nameExpression.length() - 1));
+                } else {
+                    new SynapseXPath(nameExpression);
+                }
+            } catch (JaxenException e) {
+                String msg = "Invalid expression for attribute 'name' : " + nameAttributeValue;
+                log.error(msg);
+                throw new SynapseException(msg);
+            }
+            // ValueFactory for creating dynamic Value
+            ValueFactory nameValueFactory = new ValueFactory();
+            // create dynamic Value based on OMElement
+            Value generatedNameValue = nameValueFactory.createValue(XMLConfigConstants.NAME, elem);
+            propMediator.setDynamicNameValue(generatedNameValue);
+        }
+
         propMediator.setName(name.getAttributeValue());
         String dataType = null;
         if (type != null) {
@@ -153,5 +178,27 @@ public class PropertyMediatorFactory extends AbstractMediatorFactory {
 
     public QName getTagQName() {
         return PROP_Q;
+    }
+
+    /**
+     * Validate the given name to identify whether it is static or dynamic key
+     * If the name is in the {} format then it is dynamic key(XPath)
+     * Otherwise just a static name
+     *
+     * @param nameValue string to validate as a name
+     * @return isDynamicName representing name type
+     */
+    private boolean isDynamicName(String nameValue) {
+        if (nameValue.length() < 2) {
+            return false;
+        }
+
+        final char startExpression = '{';
+        final char endExpression = '}';
+
+        char firstChar = nameValue.charAt(0);
+        char lastChar = nameValue.charAt(nameValue.length() - 1);
+
+        return (startExpression == firstChar && endExpression == lastChar);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
@@ -54,6 +54,7 @@ public class XMLConfigConstants {
     /** The scope name for environment variables */
     public static final String SCOPE_ENVIRONMENT = "env";
     public static final String KEY = "key";
+    public static final String NAME = "name";
     public static final String LOCATION = "location";
     public static final String RECEIVE = "receive";
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -20,6 +20,7 @@
 package org.apache.synapse.mediators.builtin;
 
 import org.apache.axis2.context.OperationContext;
+import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.SynapseException;
@@ -28,6 +29,7 @@ import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.config.SynapseConfigUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
+import org.apache.synapse.mediators.Value;
 import org.apache.synapse.registry.Registry;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.axiom.om.OMElement;
@@ -54,6 +56,8 @@ public class PropertyMediator extends AbstractMediator {
 
     /** The Name of the property  */
     private String name = null;
+    /** The DynamicNameValue of the property if it is dynamic  */
+    private Value dynamicNameValue = null;
     /** The Value to be set  */
     private Object value = null;
     /** The data type of the value */
@@ -104,6 +108,15 @@ public class PropertyMediator extends AbstractMediator {
 
             if (synLog.isTraceTraceEnabled()) {
                 synLog.traceTrace("Message : " + synCtx.getEnvelope());
+            }
+        }
+
+        String name = this.name;
+        //checks the name attribute value is a dynamic or not
+        if (dynamicNameValue != null) {
+            name  = dynamicNameValue.evaluateValue(synCtx);
+            if (StringUtils.isEmpty(name)) {
+                log.warn("Evaluated value for " + this.name + " is empty");
             }
         }
 
@@ -480,5 +493,14 @@ public class PropertyMediator extends AbstractMediator {
 
     @Override public String getMediatorName() {
         return super.getMediatorName() + ":" + name;
+    }
+
+    /**
+     * Setter for the Value of the Name attribute when it has a dynamic value.
+     *
+     * @param nameValue Value of the dynamic name value
+     */
+    public void setDynamicNameValue(Value nameValue) {
+        this.dynamicNameValue = nameValue;
     }
 }


### PR DESCRIPTION
Property mediator does not allow dynamic names at the moment. It is supported for other mediators - e.g. sequence mediator. This is a useful feature to have.

Examples:
```
<property name="{get-property('propertyName')}" expression="$ctx:propertyValue" />
<property name="{$ctx:propertyName}" expression="$ctx:propertyValue" />
<property name="{json-eval({$ctx:propertyName})}" expression="$ctx:propertyValue" />
```

From this PR, the property mediator can not have a static name like `{name}` since this uses the same logic used in defining the sequence mediator key attribute.

Related issue- https://github.com/wso2/product-ei/issues/3300