### PR TITLE
Fix MI-1673-Add onerror sequence and mandatory param support

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorFactory.java
@@ -50,6 +50,8 @@ public abstract class AbstractMediatorFactory implements MediatorFactory {
     protected static final QName ATT_NAME    = new QName("name");
     protected static final QName ATT_VALUE   = new QName("value");
     protected static final QName ATT_DESCRIPTION   = new QName("description");
+    protected static final QName ATT_IS_MANDATORY = new QName("isMandatory");
+    protected static final QName ATT_DEFAULT_VALUE = new QName("defaultValue");
     protected static final QName ATT_XPATH   = new QName("xpath");
     protected static final QName ATT_REGEX   = new QName("regex");
     protected static final QName ATT_SEQUENCE = new QName("sequence");

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorFactory.java
@@ -75,10 +75,9 @@ public class InvokeMediatorFactory extends AbstractMediatorFactory {
         }
 
         OMAttribute errorHandlerAttr = elem.getAttribute(ATT_ONERROR);
-        if (errorHandlerAttr != null) {
-            if (StringUtils.isNotEmpty(errorHandlerAttr.getAttributeValue())) {
-                invoker.setErrorHandler(errorHandlerAttr.getAttributeValue());
-            }
+        if ((errorHandlerAttr != null)
+                && (StringUtils.isNotEmpty(errorHandlerAttr.getAttributeValue()))) {
+            invoker.setErrorHandler(errorHandlerAttr.getAttributeValue());
         }
 
         addAllCommentChildrenToList(elem, invoker.getCommentsList());

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorFactory.java
@@ -74,6 +74,13 @@ public class InvokeMediatorFactory extends AbstractMediatorFactory {
             throw new SynapseException(msg);
         }
 
+        OMAttribute errorHandlerAttr = elem.getAttribute(ATT_ONERROR);
+        if (errorHandlerAttr != null) {
+            if (StringUtils.isNotEmpty(errorHandlerAttr.getAttributeValue())) {
+                invoker.setErrorHandler(errorHandlerAttr.getAttributeValue());
+            }
+        }
+
         addAllCommentChildrenToList(elem, invoker.getCommentsList());
 
         return invoker;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorSerializer.java
@@ -72,6 +72,11 @@ public class InvokeMediatorSerializer extends AbstractMediatorSerializer{
             saveTracingState(invokeElem, mediator);
         }
 
+        if(mediator.getErrorHandler() != null) {
+            invokeElem.addAttribute(fac.createOMAttribute(
+                    "onError", nullNS, mediator.getErrorHandler()));
+        }
+
         serializeComments(invokeElem, mediator.getCommentsList());
 
         return invokeElem;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/InvokeMediatorSerializer.java
@@ -72,9 +72,9 @@ public class InvokeMediatorSerializer extends AbstractMediatorSerializer{
             saveTracingState(invokeElem, mediator);
         }
 
-        if(mediator.getErrorHandler() != null) {
-            invokeElem.addAttribute(fac.createOMAttribute(
-                    "onError", nullNS, mediator.getErrorHandler()));
+        if (mediator.getErrorHandler() != null) {
+            invokeElem.addAttribute(fac.createOMAttribute("onError",
+                    nullNS, mediator.getErrorHandler()));
         }
 
         serializeComments(invokeElem, mediator.getCommentsList());

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorFactory.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.mediators.template.TemplateMediator;
+import org.apache.synapse.mediators.template.TemplateParam;
 import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
@@ -76,18 +77,30 @@ public class TemplateMediatorFactory extends AbstractListMediatorFactory {
 
     private void initParameters(OMElement templateElem, TemplateMediator templateMediator) {
         Iterator subElements = templateElem.getChildElements();
-        Collection<String> paramNames = new ArrayList<String>();
+        Collection<TemplateParam> templateParams = new ArrayList<>();
         while (subElements.hasNext()) {
             OMElement child = (OMElement) subElements.next();
             if (child.getQName().equals(PARAMETER_Q)) {
+                String paramName = null;
+                boolean isParamMandatory = false;
+                Object defaultValue = null;
                 OMAttribute paramNameAttr = child.getAttribute(ATT_NAME);
                 if (paramNameAttr != null) {
-                    paramNames.add(paramNameAttr.getAttributeValue());
+                    paramName = paramNameAttr.getAttributeValue();
                 }
+                OMAttribute paramMandatoryAttr = child.getAttribute(ATT_IS_MANDATORY);
+                if (paramMandatoryAttr != null) {
+                    isParamMandatory = Boolean.parseBoolean(paramMandatoryAttr.getAttributeValue());
+                }
+                OMAttribute paramDefaultValueAttr = child.getAttribute(ATT_DEFAULT_VALUE);
+                if (paramDefaultValueAttr != null) {
+                    defaultValue = paramDefaultValueAttr.getAttributeValue();
+                }
+                templateParams.add(new TemplateParam(paramName, isParamMandatory, defaultValue));
 //                child.detach();
             }
         }
-        templateMediator.setParameters(paramNames);
+        templateMediator.setParameters(templateParams);
     }
 
     public QName getTagQName() {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/TemplateMediatorSerializer.java
@@ -21,6 +21,7 @@ package org.apache.synapse.config.xml;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.template.TemplateMediator;
+import org.apache.synapse.mediators.template.TemplateParam;
 import org.apache.synapse.util.CommentListUtil;
 
 import java.util.Collection;
@@ -61,13 +62,15 @@ public class TemplateMediatorSerializer extends AbstractListMediatorSerializer {
     }
 
     private void serializeParams(OMElement templateElem, TemplateMediator mediator) {
-        Collection<String> params = mediator.getParameters();
-        for (String param : params) {
-            if (param != null && !"".equals(param)) {
-                OMElement paramEl = fac.createOMElement("parameter", synNS);
-                paramEl.addAttribute(fac.createOMAttribute("name", nullNS, param));
-                templateElem.addChild(paramEl);
+        Collection<TemplateParam> params = mediator.getParameters();
+        for (TemplateParam param : params) {
+            OMElement paramEl = fac.createOMElement("parameter", synNS);
+            paramEl.addAttribute(fac.createOMAttribute("name", nullNS, param.getName()));
+            paramEl.addAttribute(fac.createOMAttribute("isMandatory", nullNS, Boolean.toString(param.isMandatory())));
+            if(param.getDefaultValue() != null) {
+                paramEl.addAttribute(fac.createOMAttribute("defaultValue", nullNS, param.getDefaultValue().toString()));
             }
+            templateElem.addChild(paramEl);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateMediator.java
@@ -38,7 +38,7 @@ import java.util.Stack;
  */
 public class TemplateMediator extends AbstractListMediator {
 
-    private Collection<String> paramNames;
+    private Collection<TemplateParam> templateParams;
 
     private String eipPatternName;
     private String fileName;
@@ -53,12 +53,12 @@ public class TemplateMediator extends AbstractListMediator {
 
     private String errorHandler = null;
 
-    public void setParameters(Collection<String> paramNames) {
-        this.paramNames = paramNames;
+    public void setParameters(Collection<TemplateParam> paramNames) {
+        this.templateParams = paramNames;
     }
 
-    public Collection<String> getParameters() {
-        return paramNames;
+    public Collection<TemplateParam> getParameters() {
+        return templateParams;
     }
 
     public void setName(String name) {
@@ -121,15 +121,16 @@ public class TemplateMediator extends AbstractListMediator {
         }
 
         if (synLog.isTraceOrDebugEnabled()) {
-            synLog.traceOrDebug("Start : EIP Sequence " + "paramNames : " + paramNames);
+            synLog.traceOrDebug("Start : EIP Sequence " + "templateParams : " + templateParams);
 
             if (synLog.isTraceTraceEnabled()) {
                 synLog.traceTrace("Message : " + synCtx.getEnvelope());
             }
         }
-        pushFuncContextTo(synCtx);
+
         boolean result = false;
         try {
+            pushFuncContextTo(synCtx);
             result = super.mediate(synCtx);
         } finally {
             if (result) {
@@ -155,7 +156,7 @@ public class TemplateMediator extends AbstractListMediator {
      * @param synCtx  Synapse Message context
      */
     private void pushFuncContextTo(MessageContext synCtx) {
-        TemplateContext funcContext = new TemplateContext(eipPatternName, paramNames);
+        TemplateContext funcContext = new TemplateContext(eipPatternName, templateParams);
         //process the raw parameters parsed in
         funcContext.setupParams(synCtx);
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateParam.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateParam.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.synapse.mediators.template;
+
+/**
+ * Class representing a template parameter
+ */
+public class TemplateParam {
+
+    private String name;
+
+    private boolean isMandatory;
+
+    private Object defaultValue;
+
+    public TemplateParam(String parameterName, boolean isMandatory, Object defaultValue) {
+        this.name = parameterName;
+        this.isMandatory = isMandatory;
+        this.defaultValue = defaultValue;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isMandatory() {
+        return isMandatory;
+    }
+
+    public void setMandatory(boolean mandatory) {
+        isMandatory = mandatory;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(Object defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/debug/DebugManagerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/debug/DebugManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.synapse.mediators.TestMediator;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.mediators.template.TemplateMediator;
+import org.apache.synapse.mediators.template.TemplateParam;
 
 import java.util.HashSet;
 
@@ -334,7 +335,7 @@ public class DebugManagerTest extends TestCase {
         temp.addChild(t2);
         temp.addChild(t3);
         temp.setName("test_sequence_template_5");
-        temp.setParameters(new HashSet<String>());
+        temp.setParameters(new HashSet<TemplateParam>());
         synConfig.addSequenceTemplate(temp.getName(), temp);
         String debug_command = "{\"command\":\"set\",\"command-argument\":\"skip\",\"mediation-component\":\"template\"," +
                 "\"template\":{\"template-key\":\"test_sequence_template_5\",\"mediator-position\": \"0\"}}";
@@ -389,7 +390,7 @@ public class DebugManagerTest extends TestCase {
         temp.addChild(t2);
         temp.addChild(t3);
         temp.setName("test_sequence_template_6");
-        temp.setParameters(new HashSet<String>());
+        temp.setParameters(new HashSet<TemplateParam>());
         synConfig.addSequenceTemplate(temp.getName(), temp);
         String debug_command = "{\"command\":\"set\",\"command-argument\":\"breakpoint\",\"mediation-component\":" +
                 "\"template\",\"template\":{\"template-key\":\"test_sequence_template_6\",\"mediator-position\": \"0\"}}";


### PR DESCRIPTION
## Purpose

Fix - https://github.com/wso2/micro-integrator/issues/1673

## Goals

Improvement 1 - mandatory parameters and default values
Improvement 2 - Error sequence for call-template

## Approach

Modify Invoke mediator and TemplateMediator. Modified serializers and Factory classes for new parameters.

## User stories

1. Template developer can specify mandatory params
2. Template developer can provide default values for optional params
3. Template caller can attach a specific sequence to handle errors thrown from calling the template. 

These will make easy to develop WSO2 EI connectors. 

## Documentation

Compile issue description to a document

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

This is an improvement to synapse lang. Existing exercises are not affected. Can provide new to capture new capabilities. 

## Marketing
Should prepare a doc for connector writing tips!


## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

Please refer the related issue

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK -8
 
## Learning
Refer sequence mediator