### PR TITLE
Fix Synapse handler chain called twice during an API invocation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/rest/RESTRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/rest/RESTRequestHandler.java
@@ -78,19 +78,12 @@ public class RESTRequestHandler {
         API defaultAPI = null;
         if (null != synCtx.getProperty(RESTConstants.IS_PROMETHEUS_ENGAGED)) {
             API api = (API) synCtx.getProperty(RESTConstants.PROCESSED_API);
-            identifyAPI(api, synCtx, defaultStrategyApiSet);
+            if (identifyAPI(api, synCtx, defaultStrategyApiSet)) {
+                return true;
+            }
         } else {
             for (API api : apiSet) {
-                identifyAPI(api, synCtx, defaultStrategyApiSet);
-            }
-
-            for (API api : defaultStrategyApiSet) {
-                api.setLogSetterValue();
-                if (api.canProcess(synCtx)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Located specific API: " + api.getName() + " for processing message");
-                    }
-                    apiProcess(synCtx, api);
+                if (identifyAPI(api, synCtx, defaultStrategyApiSet)) {
                     return true;
                 }
             }


### PR DESCRIPTION
## Purpose
In https://github.com/wso2/wso2-synapse/pull/1543, we have refactored and moved the existing logic inside identifyAPI() method. In the earlier logic, we return a boolean response in dispatchToAPI() method. But after refactoring we do not pass the return value of identifyAPI() method to dispatchToAPI() method. Hence the mediation flow continues after executing identifyAPI() method. Which is not the expected behaviour. This PR fixes the issue.

Fixes https://github.com/wso2/micro-integrator/issues/1839