### PR TITLE
[Observability] [OpenTracing] Expose isMediationFlowStatisticsEnabled property from RuntimeStatisticCollector

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -221,6 +221,15 @@ public abstract class RuntimeStatisticCollector {
     }
 
     /**
+     * Returns whether mediation flow statistics (Analytics profile) has been enabled.
+     *
+     * @return true if mediation flow statistics has been enabled.
+     */
+    public static boolean isMediationFlowStatisticsEnabled() {
+        return isMediationFlowStatisticsEnabled;
+    }
+
+    /**
      * Return whether collecting payloads is enabled.
      *
      * @return true if need to collect payloads.

--- a/pom.xml
+++ b/pom.xml
@@ -1380,7 +1380,7 @@
        <io.netty.version>4.1.34.Final</io.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <jaeger-client.version>0.32.0.wso2v2</jaeger-client.version>
+       <jaeger-client.version>0.32.0.wso2v3</jaeger-client.version>
        <apache.felix.scr.ds-annotations.version>1.2.4</apache.felix.scr.ds-annotations.version>
        <com.hierynomus.smbj.version>0.10.0.wso2v1</com.hierynomus.smbj.version>
        <com.hierynomus.asn1.version>0.4.0.wso2v1</com.hierynomus.asn1.version>


### PR DESCRIPTION
**NOTE: This PR should be merged only after merging https://github.com/wso2/orbit/pull/428 and doing a release**

## Purpose
> - The `isMediationFlowStatisticsEnabled` property of the `RuntimeStatisticCollector` class states whether analytics profile statistics has been enabled or not. This will be used to prevent searching for analytics nodes when only OpenTracing is enabled (See: https://github.com/wso2/micro-integrator/pull/1719).
> - Upgrade jaeger-client version to accommodate `javax.annotation` version as `[1.0.0,2.0.0)`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> - Stop finding analytics server when only OpenTracing is enabled: https://github.com/wso2/micro-integrator/pull/1719