### PR TITLE
Specify javax import version

### DIFF
--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -365,6 +365,7 @@
                         <Private-Package>samples.*</Private-Package>
                         <Import-Package>
                             !org.apache.commons.logging,
+                            javax.activation;version="[1.1,2)",
                             org.apache.commons.logging; version=0.0.0,,
                             *; resolution:=optional
                         </Import-Package>


### PR DESCRIPTION
## Purpose
> With the upgrade of bundle plugin in https://github.com/wso2/wso2-synapse/pull/1514/commits/6dd28d20438fee23d533fcffd105b3fd56c9d765 the version is detected as 0.0.0 and it picks an incompatible package.