### PR TITLE
Fix duplicate artifact deployment issue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -26,17 +26,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
-import org.apache.synapse.SynapseHandler;
-import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.config.xml.MultiXMLConfigurationBuilder;
 import org.apache.synapse.config.xml.ProxyServiceFactory;
 import org.apache.synapse.config.xml.ProxyServiceSerializer;
 import org.apache.synapse.core.axis2.ProxyService;
-import org.apache.synapse.AbstractExtendedSynapseHandler;
+import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 
 import java.io.File;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Properties;
 
 /**
@@ -67,10 +63,8 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
             proxy.setArtifactContainerName(customLogContent);
             if (proxy != null) {
                 if (getSynapseConfiguration().getProxyService(proxy.getName()) != null) {
-                    log.warn("Hot deployment thread picked up an already deployed proxy - Ignoring");
-                    return proxy.getName();
+                    handleSynapseArtifactDeploymentError("ProxyService named : " + proxy.getName() + " already exists");
                 }
-
                 File proxyFile = new File(filePath);
                 proxy.setFileName(proxyFile.getName());
                 proxy.setFilePath(proxyFile.toURI().toURL());

--- a/modules/core/src/main/java/org/apache/synapse/deployers/SequenceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/SequenceDeployer.java
@@ -23,13 +23,13 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axis2.deployment.DeploymentException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.MediatorFactoryFinder;
 import org.apache.synapse.config.xml.MediatorSerializerFinder;
 import org.apache.synapse.config.xml.MultiXMLConfigurationBuilder;
 import org.apache.synapse.mediators.base.SequenceMediator;
+import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 
 import java.io.File;
 import java.util.Properties;
@@ -59,6 +59,9 @@ public class SequenceDeployer extends AbstractSynapseArtifactDeployer {
                     artifactConfig, properties);
             if (m instanceof SequenceMediator) {
                 SequenceMediator seq = (SequenceMediator) m;
+                if (getSynapseConfiguration().getDefinedSequences().get(seq.getName()) != null) {
+                    handleSynapseArtifactDeploymentError("Sequence named : " + seq.getName() + " already exists.");
+                }
                 seq.setArtifactContainerName(customLogContent);
                 seq.setFileName((new File(fileName)).getName());
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fixes https://github.com/wso2/micro-integrator/issues/1706

Currently when there is a duplicate artifact inside a capp for proxies it is getting simply ignored and for sequences it is getting overwritten. 