### PR TITLE
Fix preserve header for the response flow

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -586,42 +586,7 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
 
                 MessageFormatter formatter = MessageFormatterDecoratorFactory.createMessageFormatterDecorator(msgContext);
                 OMOutputFormat format = PassThroughTransportUtils.getOMOutputFormat(msgContext);
-
-                Object contentTypeInMsgCtx =
-                        msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE);
-                boolean isContentTypeSetFromMsgCtx = false;
-
-                // If ContentType header is set in the axis2 message context, use it.
-                if (contentTypeInMsgCtx != null) {
-                   String contentTypeValueInMsgCtx = contentTypeInMsgCtx.toString();
-                   // Skip multipart/related as it should be taken from formatter.
-                    if (!(contentTypeValueInMsgCtx.contains(
-                            PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED) ||
-                            contentTypeValueInMsgCtx.contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_FORM_DATA))) {
-
-                       // adding charset only if charset is not available,
-                       if (format != null && contentTypeValueInMsgCtx.indexOf(HTTPConstants.CHAR_SET_ENCODING) == -1 &&
-                           !"false".equals(msgContext.getProperty(PassThroughConstants.SET_CHARACTER_ENCODING))) {
-							String encoding = format.getCharSetEncoding();
-							if (encoding != null) {
-								sourceResponse.removeHeader(HTTP.CONTENT_TYPE);
-								contentTypeValueInMsgCtx += "; charset=" + encoding;
-							}
-						}
-
-                       sourceResponse.addHeader(HTTP.CONTENT_TYPE, contentTypeValueInMsgCtx);
-                       isContentTypeSetFromMsgCtx = true;
-                   }
-                }
-
-                // If ContentType is not set from msg context, get the formatter ContentType
-                if (!isContentTypeSetFromMsgCtx) {
-                    sourceResponse.removeHeader(HTTP.CONTENT_TYPE);
-                    sourceResponse.addHeader(HTTP.CONTENT_TYPE,
-                                             formatter.getContentType(
-                                                     msgContext, format, msgContext.getSoapAction()));
-                }
-
+                setContentType(msgContext, sourceResponse, formatter, format, sourceConfiguration);
                 try {
                     formatter.writeTo(msgContext, format, out, false);
                 } catch (RemoteException fault) {
@@ -719,5 +684,50 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
         }
     }
 
+    /**
+     * Set content type headers along with the charactor encoding if content type header is not preserved
+     * @param msgContext    message context
+     * @param sourceResponse    source response
+     * @param formatter response formatter
+     * @param format    response format
+     */
+    public void setContentType(MessageContext msgContext, SourceResponse sourceResponse, MessageFormatter formatter,
+                               OMOutputFormat format, SourceConfiguration sourceConfiguration) {
+        if (sourceConfiguration.isPreserveHttpHeader(HTTP.CONTENT_TYPE)) {
+            return;
+        }
+        Object contentTypeInMsgCtx =
+                msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE);
+        boolean isContentTypeSetFromMsgCtx = false;
 
+        // If ContentType header is set in the axis2 message context, use it.
+        if (contentTypeInMsgCtx != null) {
+            String contentTypeValueInMsgCtx = contentTypeInMsgCtx.toString();
+            // Skip multipart/related as it should be taken from formatter.
+            if (!(contentTypeValueInMsgCtx.contains(
+                    PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED) ||
+                  contentTypeValueInMsgCtx.contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_FORM_DATA))) {
+
+                // adding charset only if charset is not available,
+                if (format != null && contentTypeValueInMsgCtx.indexOf(HTTPConstants.CHAR_SET_ENCODING) == -1 &&
+                    !"false".equals(msgContext.getProperty(PassThroughConstants.SET_CHARACTER_ENCODING))) {
+                    String encoding = format.getCharSetEncoding();
+                    if (encoding != null) {
+                        contentTypeValueInMsgCtx += "; charset=" + encoding;
+                    }
+                }
+                sourceResponse.removeHeader(HTTP.CONTENT_TYPE);
+                sourceResponse.addHeader(HTTP.CONTENT_TYPE, contentTypeValueInMsgCtx);
+                isContentTypeSetFromMsgCtx = true;
+            }
+        }
+
+        // If ContentType is not set from msg context, get the formatter ContentType
+        if (!isContentTypeSetFromMsgCtx) {
+            sourceResponse.removeHeader(HTTP.CONTENT_TYPE);
+            sourceResponse.addHeader(HTTP.CONTENT_TYPE,
+                                     formatter.getContentType(
+                                             msgContext, format, msgContext.getSoapAction()));
+        }
+    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -32,6 +32,10 @@ import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
 import org.apache.synapse.transport.passthru.util.BufferFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * This class has common configurations for both sender and receiver.
  */
