### PR TITLE
Fix latency issue which happens due to HostName resolving

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientConnFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ClientConnFactory.java
@@ -81,8 +81,17 @@ public class ClientConnFactory {
     
     private SSLContext getSSLContext(final IOSession iosession) {
         InetSocketAddress address = (InetSocketAddress) iosession.getRemoteAddress();
-        String host = address.getHostName() + ":" + address.getPort();
-        return  getSSLContextForHost(host);
+        SSLContext customContext = null;
+        if (sslByHostMap != null) {
+            String host = address.getHostName() + ":" + address.getPort();
+            // See if there's a custom SSL profile configured for this server
+            customContext = sslByHostMap.get(host);
+        }
+        if (customContext != null) {
+            return customContext;
+        } else {
+            return ssl != null ? ssl.getContext() : null;
+        }
     }
 
     private SSLContext getSSLContext(final org.apache.http.HttpHost httpHost) {


### PR DESCRIPTION
## Purpose
This PR fixes the latency issue which happens due to HostName resolving.
We only need to resolve a hostname if we have configured a custom SSL profile. Because we retrieve the SSL profile configuration from `sslByHostMap` using the hostname. Otherwise, we do not need to resolve the hostname. 

Fixes https://github.com/wso2/product-ei/issues/4723
