### PR TITLE
Fix thread getting stuck in infinite while loop upon throwing an exception

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -676,7 +676,7 @@ public class ServerWorker implements Runnable {
         return null;
     }
 
-    protected MessageContext getRequestContext() {
+    public MessageContext getRequestContext() {
         return msgContext;
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -40,6 +40,7 @@ import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
+import org.apache.synapse.transport.passthru.ServerWorker;
 import org.apache.synapse.transport.passthru.TargetRequest;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 
@@ -478,7 +479,13 @@ public class RelayUtils {
      * @throws AxisFault AxisFault
      */
     public static void consumeAndDiscardMessage(MessageContext msgContext) throws AxisFault {
-        final Pipe pipe = (Pipe) msgContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);
+        // Get the request message context
+        MessageContext requestContext = msgContext;
+        Object outTransportInfo = msgContext.getProperty(Constants.OUT_TRANSPORT_INFO);
+        if (outTransportInfo instanceof ServerWorker) {
+            requestContext = ((ServerWorker) outTransportInfo).getRequestContext();
+        }
+        final Pipe pipe = (Pipe) requestContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);
         if (pipe != null) {
             try {
                 while (!pipe.isProducerCompleted() || pipe.isConsumeRequired()) {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-ei/issues/5125

After receiving a response for the request, when an IOException is thrown inside the write() method [1], the thread gets stuck in the infinite while loop in consumeAndDiscardMessage() method.
This happens only when we use clone or aggregate mediator and in JMS dual-channel scenario.
Because in the above scenarios the source pipe is removed from the message context during mediation [2] and then we create a new pipe (with name test) and send out the response [4]. In this test pipe we do not set producerCompleted to true. Hence, the thread gets stuck in the infinite while loop in consumeAndDiscardMessage() method.

This PR fixes the issue by getting the Pipe object from the request message context and consuming (we do not need to consume data from the response Pipe).

[1] https://github.com/wso2/wso2-synapse/blob/master/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java#L547
[2] https://github.com/wso2/wso2-synapse/blob/master/modules/core/src/main/java/org/apache/synapse/util/MessageHelper.java#L426
[3] https://github.com/wso2/wso2-synapse/blob/master/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java#L535