### PR TITLE
Fix https://github.com/wso2/micro-integrator/issues/1739

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsProducer.java
@@ -75,6 +75,7 @@ public class JmsProducer implements MessageProducer {
         if (!checkConnection()) {
             logger.warn(getId() + ". Ignored MessageID : " + synCtx.getMessageID());
             store.setCachedProducer(null);
+            store.setProducer(null);
             return false;
         }
         StorableMessage message = MessageConverter.toStorableMessage(synCtx);


### PR DESCRIPTION

## Purpose
When the original store is down, the messages are moved to failover ms in the failover msmp scenario. But when again the original store is connected (broker) failover processor is unable to send to the original store since it uses the existing producer of the original store since it hasn't been assigned to null. To solve this by assigning null to store producer when the connection is not available.

## Goals
Fixes: https://github.com/wso2/micro-integrator/issues/1739