@@ -54,6 +58,14 @@ public abstract class BaseConfiguration {
     protected IOReactorConfig ioReactorConfig = null;
 
     protected BufferFactory bufferFactory = null;
+
+    /** Weather User-Agent header coming from client should be preserved */
+    protected boolean preserveUserAgentHeader = false;
+    /** Weather Server header coming from server should be preserved */
+    protected boolean preserveServerHeader = true;
+    /** Http headers which should be preserved */
+    protected List<String> preserveHttpHeaders;
+
 
     private PassThroughTransportMetricsCollector metrics = null;
 
@@ -197,5 +209,47 @@ public abstract class BaseConfiguration {
         }
         connectionTimeout = conf.getIntProperty(HttpConnectionParams.CONNECTION_TIMEOUT, getSocketTimeout() / 2);
         return connectionTimeout;
+    }
+
+    /**
+     * Check preserving status of the given http header name
+     *
+     * @param headerName http header name which need to check preserving status
+     * @return preserving status of the given http header
+     */
+    public boolean isPreserveHttpHeader(String headerName) {
+
+        if (preserveHttpHeaders == null || preserveHttpHeaders.isEmpty() || headerName == null) {
+            return false;
+        }
+        return preserveHttpHeaders.contains(headerName.toUpperCase());
+    }
+
+    public List<String> getPreserveHttpHeaders() {
+        return preserveHttpHeaders;
+    }
+
+    /**
+     * Populate preserve http headers from comma separate string
+     *
+     * @param preserveHeaders Comma separated preserve enable http headers
+     */
+    protected void populatePreserveHttpHeaders(String preserveHeaders) {
+
+        preserveHttpHeaders = new ArrayList<String>();
+        if (preserveHeaders != null && !preserveHeaders.isEmpty()) {
+            String[] presHeaders = preserveHeaders.trim().toUpperCase().split(",");
+            if (presHeaders != null && presHeaders.length > 0) {
+                preserveHttpHeaders.addAll(Arrays.asList(presHeaders));
+            }
+        }
+
+        if (preserveServerHeader && !preserveHttpHeaders.contains(HTTP.SERVER_HEADER.toUpperCase())) {
+            preserveHttpHeaders.add(HTTP.SERVER_HEADER.toUpperCase());
+        }
+
+        if (preserveUserAgentHeader && !preserveHttpHeaders.contains(HTTP.USER_AGENT.toUpperCase())) {
+            preserveHttpHeaders.add(HTTP.USER_AGENT.toUpperCase());
+        }
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -73,6 +73,11 @@ public interface PassThroughConfigPNames {
     /**
      * Defines whether ESB needs to preserve the original Http header.
      */
+    public String HTTP_RESPONSE_HEADERS_PRESERVE = "http.response.headers.preserve";
+
+    /**
+     * Defines whether ESB needs to preserve the original Http header.
+     */
     public String HTTP_HEADERS_PRESERVE = "http.headers.preserve";
 
     /**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -144,6 +144,10 @@ public class PassThroughConfiguration {
         return getStringProperty(PassThroughConfigPNames.HTTP_HEADERS_PRESERVE, "");
     }
 
+    public String getResponsePreseveHttpHeaders() {
+        return getStringProperty(PassThroughConfigPNames.HTTP_RESPONSE_HEADERS_PRESERVE, "");
+    }
+
     public int getConnectionIdleTime() {
 
         int idleTime;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/SourceConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/SourceConfiguration.java
@@ -136,7 +136,8 @@ public class SourceConfiguration extends BaseConfiguration {
             if (httpGetRequestProcessor == null) {
                 handleException("Cannot create HttpGetRequestProcessor");
             }
-        } 
+        }
+        populatePreserveHttpHeaders(conf.getResponsePreseveHttpHeaders());
     }
 
     public HttpParams getHttpParams() {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/TargetConfiguration.java
@@ -23,7 +23,6 @@ import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpProcessor;
 import org.apache.http.protocol.ImmutableHttpProcessor;
 import org.apache.http.protocol.RequestConnControl;
@@ -35,10 +34,6 @@ import org.apache.synapse.transport.http.conn.ProxyAuthenticator;
 import org.apache.synapse.transport.passthru.connections.TargetConnections;
 import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * This class stores configuration specific to HTTP Connectors (Senders)
  */
@@ -49,13 +44,6 @@ public class TargetConfiguration extends BaseConfiguration {
     private ProxyAuthenticator proxyAuthenticator = null;
     
     private int maxConnections = Integer.MAX_VALUE;
-
-    /** Weather User-Agent header coming from client should be preserved */
-    private boolean preserveUserAgentHeader = false;
-    /** Weather Server header coming from server should be preserved */
-    private boolean preserveServerHeader = true;
-    /** Http headers which should be preserved */
-    private List<String> preserveHttpHeaders;
 
     private ConnectionTimeoutConfiguration connectionTimeoutConfiguration;
     
@@ -117,48 +105,6 @@ public class TargetConfiguration extends BaseConfiguration {
 
     public void setConnections(TargetConnections connections) {
         this.connections = connections;
-    }
-
-    /**
-     * Check preserving status of the given http header name
-     *
-     * @param headerName http header name which need to check preserving status
-     * @return preserving status of the given http header
-     */
-    public boolean isPreserveHttpHeader(String headerName) {
-
-        if (preserveHttpHeaders == null || preserveHttpHeaders.isEmpty() || headerName == null) {
-            return false;
-        }
-        return preserveHttpHeaders.contains(headerName.toUpperCase());
-    }
-
-    public List<String> getPreserveHttpHeaders() {
-        return preserveHttpHeaders;
-    }
-
-    /**
-     * Populate preserve http headers from comma separate string
-     *
-     * @param preserveHeaders Comma separated preserve enable http headers
-     */
-    private void populatePreserveHttpHeaders(String preserveHeaders) {
-
-        preserveHttpHeaders = new ArrayList<String>();
-        if (preserveHeaders != null && !preserveHeaders.isEmpty()) {
-            String[] presHeaders = preserveHeaders.trim().toUpperCase().split(",");
-            if (presHeaders != null && presHeaders.length > 0) {
-                preserveHttpHeaders.addAll(Arrays.asList(presHeaders));
-            }
-        }
-
-        if (preserveServerHeader && !preserveHttpHeaders.contains(HTTP.SERVER_HEADER.toUpperCase())) {
-            preserveHttpHeaders.add(HTTP.SERVER_HEADER.toUpperCase());
-        }
-
-        if (preserveUserAgentHeader && !preserveHttpHeaders.contains(HTTP.USER_AGENT.toUpperCase())) {
-            preserveHttpHeaders.add(HTTP.USER_AGENT.toUpperCase());
-        }
     }
 
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
@@ -66,7 +66,8 @@ public class SourceResponseFactory {
         boolean forceContentLength = msgContext.isPropertyTrue(NhttpConstants.FORCE_HTTP_CONTENT_LENGTH);
 	    boolean forceContentLengthCopy = msgContext.isPropertyTrue(PassThroughConstants.COPY_CONTENT_LENGTH_FROM_INCOMING);
 	    
-	    if (forceContentLength && forceContentLengthCopy && msgContext.getProperty(PassThroughConstants.ORGINAL_CONTEN_LENGTH) != null) {
+	    if (forceContentLength && forceContentLengthCopy && msgContext.getProperty(PassThroughConstants.ORGINAL_CONTEN_LENGTH) != null
+                && !sourceConfiguration.isPreserveHttpHeader(HTTP.CONTENT_LEN)) {
 	    	 sourceResponse.addHeader(HTTP.CONTENT_LEN, (String)msgContext.getProperty(PassThroughConstants.ORGINAL_CONTEN_LENGTH));
 		}
 
@@ -74,18 +75,21 @@ public class SourceResponseFactory {
         // body content length cannot be calculated inside synapse. Hence content length of the backend response is
         // set to sourceResponse.
         if (sourceRequest != null && PassThroughConstants.HTTP_HEAD.equalsIgnoreCase(sourceRequest.getRequest().getRequestLine().getMethod()) &&
-            msgContext.getProperty(PassThroughConstants.ORGINAL_CONTEN_LENGTH) != null) {
+            msgContext.getProperty(PassThroughConstants.ORGINAL_CONTEN_LENGTH) != null
+                && !sourceConfiguration.isPreserveHttpHeader(PassThroughConstants.ORGINAL_CONTEN_LENGTH)) {
             sourceResponse.addHeader(PassThroughConstants.ORGINAL_CONTEN_LENGTH, (String) msgContext.getProperty
                     (PassThroughConstants.ORGINAL_CONTEN_LENGTH));
         }
 
         if (transportHeaders != null && msgContext.getProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE) != null) {
             if (msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE) != null
-                    && msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE).toString().contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED)) {
+                    && msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE).toString().contains(PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED)
+                    && !sourceConfiguration.isPreserveHttpHeader(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE)) {
                 transportHeaders.put(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, PassThroughConstants.CONTENT_TYPE_MULTIPART_RELATED);
             } else {
                 Pipe pipe = (Pipe) msgContext.getProperty(PassThroughConstants.PASS_THROUGH_PIPE);
-                if (pipe != null && !Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED))) {
+                if (pipe != null && !Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED))
+                        && !sourceConfiguration.isPreserveHttpHeader(HTTP.CONTENT_TYPE)) {
                     transportHeaders.put(HTTP.CONTENT_TYPE, msgContext.getProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE));
                 }
             }
@@ -100,7 +104,8 @@ public class SourceResponseFactory {
         		 transportHeaders = new HashMap();
             	 MessageFormatter messageFormatter =
                      MessageFormatterDecoratorFactory.createMessageFormatterDecorator(msgContext);
-            	 if(msgContext.getProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE) == null){
+            	 if(msgContext.getProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE) == null
+                         && !sourceConfiguration.isPreserveHttpHeader(HTTP.CONTENT_TYPE)){
             	    transportHeaders.put(HTTP.CONTENT_TYPE, messageFormatter.getContentType(msgContext, format, msgContext.getSoapAction()));
             	 }
             	 addResponseHeader(sourceResponse, transportHeaders);


### PR DESCRIPTION
Fix preserve the header for the response flow as well. Currently, it supports only the request flow. This will support it for the response flow as well. A list of header can be specified in "http.headers.preserve" property in passthru-http.properties file with comma-separated and ignore cases.