### PR TITLE
Format audit logs for Api , Proxy and Inbounds

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
@@ -21,6 +21,7 @@ package org.apache.synapse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 import java.util.Stack;
 import java.io.StringWriter;
@@ -49,9 +50,10 @@ public abstract class FaultHandler {
         }
 
         try {
-            synCtx.getServiceLog().info("FaultHandler executing impl: " + this.getClass().getName());
+            String msg = "FaultHandler executing impl: " + this.getClass().getName();
+            // log.info(LoggingUtils.getFormattedLog(synCtx, msg));
+            synCtx.getServiceLog().info(msg);
             onFault(synCtx);
-
         } catch (SynapseException e) {
 
             Stack faultStack = synCtx.getFaultStack();
@@ -90,9 +92,10 @@ public abstract class FaultHandler {
                 synCtx.getProperty(SynapseConstants.ERROR_EXCEPTION));
         }
 
-        synCtx.getServiceLog().warn("ERROR_CODE : " +
-            synCtx.getProperty(SynapseConstants.ERROR_CODE) + " ERROR_MESSAGE : " + 
-            synCtx.getProperty(SynapseConstants.ERROR_MESSAGE));
+        String msg = "ERROR_CODE : " + synCtx.getProperty(SynapseConstants.ERROR_CODE) + " ERROR_MESSAGE : " + synCtx
+                .getProperty(SynapseConstants.ERROR_MESSAGE);
+        //log.warn(LoggingUtils.getFormattedLog(synCtx, msg));
+        synCtx.getServiceLog().warn(msg);
 
         try {
             if (traceOrDebugOn) {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.apache.synapse.ContinuationState;
-import org.apache.synapse.FaultHandler;
 import org.apache.synapse.SynapseHandler;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
@@ -67,6 +66,7 @@ import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.apache.synapse.unittest.UnitTestingExecutor;
 import org.apache.synapse.util.concurrent.InboundThreadPool;
 import org.apache.synapse.util.concurrent.SynapseThreadPool;
+import org.apache.synapse.util.logging.LoggingUtils;
 import org.apache.synapse.util.xpath.ext.SynapseXpathFunctionContextProvider;
 import org.apache.synapse.util.xpath.ext.SynapseXpathVariableResolver;
 
@@ -132,6 +132,10 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
 
     /** Unit test mode is enabled/disabled*/
     private boolean isUnitTestEnabled = false;
+
+    private static final String NO_FAULT_HANDLER_ERROR =
+            "Exception encountered but no fault handler found - message dropped";
+    private static final String EXECUTING_FAULT_HANDLER_ERROR = "Executing fault handler due to exception encountered";
 
     public Axis2SynapseEnvironment(SynapseConfiguration synCfg) {
 
@@ -470,32 +474,30 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
             return true;
         } catch (SynapseException syne) {
             if (!synCtx.getFaultStack().isEmpty()) {
-                log.warn("Executing fault handler due to exception encountered");
-                ((FaultHandler) synCtx.getFaultStack().pop()).handleFault(synCtx, syne);
+                log.warn(LoggingUtils.getFormattedLog(synCtx, EXECUTING_FAULT_HANDLER_ERROR));
+                (synCtx.getFaultStack().pop()).handleFault(synCtx, syne);
                 return true;
             } else {
-                log.warn("Exception encountered but no fault handler found - message dropped");
+                log.warn(LoggingUtils.getFormattedLog(synCtx, NO_FAULT_HANDLER_ERROR));
                 throw syne;
             }
         } catch (Exception e) {
             String msg = "Unexpected error executing task/async inject";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {
                 synCtx.getServiceLog().error(msg, e);
             }
             if (!synCtx.getFaultStack().isEmpty()) {
-                log.warn("Executing fault handler due to exception encountered");
-                ((FaultHandler) synCtx.getFaultStack().pop()).handleFault(synCtx, e);
+                log.warn(LoggingUtils.getFormattedLog(synCtx, EXECUTING_FAULT_HANDLER_ERROR));
+                (synCtx.getFaultStack().pop()).handleFault(synCtx, e);
                 return true;
             } else {
-                log.warn("Exception encountered but no fault handler found - message dropped");
-                throw new SynapseException(
-                                           "Exception encountered but no fault handler found - message dropped",
-                                           e);
+                log.warn(LoggingUtils.getFormattedLog(synCtx, NO_FAULT_HANDLER_ERROR));
+                throw new SynapseException(NO_FAULT_HANDLER_ERROR, e);
             }
         } catch (Throwable e) {
             String msg = "Unexpected error executing inbound/async inject, message dropped";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {
                 synCtx.getServiceLog().error(msg, e);
             }
@@ -1042,32 +1044,28 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
             return true;
         } catch (SynapseException syne) {
             if (!smc.getFaultStack().isEmpty()) {
-                warn(false, "Executing fault handler due to exception encountered", smc);
+                warn(false, EXECUTING_FAULT_HANDLER_ERROR, smc);
                 smc.getFaultStack().pop().handleFault(smc, syne);
-
             } else {
-                warn(false, "Exception encountered but no fault handler found - " +
-                        "message dropped", smc);
+                warn(false, NO_FAULT_HANDLER_ERROR, smc);
             }
             return false;
         } catch (Exception e) {
             String msg = "Unexpected error executing  injecting message to sequence ," + seq;
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(smc, msg), e);
             if (smc.getServiceLog() != null) {
                 smc.getServiceLog().error(msg, e);
             }
             if (!smc.getFaultStack().isEmpty()) {
-                warn(false, "Executing fault handler due to exception encountered", smc);
+                warn(false, EXECUTING_FAULT_HANDLER_ERROR, smc);
                 smc.getFaultStack().pop().handleFault(smc, e);
-
             } else {
-                warn(false, "Exception encountered but no fault handler found - " +
-                        "message dropped", smc);
+                warn(false, NO_FAULT_HANDLER_ERROR, smc);
             }
             return false;
         } catch (Throwable e) {
             String msg = "Unexpected error executing  injecting message to sequence ," + seq + " message dropped";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(smc, msg), e);
             if (smc.getServiceLog() != null) {
                 smc.getServiceLog().error(msg, e);
             }
@@ -1081,10 +1079,12 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     }
 
     private void warn(boolean traceOn, String msg, MessageContext msgContext) {
+
+        String formattedLog = LoggingUtils.getFormattedLog(msgContext, msg);
         if (traceOn) {
-            trace.warn(msg);
+            trace.warn(formattedLog);
         }
-        log.warn(msg);
+        log.warn(formattedLog);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);
         }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -54,6 +54,7 @@ import org.apache.synapse.endpoints.WSDLEndpoint;
 import org.apache.synapse.mediators.MediatorFaultHandler;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.util.PolicyInfo;
