### PR TITLE
Fix https://github.com/wso2/product-ei/issues/5256

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
@@ -159,7 +159,7 @@ public interface SynapseEnvironment {
      * Get all Xpath Extension objects for Function contexts
      * @return Map containing xpath extension objects
      */
-    public Map<QName, SynapseXpathFunctionContextProvider> getXpathFunctionExtensions();
+    public Map<String, SynapseXpathFunctionContextProvider> getXpathFunctionExtensions();
 
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -105,8 +105,8 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     private ServerContextInformation contextInformation;
 
     /** Map containing Xpath Function Context Extensions */
-    Map<QName, SynapseXpathFunctionContextProvider> xpathFunctionExtensions =
-            new HashMap<QName, SynapseXpathFunctionContextProvider>();
+    Map<String, SynapseXpathFunctionContextProvider> xpathFunctionExtensions =
+            new HashMap<String, SynapseXpathFunctionContextProvider>();
 
     /** Map containing Xpath Variable Context Extensions */
     Map<QName, SynapseXpathVariableResolver> xpathVariableExtensions =
@@ -716,7 +716,7 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
      * Returns all declared xpath Function Extensions
      * @return Hash Map Containing Function Extensions with supported QName keys
      */
-    public Map<QName, SynapseXpathFunctionContextProvider> getXpathFunctionExtensions() {
+    public Map<String, SynapseXpathFunctionContextProvider> getXpathFunctionExtensions() {
         return xpathFunctionExtensions;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/ext/SynapseXpathFunctionContextProvider.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/ext/SynapseXpathFunctionContextProvider.java
@@ -50,8 +50,8 @@ public interface SynapseXpathFunctionContextProvider {
 
     /**
      * Should Implement this API to return supported custom expression
-     * @return This should return the supported QName (localname + prefix + namespace URI combination ) for
+     * @return This should return the supported qualified name (localname + prefix + namespace URI combination ) for
      * this extension
      */
-     public QName getResolvingQName();
+     public String getResolvingQName();
 }

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/ext/XpathExtensionUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/ext/XpathExtensionUtil.java
@@ -120,7 +120,7 @@ public class XpathExtensionUtil {
             Map<String, SynapseXpathFunctionContextProvider> extensions =
                     environment.getXpathFunctionExtensions();
             SynapseXpathFunctionContextProvider functionContextProvider =
-                    getMatchingExtensionContextProvider(extensions, namespaceURI, prefix, localName);
+                    getMatchingExtensionProvider(extensions, prefix, localName);
             if (functionContextProvider != null) {
                 return initAndReturnXpathFunction(functionContextProvider, ctxt);
             }
@@ -191,21 +191,17 @@ public class XpathExtensionUtil {
     }
 
     /**
-     * returns the matching Extension provider for a given QName/namespaceURI+prefix+localName
+     * returns the matching Extension provider for a given prefix+localName
      * combination
      *
      * @param extensionMap registered extension Map for the corresponding extension provider
-     * @param namespaceURI binding namespace in xpath expression
      * @param prefix       binding prefix string in xpath expression
      * @param localName    binding localname string in xpath expression
      * @return matching Extension provider. returns null if no extension is found for the given
-     *         combination
+     * combination
      */
-    private static SynapseXpathFunctionContextProvider getMatchingExtensionContextProvider(
-            Map<String, SynapseXpathFunctionContextProvider> extensionMap,
-            String namespaceURI,
-            String prefix, String localName) {
-
+    private static SynapseXpathFunctionContextProvider getMatchingExtensionProvider(
+            Map<String, SynapseXpathFunctionContextProvider> extensionMap, String prefix, String localName) {
         String subject;
         if (localName != null && prefix != null) {
             subject = prefix + localName;
@@ -215,7 +211,6 @@ public class XpathExtensionUtil {
             //can't resolve xpath extensions - invalid combination
             return null;
         }
-
         Set<String> qNames = extensionMap.keySet();
         for (String qName : qNames) {
             //check for a match for the given combination for QName registered
@@ -225,7 +220,6 @@ public class XpathExtensionUtil {
         }
         //no match found
         return null;
-
     }
 
     /**


### PR DESCRIPTION
## Purpose
This issue happens since function providers are registered with Qnames and since Qnames do not consider prefix in equals or hashcode functions the HashiCorp and SecVault function provides were registered under the same Qname. So change function provider registration to avoid this.

Fixes: https://github.com/wso2/product-ei/issues/5256