### PR TITLE
Remove validation of ProxyServiceParameter values

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ProxyServiceFactory.java
@@ -363,7 +363,7 @@ public class ProxyServiceFactory {
                         if (prop.getText().trim() == null) {
                             resolvedParameter = null;
                         } else {
-                            resolvedParameter = ResolverFactory.getInstance().getResolver(prop.getText().trim()).resolve();
+                            resolvedParameter = prop.getText().trim();
                         }
                         proxy.addParameter(pname.getAttributeValue(), resolvedParameter);
                     }


### PR DESCRIPTION
## Purpose
Unlike the validation at runtime, in the integration studio, it is not needed to verify whether environment variables exist in the developer environment.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/701