### PR TITLE
Add milliseconds to access logger date time format.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
@@ -56,7 +56,7 @@ public class AccessLogger {
 
     private final static String DATE_EXTRACT_REGEX = "\\[([^]]+)\\]";
 
-    private final static String DATE_FORMAT_STRING = "dd/MMM/yyyy:HH:mm:ss Z";
+    private final static String DATE_FORMAT_STRING = "dd/MMM/yyyy:HH:mm:ss.SSS Z";
 
     private static final String IS_LOG_ROTATABLE = "nhttp.is.log.rotatable";
 


### PR DESCRIPTION
## Purpose
> Error occurs occurs when invoking an API as it cannot parse a date time format with milliseconds.

Related PR: https://github.com/wso2/wso2-synapse/pull/1499