### PR TITLE
[Jaeger Tracing] Fix NPE when injecting SpanContext into carrier

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/handling/span/JaegerSpanHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/handling/span/JaegerSpanHandler.java
@@ -156,7 +156,9 @@ public class JaegerSpanHandler implements OpenTracingSpanHandler {
             spanContext = span.context();
         }
         // Set tracing headers
-        tracer.inject(spanContext, Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(tracerSpecificCarrier));
+        if (spanContext != null) {
+            tracer.inject(spanContext, Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(tracerSpecificCarrier));
+        }
         // Set text map key value pairs as HTTP headers
         headersMap.putAll(tracerSpecificCarrier);
 


### PR DESCRIPTION
## Purpose
> In order to support end-to-end message tracing with Jaeger, Injecting span context into the carrier was introduced with PR https://github.com/wso2/wso2-synapse/pull/1551. Due to this change, an NPE is thrown as follows during the execution:
```
[2020-06-22 15:30:46,090] ERROR {PropagationRegistry$ExceptionCatchingInjectorDecorator} - Error when injecting SpanContext into carrier. Handling gracefully. java.lang.NullPointerException
```
This PR introduces a validation whether the spanContext is null or not before, injecting it.

## Goals
> $subject.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/wso2-synapse/pull/1551