### PR TITLE
Fix registry content empty issue with property mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -208,19 +208,19 @@ public class PropertyMediator extends AbstractMediator {
                 String[] args = name.split("@");
                 String path = "";
                 String propertyName = "";
+                Registry registry = synCtx.getConfiguration().getRegistry();
 
                 // If the name argument consistent with a @ separated property name then an empty resource is added
                 // with the property mentioned and the value as its value
                 if (args.length == 1){
                     path = args[0];
+                    registry.newNonEmptyResource(path, false, CONTENT_TYPE, resultValue.toString(), propertyName);
                 } else if (args.length == 2) {
                     path = args[0];
                     propertyName = args[1];
+                    registry.newNonEmptyResource(path, false, CONTENT_TYPE, resultValue.toString(), propertyName);
+                    registry.updateResource(path, EMPTY_CONTENT);
                 }
-
-                Registry registry = synCtx.getConfiguration().getRegistry();
-                registry.newNonEmptyResource(path, false, CONTENT_TYPE, resultValue.toString(), propertyName);
-                registry.updateResource(path, EMPTY_CONTENT);
             }
 
         } else {


### PR DESCRIPTION
## Purpose
Fix for always setting content empty, when creating registry entry via property mediator.
https://github.com/wso2/product-ei/issues/5099

## Approach
This is a regression from fix done for [1226](https://github.com/wso2/product-ei/issues/1226). With this [fix](https://github.com/wso2/wso2-synapse/pull/1440/files) all the registry contents were set to empty, which is incorrect.  

With this PR registry content has set to empty only it there's property value ("@"). 