### PR TITLE
Fix issue in destroying mediator configurations upon re-deployment of proxy service

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -1470,4 +1470,22 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
     public void setCommentsList(List<String> commentsList) {
         this.commentsList = commentsList;
     }
+
+    /**
+     * This method will destroy sequences
+     */
+    public void destroy() {
+        if (log.isDebugEnabled()) {
+            log.debug("Destroying proxy service with name: " + name);
+        }
+        if (targetInLineInSequence != null && targetInLineInSequence.isInitialized()) {
+            targetInLineInSequence.destroy();
+        }
+        if (targetInLineOutSequence != null && targetInLineOutSequence.isInitialized()) {
+            targetInLineOutSequence.destroy();
+        }
+        if (targetInLineFaultSequence != null && targetInLineFaultSequence.isInitialized()) {
+            targetInLineFaultSequence.destroy();
+        }
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/deployers/APIDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/APIDeployer.java
@@ -153,6 +153,7 @@ public class APIDeployer extends AbstractSynapseArtifactDeployer {
                         unDeployTime);
 
                 log.info("API named '" + api.getName() + "' has been undeployed");
+                api.destroy();
             } else if (log.isDebugEnabled()) {
                 log.debug("API " + artifactName + " has already been undeployed");
             }

--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -159,6 +159,7 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                 }
                 ProxyService currentProxy = getSynapseConfiguration().getProxyService(existingArtifactName);
                 currentProxy.stop(getSynapseConfiguration());
+                currentProxy.destroy();
                 getSynapseConfiguration().removeProxyService(existingArtifactName);
                 if (!existingArtifactName.equals(proxy.getName())) {
                     log.info("ProxyService named " + existingArtifactName + " has been Undeployed");
@@ -210,6 +211,7 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                     log.debug("Stopping the ProxyService named : " + artifactName);
                 }
                 proxy.stop(getSynapseConfiguration());
+                proxy.destroy();
                 getSynapseConfiguration().removeProxyService(artifactName);
                 if (log.isDebugEnabled()) {
                     log.debug("ProxyService Undeployment of the proxy named : "

--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -116,6 +116,7 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                     return proxy.getName();
                 } catch (SynapseException e) {
                     getSynapseConfiguration().removeProxyService(proxy.getName());
+                    proxy.destroy();
                     throw e;
                 }
             } else {


### PR DESCRIPTION
## Purpose
> When we re-deploy a proxy service the existing mediator configurations are not destroyed. When we re-deploy an API we destroy the configuration in [1]. This PR fixes the issue by destroying the mediators (which implement **ManagedLifecycle** interface) upon re-deployment.

[1] https://github.com/wso2/wso2-synapse/blob/29597f5967e2d123e79dd487b2613f6bf59a887f/modules/core/src/main/java/org/apache/synapse/deployers/APIDeployer.java#L123

