### PR TITLE
Update cardinality of throttle servies

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceComponent.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceComponent.java
@@ -59,7 +59,7 @@ public class ThrottleServiceComponent {
 	@Reference(
 			name = "hazelcast.instance.service",
 			service = com.hazelcast.core.HazelcastInstance.class,
-			cardinality = ReferenceCardinality.OPTIONAL,
+			cardinality = ReferenceCardinality.MANDATORY,
 			policy = ReferencePolicy.DYNAMIC,
 			unbind = "unsetHazelcastInstance"
 	)


### PR DESCRIPTION
As the hazelcast service is not available in Micro Integrator and since the cardinality is optional, if this gets activated, there will be
class not found errors when shutting down the server.

Fixes https://github.com/wso2/micro-integrator/issues/1870
