### PR TITLE
Support renaming the key name in json payloads

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
@@ -55,6 +55,7 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
     private static final QName ATT_TYPE = new QName("type");
     private static final QName ATT_CLONE = new QName("clone");
     private static final QName ATT_ACTION = new QName("action");
+    private static final QName ATT_KEY = new QName("key");
 
     public static final QName SOURCE_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "source");
     public static final QName TARGET_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "target");
@@ -64,6 +65,7 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
     public static final String ENVELOPE = "envelope";
     public static final String BODY = "body";
     public static final String INLINE = "inline";
+    public static final String KEY = "key";
 
     @Override
     protected Mediator createSpecificMediator(OMElement elem, Properties properties) {
@@ -260,6 +262,20 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
             } else {
                 handleException("xpath attribute is required for CUSTOM type");
             }
+        } else if (target.getTargetType() == EnrichMediator.KEY) {
+            OMAttribute xpathAttr = sourceEle.getAttribute(ATT_XPATH);
+            if (xpathAttr != null && xpathAttr.getAttributeValue() != null) {
+                try {
+                    target.setXpath(SynapsePathFactory.getSynapsePath(sourceEle, ATT_XPATH));
+                } catch (JaxenException e) {
+                    handleException("Invalid XPath expression: " + xpathAttr);
+                }
+                if (!target.getAction().equals(Target.ACTION_REPLACE)) {
+                    handleException("Only the replace action is supported for the target type 'key'.");
+                }
+            } else {
+                handleException("Xpath must be defined for the target type 'key'.");
+            }
         }
     }
 
@@ -274,6 +290,8 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
             return EnrichMediator.CUSTOM;
         } else if (type.equals(INLINE)) {
             return EnrichMediator.INLINE;
+        } else if (type.equals(KEY)) {
+            return EnrichMediator.KEY;
         }
         return -1;
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
@@ -83,6 +83,8 @@ public class EnrichMediator extends AbstractMediator {
 
     public static final int INLINE = 4;
 
+    public static final int KEY = 5;
+
     private Source source = null;
 
     private Target target = null;
@@ -206,6 +208,26 @@ public class EnrichMediator extends AbstractMediator {
                     sourceNode = source.evaluateJson(synCtx, synLog, sourcePropertyJson);
                     if (sourceNode == null) {
                         handleException("Failed to get the source for Enriching : ", synCtx);
+                    } else if (target.getTargetType() == KEY) {
+                        try {
+                            if (sourceNode instanceof JsonPrimitive) {
+                                String jsonPathString = target.getXpath().toString();
+                                // removing "json-eval(" and extract only the expression
+                                jsonPathString = jsonPathString.substring(10, jsonPathString.length() - 1);
+                                // json-eval expression will contain the key name as the last token in the string
+                                // e.g.: $.user.name where name is the key name
+                                // and $.user is the json path to locate the key.
+                                int lastIndex = jsonPathString.lastIndexOf(".");
+                                String jsonPath = jsonPathString.substring(0, lastIndex);
+                                String keyName = jsonPathString.substring(lastIndex + 1);
+                                target.renameKey(synCtx, jsonPath, keyName, ((JsonPrimitive)sourceNode).getAsString());
+                            } else {
+                                handleException("Failed to get the new key name from source for Enriching. " +
+                                        "Key name must be a string.", synCtx);
+                            }
+                        } catch (IOException e) {
+                            handleException("Failed to rename the key.", e, synCtx);
+                        }
                     } else {
                         target.insertJson(synCtx, sourceNode, synLog);
                     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
@@ -498,6 +498,25 @@ public class Target {
     }
 
     /**
+     * Renames a json key name at the specified json path with a new key name
+     *
+     * @param synapseContext Current message context
+     * @param jsonPath       The path to locate the key. Should be resolved to a map or an array including map items.
+     * @param keyName        Current name of the key
+     * @param newKeyName     New name of the key
+     * @throws IOException if failed to set the new json payload
+     */
+    public void renameKey(MessageContext synapseContext, String jsonPath, String keyName, String newKeyName)
+            throws IOException {
+
+        org.apache.axis2.context.MessageContext axis2MessageCtx =
+                ((Axis2MessageContext) synapseContext).getAxis2MessageContext();
+        String payload = JsonUtil.jsonPayloadToString(((Axis2MessageContext) synapseContext).getAxis2MessageContext());
+        DocumentContext doc = JsonPath.parse(payload).renameKey(jsonPath, keyName, newKeyName);
+        JsonUtil.getNewJsonPayload(axis2MessageCtx, doc.jsonString(), true, true);
+    }
+
+    /**
      * Set the enriched JSON result to body.
      * @param synapseContext Current message context.
      * @param synapseJsonPath   SynapseJsonPath instance of the target.


### PR DESCRIPTION
## Purpose
> Introduces the support to rename key names in JSON payloads.

## Approach

- The new key value must be specified as a string in the source.

Supported types for source are **inline, property and custom**.

- Target should contain the xpath to locate the key in the below format.

Consider the following payload.

```
{
	“user”: {
		“name”: “Kevin”,
		“age”: 26
         }
}
```

If you want to rename the ‘name’ attribute to ‘firstName’ the xpath expression should be json-eval(‘$.user.name’)

- Target type should be **key** and target action should be **replace**.

E.g.: xml
```
<enrich>
      <source clone="true" type="inline"> firstName </source>
      <target action="replace" type="key" xpath="json-eval($.user.name)"/>
</enrich>

```