+import org.apache.synapse.util.logging.LoggingUtils;
 import org.apache.synapse.util.resolver.CustomWSDLLocator;
 import org.apache.synapse.util.resolver.CustomXmlSchemaURIResolver;
 import org.apache.synapse.util.resolver.ResourceMap;
@@ -619,7 +620,7 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
             }
         } else if (wsdlFound) {
             handleException("Couldn't build the proxy service : " + name
-                    + ". Unable to locate the specified WSDL to build the service");
+                                    + ". Unable to locate the specified WSDL to build the service");
         }
 
         // Set the name and description. Currently Axis2 uses the name as the
@@ -858,7 +859,6 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
                 }
             }
         }
-
         auditInfo("Successfully created the Axis2 service for Proxy service : " + name);
         return axisService;
     }
@@ -930,8 +930,8 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
                     targetInLineFaultSequence.init(env);
                 }
             } else {
-                auditWarn("Unable to find the SynapseEnvironment. " +
-                        "Components of the proxy service may not be initialized");
+                auditWarn(
+                        "Unable to find the SynapseEnvironment. Components of the proxy service may not be initialized");
             }
 
             AxisService as = axisConfig.getServiceForActivation(this.getName());
@@ -963,22 +963,29 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
             this.setRunning(false);
             auditInfo("Stopped the proxy service : " + name);
         } else {
-            auditWarn("Unable to stop proxy service : " + name +
-                    ". Couldn't access Axis configuration");
+            auditWarn("Unable to stop proxy service : " + name + ". Couldn't access Axis configuration");
         }
     }
 
     private void handleException(String msg) {
+
+        String formattedMSg = getFormattedLog(msg);
         serviceLog.error(msg);
-        log.error(msg);
-        if (trace()) trace.error(msg);
+        log.error(formattedMSg);
+        if (trace()) {
+            trace.error(formattedMSg);
+        }
         throw new SynapseException(msg);
     }
 
     private void handleException(String msg, Exception e) {
+
+        String formattedMSg = getFormattedLog(msg);
         serviceLog.error(msg);
-        log.error(msg, e);
-        if (trace()) trace.error(msg + " :: " + e.getMessage());
+        log.error(formattedMSg, e);
+        if (trace()) {
+            trace.error(formattedMSg + " :: " + e.getMessage());
+        }
         throw new SynapseException(msg, e);
     }
 
