### PR TITLE
Add environment support for cron expression

### DIFF
--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskDescriptionFactory.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskDescriptionFactory.java
@@ -166,7 +166,8 @@ public class TaskDescriptionFactory {
                     handleException("Trigger syntax error : " +
                             "both cron and simple trigger attributes are present");
                 } else if (expr != null && expr.getAttributeValue() != null) {
-                    taskDescription.setCronExpression(expr.getAttributeValue());
+                    taskDescription.setCronExpression(ResolverFactory.getInstance().
+                            getResolver(expr.getAttributeValue()).resolve());
                 }
 
             } else {


### PR DESCRIPTION

Add support to read environmental variables for corn jobs in scheduled tasks. An example of task implementation as follows.
```
<?xml version="1.0" encoding="UTF-8"?>
<task xmlns="http://ws.apache.org/ns/synapse"
      name="TestTask"
      class="org.apache.synapse.startup.tasks.MessageInjector"
      group="synapse.simple.quartz">
   <trigger cron="$SYSTEM:cronJob_VAR"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks" name="message">
      <message xmlns="">Calling the sequence</message>
   </property>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks"
             name="sequenceName"
             value="testSequence"/>
   <property xmlns:task="http://www.wso2.org/products/wso2commons/tasks"
             name="injectTo"
             value="sequence"/>
</task>
```
Fix https://github.com/wso2/product-ei/issues/5258