### PR TITLE
Add Look ahead class validation while deserialization

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/LookAheadObjectInputStream.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/LookAheadObjectInputStream.java
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.synapse.commons.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+public class LookAheadObjectInputStream extends ObjectInputStream {
+
+    private Class<?> aClass;
+
+    /**
+     * Constructor.
+     *
+     * @param in     input stream to read from
+     * @param aClass a <code>Class</code> object
+     * @throws IOException any of the usual Input/Output exceptions
+     */
+    public LookAheadObjectInputStream(InputStream in, Class<?> aClass) throws IOException {
+        super(in);
+        this.aClass = aClass;
+    }
+
+    /**
+     * @see java.io.ObjectInputStream#resolveClass(ObjectStreamClass).
+     */
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        if (!desc.getName().equals(aClass.getName())) {
+            throw new InvalidClassException("Unauthorized deserialization attempt", desc.getName());
+        }
+        return super.resolveClass(desc);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQConsumer.java
@@ -24,6 +24,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.util.LookAheadObjectInputStream;
 import org.apache.synapse.message.MessageConsumer;
 
 import org.apache.synapse.message.store.impl.commons.MessageConverter;
@@ -109,7 +110,7 @@ public class RabbitMQConsumer implements MessageConsumer {
     private StorableMessage deserializeMessage(GetResponse delivery) throws IOException, ClassNotFoundException {
         StorableMessage storableMessage;
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(delivery.getBody());
-             ObjectInput objectInput = new ObjectInputStream(inputStream)) {
+             ObjectInput objectInput = new LookAheadObjectInputStream(inputStream, StorableMessage.class)) {
             storableMessage = (StorableMessage) objectInput.readObject();
         }
         return storableMessage;

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -145,6 +145,10 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-commons</artifactId>
+        </dependency>
     </dependencies>
     <properties />
     <pluginRepositories>

--- a/modules/securevault/src/main/java/org/apache/synapse/securevault/tool/CipherTool.java
+++ b/modules/securevault/src/main/java/org/apache/synapse/securevault/tool/CipherTool.java
@@ -21,6 +21,7 @@ package org.apache.synapse.securevault.tool;
 import org.apache.commons.cli.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.util.LookAheadObjectInputStream;
 import org.apache.synapse.securevault.*;
 import org.apache.synapse.securevault.definition.CipherInformation;
 import org.apache.synapse.securevault.definition.IdentityKeyStoreInformation;
@@ -386,7 +387,7 @@ public final class CipherTool {
 
         ObjectInputStream in = null;
         try {
-            in = new ObjectInputStream(new FileInputStream(keyFile));
+            in = new LookAheadObjectInputStream(new FileInputStream(keyFile), Key.class);
             Object object = in.readObject();
             if (object instanceof Key) {
                 return (Key) object;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/SynapseWireLogHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/SynapseWireLogHolder.java
@@ -1,5 +1,7 @@
 package org.apache.synapse.transport.http.conn;
 
+import org.apache.synapse.commons.util.LookAheadObjectInputStream;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -143,7 +145,7 @@ public class SynapseWireLogHolder implements Serializable {
             wireLogHolderOutputStream.flush();
             ByteArrayInputStream binaryInputStream =
                     new ByteArrayInputStream(binaryOutputStream.toByteArray());
-            wireLogHolderInputStream = new ObjectInputStream(binaryInputStream);
+            wireLogHolderInputStream = new LookAheadObjectInputStream(binaryInputStream, SynapseWireLogHolder.class);
 
             return (SynapseWireLogHolder) wireLogHolderInputStream.readObject();
         } finally {


### PR DESCRIPTION
## Purpose
This PR will avoid the insecure deserialization of Storable objects. 

## Security Concern
When type checking is performed on a deserialized object as in this code, there is a chance that an attacker can instantiate any object available to the application with an arbitrary internal state. In other words, an attacker could instantiate any class on the classpath with malicious member variables they wanted. This would allow an attacker to cause remote code execution upon deserialization or create malicious deserialized objects that can cause remote code execution and data tampering upon usage. Hence, this is a threat.
