### PR TITLE
Fix issue of performing connector operations during DB outage

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
@@ -504,7 +504,13 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
 
         if (entry.getType() == Entry.REMOTE_ENTRY) {
             if (registry != null) {
-                o = registry.getResource(entry, getProperties());
+                try {
+                    o = registry.getResource(entry, getProperties());
+                } catch (SynapseException synEx) {
+                    o = null;
+                    log.warn("Encountered an error while retrieving resources from registry : " + synEx.getMessage()
+                             + "\nTherefore fetching template from registry will be skipped.");
+                }
                 if (o != null && o instanceof TemplateMediator) {
                     localRegistry.put(key, entry);
                     return (TemplateMediator) o;


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-ei/issues/5158
If the user has not stored templates in the registry, stopping the mediation when an exception is thrown while checking the registry is not acceptable. This is fixed by logging the error and proceeding further to read templates from the synapse-libs during DB outage without throwing the exception. Furthermore, when there are no templates found in any of the locations, it will throw an error saying that this particular template cannot be found.
