### PR TITLE
Fix EI-5071 return session cookie when boxcarring enabled.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -72,6 +72,7 @@ import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsColl
 import org.apache.synapse.transport.passthru.jmx.TransportView;
 
 import org.apache.synapse.transport.passthru.util.ActiveConnectionMonitor;
+import org.apache.synapse.transport.passthru.util.SessionContextUtil;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -411,7 +412,7 @@ public class PassThroughHttpListener implements TransportListener {
     }
 
     public SessionContext getSessionContext(MessageContext messageContext) {
-        return null;
+        return SessionContextUtil.createSessionContext(messageContext);
     }
 
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SessionContextUtil.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SessionContextUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.synapse.transport.passthru.util;
+
+import org.apache.axis2.Constants;
+import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.context.SessionContext;
+import org.apache.axis2.transport.http.HTTPConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+/**
+ * This manages session context in the message context
+ */
+public class SessionContextUtil {
+
+    public static SessionContext createSessionContext(MessageContext messageContext) {
+
+        HttpServletRequest request = (HttpServletRequest) messageContext.getProperty(
+                HTTPConstants.MC_HTTP_SERVLETREQUEST);
+        if (request == null) {
+            // This can happen inside a HostObject accessed by a Jaggery application.
+            return null;
+        }
+        SessionContext sessionContext = null;
+
+        HttpSession httpSession = request.getSession(true);
+        if (httpSession != null) {
+            sessionContext =
+                    (SessionContext) httpSession.getAttribute(Constants.SESSION_CONTEXT_PROPERTY);
+            if (sessionContext == null) {
+                String cookieValueString = httpSession.getId();
+                sessionContext = new SessionContext(null);
+                sessionContext.setParent(messageContext.getConfigurationContext());
+                sessionContext.setCookieID(cookieValueString);
+                httpSession.setAttribute(Constants.SESSION_CONTEXT_PROPERTY, sessionContext);
+                messageContext.setSessionContext(sessionContext);
+                messageContext.setProperty("SessionId", cookieValueString);
+            } else if (sessionContext.getParent() != messageContext.getConfigurationContext()) {
+                httpSession.removeAttribute(Constants.SESSION_CONTEXT_PROPERTY);
+                sessionContext = new SessionContext(null);
+                sessionContext.setParent(messageContext.getConfigurationContext());
+                String cookieValueString = httpSession.getId();
+                sessionContext.setCookieID(cookieValueString);
+                messageContext.setProperty("SessionId", cookieValueString);
+                httpSession.setAttribute(Constants.SESSION_CONTEXT_PROPERTY,
+                        sessionContext);
+
+            }
+        }
+        return sessionContext;
+    }
+}


### PR DESCRIPTION
This PR is to fix https://github.com/wso2/product-ei/issues/5071

In EI the transport In listener is PassThroughHttpListener. In PassThroughHttpListener the session context returns null. As a result, the session cookie is not set for sevice requests. This PR fixes that issue.