@@ -987,11 +994,17 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
      * @param message the INFO level audit message
      */
     private void auditInfo(String message) {
-        log.info(message);
+
+        String formattedMSg = getFormattedLog(message);
+        log.info(formattedMSg);
         serviceLog.info(message);
         if (trace()) {
-            trace.info(message);
+            trace.info(formattedMSg);
         }
+    }
+
+    private String getFormattedLog(String msg) {
+        return LoggingUtils.getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE, getName(), msg);
     }
 
     /**
@@ -999,10 +1012,12 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
      * @param message the WARN level audit message
      */
     private void auditWarn(String message) {
-        log.warn(message);
+
+        String formattedMsg = getFormattedLog(message);
+        log.warn(formattedMsg);
         serviceLog.warn(message);
         if (trace()) {
-            trace.warn(message);
+            trace.warn(formattedMsg);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -40,6 +40,7 @@ import org.apache.synapse.debug.SynapseDebugManager;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.transport.http.conn.SynapseDebugInfoHolder;
 import org.apache.synapse.transport.http.conn.SynapseWireLogHolder;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 import java.util.Iterator;
 import java.util.List;
@@ -290,20 +291,22 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
     }
 
     private void traceOrDebug(boolean traceOn, String msg) {
+
+        String formattedLog = LoggingUtils.getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE, name, msg);
         if (traceOn) {
-            trace.info(msg);
+            trace.info(formattedLog);
         }
-        if (log.isDebugEnabled()) {
-            log.debug(msg);
-        }
+        log.debug(formattedLog);
     }
 
     private void warn(boolean traceOn, String msg, MessageContext msgContext) {
+
+        String formattedLog = LoggingUtils.getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE, name, msg);
         if (traceOn) {
-            trace.warn(msg);
+            trace.warn(formattedLog);
         }
         if (log.isDebugEnabled()) {
-            log.warn(msg);
+            log.warn(formattedLog);
         }
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);
@@ -311,12 +314,14 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
     }
 
     private void handleException(String msg, MessageContext msgContext) {
-        log.error(msg);
+
+        String formattedLog = LoggingUtils.getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE, name, msg);
+        log.error(formattedLog);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().error(msg);
         }
         if (proxy.getAspectConfiguration().isTracingEnabled()) {
-            trace.error(msg);
+            trace.error(formattedLog);
         }
         throw new SynapseException(msg);
     }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
@@ -29,6 +29,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
  * This message receiver should be configured in the Axis2 configuration as the
@@ -122,11 +123,13 @@ public class SynapseMessageReceiver implements MessageReceiver {
     }
 
     private void warn(boolean traceOn, String msg, MessageContext msgContext) {
+
+        String formattedMsg = LoggingUtils.getFormattedLog(msgContext, msg);
         if (traceOn) {
-            trace.warn(msg);
+            trace.warn(formattedMsg);
         }
         if (log.isDebugEnabled()) {
-            log.warn(msg);
+            log.warn(formattedMsg);
         }
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -50,6 +50,7 @@ import org.apache.synapse.mediators.MediatorFaultHandler;
 import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.transport.passthru.util.RelayConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.apache.synapse.util.logging.LoggingUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -387,7 +388,7 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
                     ((Axis2MessageContext) synCtx).getAxis2MessageContext().getEnvelope().build();
                 }
             } catch (Exception e) {
-                handleException("Error while building message", e);
+                handleException("Error while building message", e, synCtx);
             }
         }
 
