### PR TITLE
Add property values to the Jaeger tracing

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
@@ -83,6 +83,8 @@ public class StatisticDataUnit extends BasicStatisticDataUnit {
 	 */
 	private String componentId;
 
+	private String propertyValue;
+
 	/**
 	 * HashCode of the reporting component.
 	 */
@@ -221,5 +223,13 @@ public class StatisticDataUnit extends BasicStatisticDataUnit {
 
 	public void setContinuationCall(boolean continuationCall) {
 		this.continuationCall = continuationCall;
+	}
+
+	public String getPropertyValue() {
+		return propertyValue;
+	}
+
+	public void setPropertyValue(String propertyValue) {
+		this.propertyValue = propertyValue;
 	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
@@ -103,6 +103,11 @@ public class StatisticsLog {
 	private String componentId;
 
 	/**
+	 * Value of the property which is in trace scope..
+	 */
+	private String propertyValue;
+
+	/**
 	 * HashCode of the reporting component.
 	 */
 	private Integer hashCode;
@@ -151,6 +156,7 @@ public class StatisticsLog {
 		this.transportPropertyMap = statisticDataUnit.getTransportPropertyMap();
 		this.componentType = statisticDataUnit.getComponentType();
 		this.hashCode = statisticDataUnit.getHashCode();
+		this.propertyValue = statisticDataUnit.getPropertyValue();
 		if (statisticDataUnit.getComponentId() == null) {
 			this.componentId = StatisticsConstants.HASH_CODE_NULL_COMPONENT;
 		} else {
@@ -348,5 +354,13 @@ public class StatisticsLog {
 
 	public void setComponentType(ComponentType componentType) {
 		this.componentType = componentType;
+	}
+
+	public String getPropertyValue() {
+		return propertyValue;
+	}
+
+	public void setPropertyValue(String propertyValue) {
+		this.propertyValue = propertyValue;
 	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/models/SpanWrapper.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/models/SpanWrapper.java
@@ -41,7 +41,12 @@ public class SpanWrapper {
     /**
      * Statistic data unit that has been collected during an open event, which carries data related to the span.
      */
-    private StatisticDataUnit statisticDataUnit;
+    private StatisticDataUnit openEventStatisticDataUnit;
+
+    /**
+     * Statistic data unit that has been collected during an closing event, which carries data related to the span.
+     */
+    private StatisticDataUnit closeEventStatisticDataUnit;
 
     /**
      * Parent span wrapper for this span wrapper.
@@ -82,10 +87,10 @@ public class SpanWrapper {
      */
     private Set<String> childStructuredElementIds;
 
-    public SpanWrapper(String id, Span span, StatisticDataUnit statisticDataUnit, SpanWrapper parentSpanWrapper) {
+    public SpanWrapper(String id, Span span, StatisticDataUnit openEventStatisticDataUnit, SpanWrapper parentSpanWrapper) {
         this.id = id;
         this.span = span;
-        this.statisticDataUnit = statisticDataUnit;
+        this.openEventStatisticDataUnit = openEventStatisticDataUnit;
         this.anonymousSequences = new LinkedHashMap<>();
         this.parentSpanWrapper = parentSpanWrapper;
         this.childStructuredElementIds = new HashSet<>();
@@ -97,11 +102,19 @@ public class SpanWrapper {
     }
 
     public StatisticDataUnit getStatisticDataUnit() {
-        return statisticDataUnit;
+        return openEventStatisticDataUnit;
     }
 
     public void setStatisticDataUnit(StatisticDataUnit statisticDataUnit) {
-        this.statisticDataUnit = statisticDataUnit;
+        this.openEventStatisticDataUnit = statisticDataUnit;
+    }
+
+    public StatisticDataUnit getCloseEventStatisticDataUnit() {
+        return closeEventStatisticDataUnit;
+    }
+
+    public void setCloseEventStatisticDataUnit(StatisticDataUnit closeEventStatisticDataUnit) {
+        this.closeEventStatisticDataUnit = closeEventStatisticDataUnit;
     }
 
     public void addAnonymousSequence(String id, SpanWrapper anonymousSequenceSpanWrapper) {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/stores/SpanStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/stores/SpanStore.java
@@ -120,7 +120,7 @@ public class SpanStore {
     public void finishSpan(SpanWrapper spanWrapper) {
         if (spanWrapper != null && spanWrapper.getSpan() != null) {
             if (spanWrapper.getStatisticDataUnit() != null) {
-                SpanTagger.setSpanTags(spanWrapper, spanWrapper.getStatisticDataUnit());
+                SpanTagger.setSpanTags(spanWrapper);
             }
             spanWrapper.getSpan().finish();
             activeSpanWrappers.remove(spanWrapper);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PropertyMediatorFactory.java
@@ -148,11 +148,12 @@ public class PropertyMediatorFactory extends AbstractMediatorFactory {
         if (scope != null) {
             String valueStr = scope.getAttributeValue();
             if (!XMLConfigConstants.SCOPE_AXIS2.equals(valueStr) &&
-                !XMLConfigConstants.SCOPE_TRANSPORT.equals(valueStr) &&
-                !XMLConfigConstants.SCOPE_OPERATION.equals(valueStr) &&
-                !XMLConfigConstants.SCOPE_DEFAULT.equals(valueStr) &&
-                !XMLConfigConstants.SCOPE_CLIENT.equals(valueStr) &&
-                !XMLConfigConstants.SCOPE_REGISTRY.equals(valueStr)) {
+                    !XMLConfigConstants.SCOPE_TRANSPORT.equals(valueStr) &&
+                    !XMLConfigConstants.SCOPE_OPERATION.equals(valueStr) &&
+                    !XMLConfigConstants.SCOPE_DEFAULT.equals(valueStr) &&
+                    !XMLConfigConstants.SCOPE_CLIENT.equals(valueStr) &&
+                    !XMLConfigConstants.SCOPE_REGISTRY.equals(valueStr) &&
+                    !XMLConfigConstants.SCOPE_TRACE.equals(valueStr)) {
 
                 String msg = "Only '" + XMLConfigConstants.SCOPE_AXIS2 +
                              "' or '" + XMLConfigConstants.SCOPE_TRANSPORT +
@@ -160,6 +161,7 @@ public class PropertyMediatorFactory extends AbstractMediatorFactory {
                              "' or '" + XMLConfigConstants.SCOPE_DEFAULT +
                              "' or '" + XMLConfigConstants.SCOPE_OPERATION +
                              "' or '" + XMLConfigConstants.SCOPE_REGISTRY +
+                             "' or '" + XMLConfigConstants.SCOPE_TRACE +
                              "' values are allowed for attribute scope for a property mediator" +
                              ", Unsupported scope " + valueStr;
                 log.error(msg);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
@@ -53,6 +53,8 @@ public class XMLConfigConstants {
     public static final String SCOPE_SYSTEM = "system";
     /** The scope name for environment variables */
     public static final String SCOPE_ENVIRONMENT = "env";
+    /** The scope name for properties used for tracing */
+    public static final String SCOPE_TRACE = "trace";
     public static final String KEY = "key";
     public static final String NAME = "name";
     public static final String LOCATION = "location";


### PR DESCRIPTION


## Purpose
In Jaeger Tracing span tags Before mediation and after mediation are the same. If we put a payload factory mediator and change the payload, in span tags of PayloadFactoryMediator it shows the same payload for beforePayload tag
and the afterPayload tag. Fix this issue by changing the design of close event handling.

Also Currently, in EI Jager tracing, we can only see the property name. This commit improves the code to add the property value as well.


## Goals
Fixes: https://github.com/wso2/product-ei/issues/5218
Fixes: https://github.com/wso2/product-ei/issues/5215

