### PR TITLE
Preserve INTERNAL_TRANSACTION_COUNTED property in Passthru transport

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -330,7 +330,11 @@
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
         </dependency>
-        <!--  JSON Schema validator dependency -->
+	<dependency>
+		<groupId>org.apache.axis2</groupId>
+		<artifactId>axis2-transport-base</artifactId>
+	</dependency>
+	<!--  JSON Schema validator dependency -->
         <dependency>
             <groupId>org.wso2.orbit.com.github.fge</groupId>
             <artifactId>json-schema-validator-all</artifactId>

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -37,6 +37,7 @@ import org.apache.axis2.description.AxisServiceGroup;
 import org.apache.axis2.description.TransportOutDescription;
 import org.apache.axis2.description.WSDL2Constants;
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.transport.http.HTTPTransportUtils;
 import org.apache.axis2.wsdl.WSDLConstants;
@@ -56,12 +57,12 @@ import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.util.MediatorPropertyUtils;
 import org.apache.synapse.util.MessageHelper;
 
-import javax.mail.internet.ContentType;
-import javax.mail.internet.ParseException;
-import javax.xml.namespace.QName;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import javax.mail.internet.ContentType;
+import javax.mail.internet.ParseException;
+import javax.xml.namespace.QName;
 
 /**
  * This is a simple client that handles both in only and in out
@@ -159,6 +160,11 @@ public class Axis2FlexibleMEPClient {
         String preserveAddressingProperty = (String) synapseOutMessageContext.getProperty(
                 SynapseConstants.PRESERVE_WS_ADDRESSING);
         MessageContext axisOutMsgCtx = cloneForSend(originalInMsgCtx, preserveAddressingProperty);
+
+        // set "INTERNAL_TRANSACTION_COUNTED" property in axisOutMsgCtx's message context.
+        axisOutMsgCtx.setProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED,
+                                  originalInMsgCtx.getProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
+
         Object TRIGGER_NAME;
         if ((TRIGGER_NAME = synapseOutMessageContext.getProperty(SynapseConstants.PROXY_SERVICE)) != null) {
             axisOutMsgCtx.setProperty(PassThroughConstants.INTERNAL_TRIGGER_TYPE, SynapseConstants.PROXY_SERVICE_TYPE);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -16,17 +16,6 @@
 
 package org.apache.synapse.transport.passthru;
 
-import java.io.OutputStream;
-import java.net.InetAddress;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.xml.parsers.FactoryConfigurationError;
-
-
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAP12Constants;
@@ -46,6 +35,7 @@ import org.apache.axis2.dispatchers.RequestURIBasedDispatcher;
 import org.apache.axis2.engine.AxisEngine;
 import org.apache.axis2.transport.RequestResponseTransport;
 import org.apache.axis2.transport.TransportUtils;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.transport.http.HTTPTransportUtils;
 import org.apache.axis2.util.MessageContextBuilder;
@@ -67,7 +57,6 @@ import org.apache.synapse.commons.util.ext.TenantInfoInitiatorProvider;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.transport.http.conn.SynapseDebugInfoHolder;
 import org.apache.synapse.transport.nhttp.HttpCoreRequestResponseTransport;
-import org.apache.synapse.transport.nhttp.NHttpConfiguration;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.nhttp.util.NhttpUtil;
 import org.apache.synapse.transport.nhttp.util.RESTUtil;
@@ -75,6 +64,15 @@ import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.apache.synapse.transport.passthru.util.SourceResponseFactory;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.xml.parsers.FactoryConfigurationError;
 
 /**
  * This is a worker thread for executing an incoming request in to the transport.
@@ -513,7 +511,9 @@ public class ServerWorker implements Runnable {
                 conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID));
         msgContext.setProperty(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY,
                 sourceConfiguration.isCorrelationLoggingEnabled());
-
+        // propagate transaction property
+        msgContext.setProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED,
+                               conn.getContext().getAttribute(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
         if (sourceConfiguration.getScheme().isSSL()) {
             msgContext.setTransportOut(cfgCtx.getAxisConfiguration()
                 .getTransportOut(Constants.TRANSPORT_HTTPS));

--- a/pom.xml
+++ b/pom.xml
@@ -1279,8 +1279,8 @@
       <mina.version>1.1.0</mina.version>
       <jms-1.1-spec.version>1.1</jms-1.1-spec.version>
       <!-- Axis2 and its dependencies -->
-      <axis2.version>1.6.1-wso2v48</axis2.version>
-      <axis2.transport.version>2.0.0-wso2v47</axis2.transport.version>
+      <axis2.version>1.6.1-wso2v50</axis2.version>
+      <axis2.transport.version>2.0.0-wso2v48</axis2.transport.version>
       <axiom.version>1.2.11-wso2v16</axiom.version>
       <xml_schema.version>1.4.7</xml_schema.version>
       <xml_apis.version>1.3.04</xml_apis.version>


### PR DESCRIPTION
## Purpose
To track the transactions in the Passthru transport (as part of the transaction counting mechanism), the message property called "INTERNAL_TRANSACTION_COUNTED" is maintained throughout the message flow.

Related PRs: https://github.com/wso2/wso2-axis2/pull/207, https://github.com/wso2/wso2-axis2-transports/pull/268