@@ -671,6 +672,20 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
      */
     protected void handleException(String msg, Exception e) {
         log.error(msg, e);
+        throw new SynapseException(msg, e);
+    }
+
+    /**
+     * Helper methods to handle errors.
+     *
+     * @param msg    The error message
+     * @param e      The exception
+     * @param msgCtx The message context
+     */
+    protected void handleException(String msg, Exception e, MessageContext msgCtx) {
+
+        String formattedLog = LoggingUtils.getFormattedLog(msgCtx, msg);
+        log.error(formattedLog, e);
         throw new SynapseException(msg, e);
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/DefaultEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/DefaultEndpoint.java
@@ -77,8 +77,8 @@ public class DefaultEndpoint extends AbstractEndpoint {
         	 try {
 	            RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(),false);
             } catch (Exception e) {
-            	 handleException("Error while building message", e);
-            } 
+                 handleException("Error while building message", e, synCtx);
+             }
         }
         if (getParentEndpoint() == null && !readyToSend()) {
             // if the this leaf endpoint is too a root endpoint and is in inactive

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
@@ -327,8 +327,7 @@ public class FailoverEndpoint extends AbstractEndpoint {
         try {
             RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
         } catch (IOException | XMLStreamException ex) {
-            handleException("Error while building the message", ex);
-
+            handleException("Error while building the message", ex, synCtx);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -524,8 +524,7 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
         try {
             RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
         } catch (IOException | XMLStreamException ex) {
-            handleException("Error while building the message", ex);
-
+            handleException("Error while building the message", ex, synCtx);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/RecipientListEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/RecipientListEndpoint.java
@@ -169,7 +169,7 @@ public class RecipientListEndpoint extends AbstractEndpoint {
         try {
 	        RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(),false);
         } catch (Exception e) {
-        	  handleException("Error while building message", e);
+            handleException("Error while building message", e, synCtx);
         }
 
         for (Endpoint childEndpoint : children) {
@@ -180,7 +180,7 @@ public class RecipientListEndpoint extends AbstractEndpoint {
                 try {
                     newCtx = MessageHelper.cloneMessageContext(synCtx);
                 } catch (AxisFault e) {
-                    handleException("Error cloning the message context", e);
+                    handleException("Error cloning the message context", e, synCtx);
                 }
 
                 //Used when aggregating responses
@@ -281,8 +281,8 @@ public class RecipientListEndpoint extends AbstractEndpoint {
 			try {
 				newCtx = MessageHelper.cloneMessageContext(synCtx);
 			} catch (AxisFault e) {
-				handleException("Error cloning the message context", e);
-			}
+                handleException("Error cloning the message context", e, synCtx);
+            }
 
 			// Used when aggregating responses
 			newCtx.setProperty(

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/SALoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/SALoadbalanceEndpoint.java
@@ -139,7 +139,7 @@ public class SALoadbalanceEndpoint extends LoadbalanceEndpoint {
             try {
                 RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(),false);
             } catch (Exception e) {
-                handleException("Error while building message", e);
+                handleException("Error while building message", e, synCtx);
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/AbstractMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/AbstractMediator.java
@@ -35,6 +35,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
 import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
 import org.apache.synapse.debug.constructs.SynapseMediationFlowPoint;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -301,12 +302,14 @@ public abstract class AbstractMediator implements Mediator, AspectConfigurable {
      */
     @Deprecated
     protected void auditLog(String msg, MessageContext msgContext) {
-        log.info(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(msgContext, msg);
+        log.info(formattedMsg);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().info(msg);
         }
         if (shouldTrace(msgContext)) {
-            trace.info(msg);
+            trace.info(formattedMsg);
         }
     }
 
@@ -317,12 +320,14 @@ public abstract class AbstractMediator implements Mediator, AspectConfigurable {
      * @param msgContext the message context
      */
     protected void handleException(String msg, MessageContext msgContext) {
-        log.error(msg);
+
+        String formattedLog = LoggingUtils.getFormattedLog(msgContext, msg);
+        log.error(formattedLog);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().error(msg);
         }
         if (shouldTrace(msgContext)) {
-            trace.error(msg);
+            trace.error(formattedLog);
         }
         throw new SynapseException(msg);
     }
@@ -340,12 +345,14 @@ public abstract class AbstractMediator implements Mediator, AspectConfigurable {
      */
     @Deprecated
     protected void auditWarn(String msg, MessageContext msgContext) {
-        log.warn(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(msgContext, msg);
+        log.warn(formattedMsg);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);
         }
         if (shouldTrace(msgContext)) {
-            trace.warn(msg);
+            trace.warn(formattedMsg);
         }
     }
 
@@ -357,12 +364,14 @@ public abstract class AbstractMediator implements Mediator, AspectConfigurable {
      * @param msgContext the message context
      */
     protected void handleException(String msg, Exception e, MessageContext msgContext) {
-        log.error(msg, e);
+
+        String formattedLog = LoggingUtils.getFormattedLog(msgContext, msg);
+        log.error(formattedLog, e);
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().error(msg, e);
         }
         if (shouldTrace(msgContext)) {
-            trace.error(msg, e);
+            trace.error(formattedLog, e);
         }
         throw new SynapseException(msg, e);
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorLog.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorLog.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseLog;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
  * Concrete implementation of the {@link SynapseLog} interface appropriate
@@ -78,10 +79,12 @@ public class MediatorLog implements SynapseLog {
      * at level INFO if trace is enabled for the mediator.
      */
     public void traceOrDebug(Object msg) {
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.debug(formattedMsg);
         if (traceOn) {
-            traceLog.info(msg);
+            traceLog.info(formattedMsg);
         }
-        defaultLog.debug(msg);
     }
 
     /**
@@ -89,11 +92,13 @@ public class MediatorLog implements SynapseLog {
      * and to the trace log, if trace is enabled for the mediator.
      */
     public void traceOrDebugWarn(Object msg) {
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
         if (traceOn) {
-            traceLog.warn(msg);
+            traceLog.warn(formattedMsg);
         }
         if (defaultLog.isDebugEnabled()) {
-            defaultLog.warn(msg);
+            defaultLog.warn(formattedMsg);
         }
     }
     
@@ -106,7 +111,7 @@ public class MediatorLog implements SynapseLog {
      */
     public void traceTrace(Object msg) {
         if (traceOn) {
-            traceLog.trace(msg);
+            traceLog.trace(LoggingUtils.getFormattedLog(synCtx, msg));
         }
     }
 
@@ -114,12 +119,14 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level INFO to all available/enabled logs.
      */
     public void auditLog(Object msg) {
-        defaultLog.info(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.info(formattedMsg);
         if (synCtx.getServiceLog() != null) {
             synCtx.getServiceLog().info(msg);
         }
         if (traceOn) {
-            traceLog.info(msg);
+            traceLog.info(formattedMsg);
         }
     }
 
@@ -127,14 +134,14 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level DEBUG to all available/enabled logs.
      */
     public void auditDebug(Object msg) {
-    	if (defaultLog.isDebugEnabled()) { 
-    		defaultLog.debug(msg);
-    	}
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.debug(formattedMsg);
         if (synCtx.getServiceLog() != null && synCtx.getServiceLog().isDebugEnabled()) {
             synCtx.getServiceLog().debug(msg);
         }
         if (traceOn) {
-            traceLog.debug(msg);
+            traceLog.debug(formattedMsg);
         }
     }
 
@@ -142,14 +149,16 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level TRACE to all available/enabled logs.
      */
     public void auditTrace(Object msg) {
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
         if (defaultLog.isTraceEnabled()) {
-            defaultLog.trace(msg);
+            defaultLog.trace(formattedMsg);
         }
         if (synCtx.getServiceLog() != null && synCtx.getServiceLog().isTraceEnabled()) {
             synCtx.getServiceLog().trace(msg);
         }
         if (traceOn) {
-            traceLog.trace(msg);
+            traceLog.trace(formattedMsg);
         }
     }
 
@@ -157,12 +166,14 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level WARN to all available/enabled logs.
      */
     public void auditWarn(Object msg) {
-        defaultLog.warn(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.warn(formattedMsg);
         if (synCtx.getServiceLog() != null) {
             synCtx.getServiceLog().warn(msg);
         }
         if (traceOn) {
-            traceLog.warn(msg);
+            traceLog.warn(formattedMsg);
         }
     }
 
@@ -170,12 +181,14 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level ERROR to all available/enabled logs.
      */
     public void auditError(Object msg) {
-        defaultLog.error(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.error(formattedMsg);
         if (synCtx.getServiceLog() != null) {
             synCtx.getServiceLog().error(msg);
         }
         if (traceOn) {
-            traceLog.error(msg);
+            traceLog.error(formattedMsg);
         }
     }
 
@@ -183,12 +196,14 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level FATAL to all available/enabled logs.
      */
     public void auditFatal(Object msg) {
-        defaultLog.fatal(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.fatal(formattedMsg);
         if (synCtx.getServiceLog() != null) {
             synCtx.getServiceLog().fatal(msg);
         }
         if (traceOn) {
-            traceLog.fatal(msg);
+            traceLog.fatal(formattedMsg);
         }
     }
 
@@ -196,9 +211,11 @@ public class MediatorLog implements SynapseLog {
      * Log a message at level ERROR to the default log and to the trace, if trace is enabled.
      */
     public void error(Object msg) {
-        defaultLog.error(msg);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.error(formattedMsg);
         if (traceOn) {
-            traceLog.error(msg);
+            traceLog.error(formattedMsg);
         }
     }
 
@@ -207,12 +224,14 @@ public class MediatorLog implements SynapseLog {
      * is enabled.
      */
     public void logSynapseException(String msg, Throwable cause) {
-        defaultLog.error(msg, cause);
+
+        String formattedMsg = LoggingUtils.getFormattedLog(synCtx, msg);
+        defaultLog.error(formattedMsg, cause);
         if (synCtx.getServiceLog() != null) {
             synCtx.getServiceLog().error(msg, cause);
         }
         if (traceOn) {
-            traceLog.error(msg, cause);
+            traceLog.error(formattedMsg, cause);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -27,6 +27,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
 import org.apache.synapse.debug.SynapseDebugManager;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
  * This class will be used as the executer for the injectAsync method for the
@@ -98,7 +99,7 @@ public class MediatorWorker implements Runnable {
 
         } catch (Exception e) {
             String msg = "Unexpected error executing task/async inject";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {
                 synCtx.getServiceLog().error(msg, e);
             }
@@ -112,7 +113,7 @@ public class MediatorWorker implements Runnable {
             }
         } catch (Throwable e) {
             String msg = "Unexpected error executing task/async inject, message dropped";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {
                 synCtx.getServiceLog().error(msg, e);
             }
@@ -131,11 +132,13 @@ public class MediatorWorker implements Runnable {
     }
 
     private void warn(boolean traceOn, String msg, MessageContext msgContext) {
+
+        String formattedLog = LoggingUtils.getFormattedLog(msgContext, msg);
         if (traceOn) {
-            trace.warn(msg);
+            trace.warn(formattedLog);
         }
         if (log.isDebugEnabled()) {
-            log.warn(msg);
+            log.warn(formattedLog);
         }
         if (msgContext.getServiceLog() != null) {
             msgContext.getServiceLog().warn(msg);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/Target.java
@@ -31,6 +31,7 @@ import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
 import org.apache.synapse.continuation.ContinuationStackManager;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.mediators.base.SequenceMediator;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
  * A bean class that holds the target (i.e. sequence or endpoint) information for a message
@@ -255,22 +256,27 @@ public class Target {
             return sequenceMediator.mediate(synCtx);
         } catch (SynapseException syne) {
             if (!synCtx.getFaultStack().isEmpty()) {
-                log.warn("Executing fault handler due to exception encountered", syne);
-                ((FaultHandler) synCtx.getFaultStack().pop()).handleFault(synCtx, syne);
+                log.warn(LoggingUtils.getFormattedLog(synCtx, "Executing fault handler due to exception encountered"),
+                         syne);
+                (synCtx.getFaultStack().pop()).handleFault(synCtx, syne);
             } else {
-                log.warn("Exception encountered but no fault handler found - message dropped");
+                log.warn(LoggingUtils.getFormattedLog(synCtx,
+                                                      "Exception encountered but no fault handler found - message "
+                                                              + "dropped"));
             }
         } catch (Exception e) {
             String msg = "Unexpected error occurred executing the Target";
-            log.error(msg, e);
+            log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {
                 synCtx.getServiceLog().error(msg, e);
             }
             if (!synCtx.getFaultStack().isEmpty()) {
-                log.warn("Executing fault handler due to exception encountered");
-                ((FaultHandler) synCtx.getFaultStack().pop()).handleFault(synCtx, e);
+                log.warn(LoggingUtils.getFormattedLog(synCtx, "Executing fault handler due to exception encountered"));
+                (synCtx.getFaultStack().pop()).handleFault(synCtx, e);
             } else {
-                log.warn("Exception encountered but no fault handler found - message dropped");
+                log.warn(LoggingUtils.getFormattedLog(synCtx,
+                                                      "Exception encountered but no fault handler found - message "
+                                                              + "dropped"));
             }
         }
         return true;

--- a/modules/core/src/main/java/org/apache/synapse/rest/API.java
+++ b/modules/core/src/main/java/org/apache/synapse/rest/API.java
@@ -48,6 +48,7 @@ import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
+import org.apache.synapse.util.logging.LoggingUtils;
 
 import java.util.*;
 
@@ -543,6 +544,10 @@ public class API extends AbstractRESTProcessor implements ManagedLifecycle, Aspe
         }
     }
 
+    private String getFormattedLog(String msg) {
+        return LoggingUtils.getFormattedLog(SynapseConstants.FAIL_SAFE_MODE_API, getName(), msg);
+    }
+
     public void destroy() {
         auditInfo("Destroying API: " + getName());
         for (Resource resource : resources.values()) {
@@ -578,12 +583,14 @@ public class API extends AbstractRESTProcessor implements ManagedLifecycle, Aspe
      * @param message the INFO level audit message
      */
     private void auditInfo(String message) {
-        log.info(message);
+
+        String formattedMsg = getFormattedLog(message);
+        log.info(formattedMsg);
         apiLog.info(message);
 
         //TODO - Implement 'trace' attribute support in API configuration.
         if (trace()) {
-            trace.info(message);
+            trace.info(formattedMsg);
         }
     }
 
@@ -592,15 +599,16 @@ public class API extends AbstractRESTProcessor implements ManagedLifecycle, Aspe
      * @param message the DEBUG level audit message
      */
     private void auditDebug(String message) {
-        if (log.isDebugEnabled()){
-            log.debug(message);
+
+        if (log.isDebugEnabled()) {
+            String formattedMsg = getFormattedLog(message);
+            log.debug(formattedMsg);
             apiLog.debug(message);
 
             //TODO - Implement 'trace' attribute support in API configuration.
             if (trace()) {
-               trace.debug(message);
+                trace.debug(formattedMsg);
             }
-
         }
 
     }

--- a/modules/core/src/main/java/org/apache/synapse/util/logging/LoggingUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/logging/LoggingUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.util.logging;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+
+/**
+ * Util class to get formatted logs for audit purposes.
+ */
+public class LoggingUtils {
+
+    private static final String OPEN_BRACKETS = "{";
+    private static final String CLOSE_BRACKETS = "}";
+
+    private LoggingUtils() {
+        // do nothing
+    }
+
+    public static String getFormattedLog(MessageContext synCtx, Object msg) {
+
+        Object artifactNameObject = synCtx.getProperty(SynapseConstants.ARTIFACT_NAME);
+        if (artifactNameObject != null) {
+            String artifactName = artifactNameObject.toString();
+            if (artifactName.startsWith(SynapseConstants.PROXY_SERVICE_TYPE)) {
+                return getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE,
+                                       artifactName.substring(SynapseConstants.PROXY_SERVICE_TYPE.length()), msg);
+            } else if (artifactName.startsWith(SynapseConstants.FAIL_SAFE_MODE_API)) {
+                return getFormattedLog(SynapseConstants.FAIL_SAFE_MODE_API,
+                                       artifactName.substring(SynapseConstants.FAIL_SAFE_MODE_API.length()), msg);
+            } else if (artifactName.startsWith(SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT)) {
+                return getFormattedLog(SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT, artifactName
+                        .substring(SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT.length()), msg);
+            }
+            return getFormattedString(artifactName, msg);
+        }
+        return msg.toString();
+    }
+
+    public static String getFormattedLog(String artifactType, Object artifactName, Object msg) {
+
+        String name = artifactName != null ? artifactName.toString() : "";
+        return getFormattedString(artifactType.concat(":").concat(name), msg);
+    }
+
+    private static String getFormattedString(String name, Object msg) {
+
+        String message = msg != null ? msg.toString() : "";
+        return OPEN_BRACKETS.concat(name).concat(CLOSE_BRACKETS).concat(" ").concat(message);
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/wso2/micro-integrator/issues/1647

Logs will be printed in following format.
```
[2020-06-09 16:48:50,221]  INFO {org.wso2.micro.integrator.server.extensions.PatchInstaller perform} - Patch changes detected  
[2020-06-09 16:48:54,034]  INFO {org.wso2.micro.integrator.server.util.PatchUtils checkMD5Checksum} - Patch verification started  
[2020-06-09 16:48:54,047]  INFO {org.wso2.micro.integrator.server.util.PatchUtils checkMD5Checksum} - Patch verification successfully completed  
[2020-06-09 16:48:56,945]  INFO {EventAdminConfigurationNotifier} - Logging configuration changed. (Event Admin service unavailable - no notification sent).
[2020-06-09 16:48:59,872]  INFO {ProxyService} - {proxy:TestProxy} Building Axis service for Proxy service
[2020-06-09 16:48:59,874]  INFO {ProxyService} - {proxy:TestProxy} Adding service to the Axis2 configuration
[2020-06-09 16:48:59,875]  INFO {ProxyService} - {proxy:TestProxy} Successfully created the Axis2 service for Proxy service
[2020-06-09 16:48:59,891]  INFO {Axis2SynapseEnvironment} - Continuation call is set to true
[2020-06-09 16:48:59,892]  INFO {API} - {api:TestAPI} Initializing API
[2020-06-09 16:48:59,975]  INFO {PassThroughListeningIOReactorManager} - Pass-through HTTP Listener started on 0.0.0.0:8290
[2020-06-09 16:48:59,977]  INFO {PassThroughListeningIOReactorManager} - Pass-through HTTPS Listener started on 0.0.0.0:8253
[2020-06-09 16:48:59,979]  INFO {StartupFinalizer} - WSO2 Micro Integrator started in 10.03 seconds
[2020-06-09 16:49:00,064]  INFO {PassThroughListeningIOReactorManager} - Pass-through EI_INTERNAL_HTTP_INBOUND_ENDPOINT Listener started on 0.0.0.0:9201



[2020-06-09 16:49:33,848]  INFO {LogMediator} - main sequence executed for call to non-existent = /orginal


[2020-06-09 16:49:48,617]  INFO {LogMediator} - {api:TestAPI} To: /original, MessageID: urn:uuid:88f03a27-d0c4-494d-97c1-0cb0b0b4dcb8, Direction: request, Payload: { "msg":"Hello", "services":[ "elec", "patrol" ], "test":"World." },{ "msg":"Hi", "services":[ "water" ], "test":"Sri Lanka." }
[2020-06-09 16:49:48,628]  INFO {TimeoutHandler} - This engine will expire all callbacks after GLOBAL_TIMEOUT: 120 seconds, irrespective of the timeout action, after the specified or optional timeout



[2020-06-09 16:49:56,063]  INFO {LogMediator} - {api:TestAPI} To: /original, MessageID: urn:uuid:1185e5a9-50ee-486f-9dc1-49f422d4b8c1, Direction: request, Payload: { "msg":"Hello", "services":[ "elec", "patrol" ], "test":"World." },{ "msg":"Hi", "services":[ "water" ], "test":"Sri Lanka." }




[2020-06-09 16:50:16,606]  INFO {LogMediator} - {proxy:TestProxy} To: /services/TestProxy, MessageID: urn:uuid:90ae4a37-bc89-49c9-b269-6ff49b5128e3, Direction: request, Payload: { "msg":"Hello", "services":[ "elec", "patrol" ], "test":"World." },{ "msg":"Hi", "services":[ "water" ], "test":"Sri Lanka." }



[2020-06-09 16:53:34,767]  INFO {LogMediator} - {proxy:TestProxy} To: /services/TestProxy, MessageID: urn:uuid:0a0bd072-33d1-41a0-93b4-d3f5d08f221d, Direction: request, Payload: { "msg":"Hello", ervices":[ "elec", "patrol" ], "test":"World." },{ "msg":"Hi", "services":[ "water" ], "test":"Sri Lanka." }


[2020-06-09 16:53:51,091]  INFO {LogMediator} - {proxy:TestProxy} To: /services/TestProxy, MessageID: urn:uuid:0a31e093-e027-4f20-9134-405c384a2231, Direction: request, Payload: {"asasa":asssssssss}
```