### PR TITLE
Acquire lock after the rawSerializationComplete

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -595,11 +595,12 @@ public class Pipe {
         }
 
         private void flushContent() throws IOException {
-            lock.lock();
 
             if(rawSerializationComplete){
                 return;
             }
+
+            lock.lock();
 
             try {
                 try {


### PR DESCRIPTION
## Purpose
>Acquire lock after the rawSerializationComplete check. Previously, we
just return without releasing the lock.
Fixes wso2/product-ei/issues/5243