### PR TITLE
Prevent new thread being created whenever BlockingMessage Sender/Callout is initialized

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2ContextReferenceHolder.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2ContextReferenceHolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.synapse.core.axis2;
+
+import org.apache.axis2.context.ConfigurationContext;
+
+/**
+ * Singleton class to hold Axis2ConfigurationContext.
+ */
+public class Axis2ContextReferenceHolder {
+
+    private static final Axis2ContextReferenceHolder instance = new Axis2ContextReferenceHolder();
+    private ConfigurationContext axis2ConfigurationContext;
+
+    private Axis2ContextReferenceHolder() {
+
+    }
+
+    /**
+     * Get instance of Axis2ContextReferenceHolder.
+     *
+     * @return Axis2ContextReferenceHolder instance
+     */
+    public static Axis2ContextReferenceHolder getInstance() {
+        return instance;
+    }
+
+    /**
+     * Set Axis2ConfigurationContext.
+     *
+     * @param axis2ConfigurationContext context to set
+     */
+    public void setAxis2ConfigurationContext(ConfigurationContext axis2ConfigurationContext) {
+        this.axis2ConfigurationContext = axis2ConfigurationContext;
+    }
+
+    /**
+     * Get axis2 Configuration Context reference.
+     *
+     * @return ConfigurationContext
+     */
+    public ConfigurationContext getAxis2ConfigurationContext() {
+        return axis2ConfigurationContext;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -32,6 +32,7 @@ import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
 import org.apache.synapse.continuation.ContinuationStackManager;
 import org.apache.synapse.continuation.SeqContinuationState;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2ContextReferenceHolder;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.mediators.AbstractMediator;
@@ -313,9 +314,13 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
 
         if (blocking) {
             try {
-                configCtx = ConfigurationContextFactory.createConfigurationContextFromFileSystem(
-                        clientRepository != null ? clientRepository : DEFAULT_CLIENT_REPO,
-                        axis2xml != null ? axis2xml : DEFAULT_AXIS2_XML);
+                configCtx = Axis2ContextReferenceHolder.getInstance().getAxis2ConfigurationContext();
+                if (configCtx == null) {
+                    configCtx = ConfigurationContextFactory.createConfigurationContextFromFileSystem(
+                            clientRepository != null ? clientRepository : DEFAULT_CLIENT_REPO,
+                            axis2xml != null ? axis2xml : DEFAULT_AXIS2_XML);
+                    Axis2ContextReferenceHolder.getInstance().setAxis2ConfigurationContext(configCtx);
+                }
                 blockingMsgSender = new BlockingMsgSender();
                 blockingMsgSender.setConfigurationContext(configCtx);
                 blockingMsgSender.init();


### PR DESCRIPTION
## Purpose
When redeploying a service that has callout or call blocking mediator. Thread count increasing with each new configuration context. Because we create axis2ConfigurationContext whenever BlockingMessage Sender and callout mediator is initialized.

This PR fixes the issue by preventing axis2ConfigurationContext being created each time BlockingMessage Sender and callout mediator is initialized.

Fixes https://github.com/wso2/product-ei/issues/5149
