### PR TITLE
Fix: https://github.com/wso2/product-ei/issues/5047

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
@@ -71,6 +71,15 @@ public abstract class FaultHandler {
         boolean traceOn = synCtx.getTracingState() == SynapseConstants.TRACING_ON;
         boolean traceOrDebugOn = traceOn || log.isDebugEnabled();
 
+        if (e != null && SynapseConstants.JMS_INVALID_MESSAGE_TYPE_EXCEPTION
+                .equals(synCtx.getProperty(SynapseConstants.JMS_TRANSPORT_EXCEPTION_TRIGGER_TYPE))) {
+            synCtx.setProperty(SynapseConstants.ERROR_CODE, SynapseConstants.JMS_INVALID_MESSAGE_TYPE_ERROR);
+            // use only the first line as the message for multiline exception messages (Axis2 has these)
+            synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, e.getMessage().split("\n")[0]);
+            synCtx.setProperty(SynapseConstants.ERROR_DETAIL, getStackTrace(e));
+            synCtx.setProperty(SynapseConstants.ERROR_EXCEPTION, e);
+        }
+
         if (e != null && synCtx.getProperty(SynapseConstants.ERROR_CODE) == null) {
             synCtx.setProperty(SynapseConstants.ERROR_CODE, SynapseConstants.DEFAULT_ERROR);
             // use only the first line as the message for multiline exception messages (Axis2 has these)

--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -493,6 +493,10 @@ public final class SynapseConstants {
     public static final String FORCE_ERROR_PROPERTY = "FORCE_ERROR_ON_SOAP_FAULT";
     public static final int ENDPOINT_CUSTOM_ERROR = 500000;
 
+    public static final String JMS_TRANSPORT_EXCEPTION_TRIGGER_TYPE = "JMS_TRANSPORT_EXCEPTION_TRIGGER_TYPE";
+    public static final String JMS_INVALID_MESSAGE_TYPE_EXCEPTION = "JMS_INVALID_MESSAGE_TYPE_EXCEPTION";
+    public static final int JMS_INVALID_MESSAGE_TYPE_ERROR = 101550;
+
     // Error code for XML/JSON parsing errors
     public static final int MESSAGE_PARSING_ERROR = 601000;
 

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -31,6 +31,7 @@ import org.apache.axis2.addressing.AddressingConstants;
 import org.apache.axis2.addressing.AddressingHelper;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.engine.AxisEngine;
+import org.apache.axis2.transport.base.IgnoreSuspensionBaseTransportException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseConstants;
@@ -87,6 +88,10 @@ public class Axis2Sender {
                     endpoint,
                     // The Axis2 Message context of the Synapse MC
                     synapseInMessageContext);
+        } catch (IgnoreSuspensionBaseTransportException e) {
+            synapseInMessageContext.setProperty(SynapseConstants.JMS_TRANSPORT_EXCEPTION_TRIGGER_TYPE,
+                    SynapseConstants.JMS_INVALID_MESSAGE_TYPE_EXCEPTION);
+            handleException("Invalid JMS message type received by the JMS transport", e);
         } catch (Exception e) {
             handleException("Unexpected error during sending message out", e);
         }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -521,6 +521,11 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
         Integer errorCode = (Integer) synCtx.getProperty(SynapseConstants.ERROR_CODE);
         if (errorCode != null) {
             if (definition.getSuspendErrorCodes().isEmpty()) {
+                // if suspend codes are not defined, jms transport receiving a malformed jms message should not be
+                // considered as a suspend error code
+                if (errorCode == SynapseConstants.JMS_INVALID_MESSAGE_TYPE_ERROR) {
+                    return false;
+                }
                 // if suspend codes are not defined, any error will be fatal for the endpoint
                 if (log.isDebugEnabled()) {
                     log.debug(this.toString() + " encountered a fatal error : " + errorCode);

--- a/pom.xml
+++ b/pom.xml
@@ -1279,8 +1279,8 @@
       <mina.version>1.1.0</mina.version>
       <jms-1.1-spec.version>1.1</jms-1.1-spec.version>
       <!-- Axis2 and its dependencies -->
-      <axis2.version>1.6.1-wso2v46</axis2.version>
-      <axis2.transport.version>2.0.0-wso2v46</axis2.transport.version>
+      <axis2.version>1.6.1-wso2v48</axis2.version>
+      <axis2.transport.version>2.0.0-wso2v47</axis2.transport.version>
       <axiom.version>1.2.11-wso2v16</axiom.version>
       <xml_schema.version>1.4.7</xml_schema.version>
       <xml_apis.version>1.3.04</xml_apis.version>


### PR DESCRIPTION
## Purpose
The JMS endpoints in request-response service (JMS dual-channel proxy service )
will immediately suspend when it receives a malformed JMS message (The type which).
Fix this by introducing a new error_code 101550.

Fixes: https://github.com/wso2/product-ei/issues/5047
