### PR TITLE
Added a new constant with the synapse property to decide Artifact storage

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -581,4 +581,8 @@ public final class SynapseConstants {
     // Common property for all artifacts
     public static final String ARTIFACT_NAME = "ARTIFACT_NAME";
 
+    //This synapse property will be read in the mediation layer to decide whether to save artifacts to a local
+    // directory or not. By default this property is set to true.
+    public static final String STORE_ARTIFACTS_LOCALLY = "synapse.artifacts.file.storage.enabled";
+
 }


### PR DESCRIPTION
This Synapse property will be read in wso2/carbon-mediation#1422 and decide whether to save artifacts locally or not.

Used with the new feature: wso2/product-apim#8246