### PR TITLE
Fix the issue of throttle configurations not being retrieved properly

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/AccessRateController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/AccessRateController.java
@@ -42,6 +42,7 @@ public class AccessRateController {
     private final Object lock = new Object();
 
     private boolean debugOn = false;  //is debug enable
+    private static final String SYMBOL_UNDERSCORE = "_";
 
     public AccessRateController() {
         debugOn = log.isDebugEnabled();
@@ -82,9 +83,9 @@ public class AccessRateController {
             accessInformation.setFaultReason(msg);
             return accessInformation;
         }
-
-        CallerConfiguration configuration =
-                throttleConfigurationBean.getCallerConfiguration(callerID);
+        // The configs are added without unique key hence removing it while retrieving the configuration.
+        String callerAddress = callerID.substring(callerID.lastIndexOf(SYMBOL_UNDERSCORE) + 1);
+        CallerConfiguration configuration = throttleConfigurationBean.getCallerConfiguration(callerAddress);
         if (configuration == null) {
             if (debugOn) {
                 log.debug("Caller configuration couldn't find for " + type + " and for caller " +

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/throttle/ThrottleMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/throttle/ThrottleMediator.java
@@ -106,6 +106,7 @@ public class ThrottleMediator extends AbstractMediator implements ManagedLifecyc
     private final Object throttleLock = new Object();
     /* Last version of dynamic policy resource*/
     private long version;
+    private static final String SYMBOL_UNDERSCORE = "_";
 
     public ThrottleMediator() {
     }
@@ -356,6 +357,7 @@ public class ThrottleMediator extends AbstractMediator implements ManagedLifecyc
         } else {
             uniqueKey = id;
         }
+        uniqueKey = uniqueKey.concat(SYMBOL_UNDERSCORE);
 
         //Using remote caller domain name , If there is a throttle configuration for
         // this domain name ,then throttling will occur according to that configuration


### PR DESCRIPTION
A unique key was added as a fix in https://github.com/wso2/wso2-synapse/pull/1434/commits/738142dffbe5d871d50ff4e53f99db684839c1ea to identify throttle counts across the cluster when same policy is used in multiple artifacts. However as we are using this only to identify the count in the run time, in the deployment time policies ( static configs ) are stored without unique id. Hence as a fix removing the unique id while retrieving the configurations to fix the issue. 
Verified https://github.com/wso2/product-ei/issues/4755 issue in 2 node cluster with the fix.

Fixes wso2/product-ei#5104. 