### PR TITLE
[Front Port] Set GsonJsonProvider as the default config for Jayway JsonPath when Init

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/ServerManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerManager.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.commons.jmx.MBeanRegistrar;
 import org.apache.synapse.config.SynapsePropertiesLoader;
+import org.apache.synapse.mediators.eip.EIPUtils;
 import org.wso2.securevault.PasswordManager;
 import org.wso2.securevault.SecurityConstants;
 
@@ -102,6 +103,9 @@ public class ServerManager {
         }
         synapseController = SynapseControllerFactory
                 .createSynapseController(serverConfigurationInformation);
+
+        // set GsonJsonProvider as the default configuration for Jayway JsonPath
+        EIPUtils.setJsonPathConfiguration();
 
         // does the initialization of the controller
         doInit();


### PR DESCRIPTION
#### Issues
wso2/product-apim#7949

#### Reason
Default is `JacksonJsonProvider` and it is changing to `GsonJsonProvider` when setting the property mediator as follows.
```xml
<property name="JSON-Payload" expression="json-eval($.)"/>
```

So make `GsonJsonProvider` as the default when initializing.