### PR TITLE
Remove duplicate invocation of handleRequestOutFlow in call blocking

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -465,7 +465,6 @@ public class BlockingMsgSender {
     private void sendRobust(org.apache.axis2.context.MessageContext axisOutMsgCtx,
                             Options clientOptions, AxisService anonymousService,
                             ServiceContext serviceCtx, MessageContext synapseInMsgCtx) throws AxisFault {
-        this.invokeHandlers(synapseInMsgCtx, false);
         AxisOperation axisAnonymousOperation =
                 anonymousService.getOperation(new QName(AnonymousServiceFactory.OUT_ONLY_OPERATION));
         OperationClient operationClient =
@@ -492,7 +491,6 @@ public class BlockingMsgSender {
         operationClient.addMessageContext(axisOutMsgCtx);
         axisOutMsgCtx.setAxisMessage(
                 axisAnonymousOperation.getMessage(WSDLConstants.MESSAGE_LABEL_OUT_VALUE));
-        this.invokeHandlers(synapseInMsgCtx, false);
         operationClient.execute(true);
         org.apache.axis2.context.MessageContext resultMsgCtx =
                 operationClient.getMessageContext(WSDLConstants.MESSAGE_LABEL_IN_VALUE);
@@ -517,7 +515,7 @@ public class BlockingMsgSender {
         returnMsgCtx.setProperty(
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS,
                 resultMsgCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS));
-        this.invokeHandlers(synapseInMsgCtx, true);
+        this.invokeHandlers(synapseInMsgCtx);
         return returnMsgCtx;
     }
 
@@ -570,30 +568,18 @@ public class BlockingMsgSender {
      * Invoke Synapse Handlers
      *
      * @param synCtx synapse message context
-     * @param isResponse whether message is response path or not
      */
-    private void invokeHandlers(MessageContext synCtx, boolean isResponse) {
+    private void invokeHandlers(MessageContext synCtx) {
 
-        Iterator<SynapseHandler> iterator =
-                synCtx.getEnvironment().getSynapseHandlers().iterator();
+        Iterator<SynapseHandler> iterator = synCtx.getEnvironment().getSynapseHandlers().iterator();
 
         if (iterator.hasNext()) {
-
-            if (isResponse) {
-                do {
-                    SynapseHandler handler = iterator.next();
-                    if (!handler.handleResponseInFlow(synCtx)) {
-                        log.warn("Synapse not executed in the response in path");
-                    }
-                } while (iterator.hasNext());
-            } else {
-                do {
-                    SynapseHandler handler = iterator.next();
-                    if (!handler.handleRequestOutFlow(synCtx)) {
-                        log.warn("Synapse not executed in the request out path");
-                    }
-                } while (iterator.hasNext());
-            }
+            do {
+                SynapseHandler handler = iterator.next();
+                if (!handler.handleResponseInFlow(synCtx)) {
+                    log.warn("Synapse not executed in the response in path");
+                }
+            } while (iterator.hasNext());
         }
     }
 


### PR DESCRIPTION
HandleRequestOutFlow is invoked for the second time in BlockingMsgSender though it is already invoked in Axis2Sender.send method. Hence removed the second invocation to eliminate duplicate invocation.

Fixes wso2/micro-integrator#1536.