### PR TITLE
Added a new constant with the synapse property to decide Artifact storage

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -581,4 +581,6 @@ public final class SynapseConstants {
     // Common property for all artifacts
     public static final String ARTIFACT_NAME = "ARTIFACT_NAME";
 
+    public static final String ARTIFACT_STORAGE_ENABLING_SYNAPSE_PROPERTY = "synapse.artifacts.file.storage.enabled";
+
 }


### PR DESCRIPTION
This Synapse property will be read in https://github.com/wso2/carbon-mediation/pull/1422 and decide whether to save artifacts locally or not.

Used with the new feature: wso2/product-apim#8246