### PR TITLE
Check jsonpath expression is root in Foreach mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ForEachMediator.java
@@ -154,8 +154,13 @@ public class ForEachMediator extends AbstractMediator implements ManagedLifecycl
                             element.toString(), axisFault, synCtx);
                 }
             }
-            JsonElement jsonPayloadElement = parsedJsonPayload
-                    .set(((SynapseJsonPath) expression).getJsonPath(), modifiedPayloadArray).json();
+            JsonElement jsonPayloadElement;
+            if (((SynapseJsonPath) expression).isWholeBody()){
+                jsonPayloadElement = modifiedPayloadArray;
+            } else {
+                jsonPayloadElement = parsedJsonPayload.set(((SynapseJsonPath) expression).getJsonPath(),
+                        modifiedPayloadArray).json();
+            }
             try {
                 JsonUtil.getNewJsonPayload(((Axis2MessageContext) synCtx).getAxis2MessageContext(),
                         jsonPayloadElement.toString(), true, true);

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -347,6 +347,15 @@ public class SynapseJsonPath extends SynapsePath {
     }
 
     /**
+     * Getter method for isWholeBody
+     *
+     * @return returns true if jsonPath expression is $ or $
+     */
+    public boolean isWholeBody() {
+        return isWholeBody;
+    }
+
+    /**
      * This method will return the boolean value of the jsonpath.
      *
      * @param synCtx message context


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The following foreach mediator configuration fails since the jsonpath expression $ is not handled properly. This PR will fix it. Resolves https://github.com/wso2/product-ei/issues/5186

```
<foreach id="foreach1" expression="json-eval($)">
                    <sequence>
                        <payloadFactory media-type="json">
                            <format>                  {"candidate" : $1}              </format>
                            <args>
                                <arg evaluator="json" expression="$"/>
                            </args>
                        </payloadFactory>
                    </sequence>
                </foreach>
```