### PR TITLE
Fix service chaining issue for GET request

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -383,16 +383,18 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                     }
                     out = (OutputStream) msgContext.getProperty(PassThroughConstants.BUILDER_OUTPUT_STREAM);
                     if (out != null) {
+                        //if HTTP MEHOD = GET we need to write down the HEADER information to the wire and need
+                        //to ignore any entity enclosed methods available.
+                        if (HTTPConstants.HTTP_METHOD_GET.equals(msgContext.getProperty(Constants.Configuration.HTTP_METHOD)) ||
+                            RelayUtils.isDeleteRequestWithoutPayload(msgContext)) {
+                            pipe.setSerializationCompleteWithoutData(true);
+                            return;
+                        }
                         overflowBlob.writeTo(out);
                         if (pipe.isStale) {
                             throw new IOException("Target Connection is stale..");
                         }
-                        //if HTTP MEHOD = GET we need to write down the HEADER information to the wire and need
-                        //to ignore any entity enclosed methods available.
-                        if (HTTPConstants.HTTP_METHOD_GET.equals(msgContext.getProperty(Constants.Configuration.HTTP_METHOD)) ||
-                                RelayUtils.isDeleteRequestWithoutPayload(msgContext)) {
-                            pipe.setSerializationCompleteWithoutData(true);
-                        } else if (messageSize == 0 &&
+                        if (messageSize == 0 &&
                                 (msgContext.getProperty(PassThroughConstants.FORCE_POST_PUT_NOBODY) != null &&
                                         (Boolean) msgContext.getProperty(PassThroughConstants.FORCE_POST_PUT_NOBODY))) {
                             pipe.setSerializationCompleteWithoutData(true);


### PR DESCRIPTION
Fix service chaining timeout issue that occurs since it tries to read and send a large response. First endpoint response with a large payload and second request try to send that large response over a GET request. Here Pipe waits in a thread but it never gets notify since message not consume. After the wait period it gets timeout and throw an exception. This PR avoids sending payload through a GET request.

Fix wso2/product-ei#5220