### PR TITLE
Refactor checkXMLVersion in PayloadFactory to improve performance

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -36,12 +36,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.Value;
 import org.apache.synapse.util.AXIOMUtils;
+import org.apache.synapse.util.PayloadHelper;
 import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.w3c.dom.Document;
@@ -50,7 +52,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -98,10 +99,17 @@ public class PayloadFactoryMediator extends AbstractMediator {
     private static Pattern validJsonNumber = Pattern.compile("^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$");
 
     private static final Log log = LogFactory.getLog(PayloadFactoryMediator.class);
+    private DocumentBuilder documentBuilder = null;
 
     public PayloadFactoryMediator() {
         //ignore DTDs for XML Input
         inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+
+        try {
+            this.documentBuilder = PayloadHelper.createSimpleDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new SynapseException("Error creating Simple Document Builder", e);
+        }
     }
 
     /**
@@ -537,6 +545,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
         HashMap<String, ArgumentDetails>[] argValues = new HashMap[pathArgumentList.size()];
         HashMap<String, ArgumentDetails> valueMap;
         String value = "";
+        String xmlVersion = null;
         for (int i = 0; i < pathArgumentList.size(); ++i) {       /*ToDo use foreach*/
             Argument arg = pathArgumentList.get(i);
             ArgumentDetails details = new ArgumentDetails();
@@ -544,7 +553,10 @@ public class PayloadFactoryMediator extends AbstractMediator {
                 value = arg.getValue();
                 details.setXml(isXML(value));
                 if (!details.isXml()) {
-                    value = escapeXMLEnvelope(synCtx, value);
+                    if (xmlVersion == null) {
+                        xmlVersion = checkXMLVersion(synCtx);
+                    }
+                    value = escapeXMLEnvelope(xmlVersion, value);
                 }
                 value = Matcher.quoteReplacement(value);
             } else if (arg.getExpression() != null) {
@@ -555,7 +567,10 @@ public class PayloadFactoryMediator extends AbstractMediator {
                     // of the payload is XML.
                     details.setXml(isXML(value));
                     if (!details.isXml() && XML_TYPE.equals(getType()) && !isJson(value.trim(), arg.getExpression())) {
-                        value = escapeXMLEnvelope(synCtx, value);
+                        if (xmlVersion == null) {
+                            xmlVersion = checkXMLVersion(synCtx);
+                        }
+                        value = escapeXMLEnvelope(xmlVersion, value);
                     }
                     value = Matcher.quoteReplacement(value);
                 } else {
@@ -698,44 +713,36 @@ public class PayloadFactoryMediator extends AbstractMediator {
      *
      * @param msgCtx Message Context
      * @return xmlVersion in XML Declaration
-     * @throws ParserConfigurationException failure in building message envelope document
-     * @throws IOException Error reading message envelope
-     * @throws SAXException Error parsing message envelope
      */
-    private String checkXMLVersion(MessageContext msgCtx) throws IOException, SAXException, ParserConfigurationException {
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        InputSource inputSource = new InputSource(new StringReader(msgCtx.getEnvelope().toString()));
-        Document document = documentBuilder.parse(inputSource);
-        return document.getXmlVersion();
+    private String checkXMLVersion(MessageContext msgCtx) {
+        try {
+            InputSource inputSource = new InputSource(new StringReader(msgCtx.getEnvelope().toString()));
+            Document document;
+            synchronized (documentBuilder) {
+                document = documentBuilder.parse(inputSource);
+            }
+            return document.getXmlVersion();
+        } catch (SAXException e) {
+            log.error("Error parsing message envelope", e);
+        } catch (IOException e) {
+            log.error("Error reading message envelope", e);
+        }
+        return "1.0";
     }
 
     /**
      * Escapes XML special characters
      *
-     * @param msgCtx Message Context
-     * @param value XML String which needs to be escaped
+     * @param xmlVersion XML version of the value
+     * @param value      XML String which needs to be escaped
      * @return XML special char escaped string
      */
-    private String escapeXMLEnvelope(MessageContext msgCtx, String value) {
-        String xmlVersion = "1.0"; //Default is set to 1.0
-
-        try {
-            xmlVersion = checkXMLVersion(msgCtx);
-        } catch (IOException e) {
-            log.error("Error reading message envelope", e);
-        } catch (SAXException e) {
-            log.error("Error parsing message envelope", e);
-        } catch (ParserConfigurationException e) {
-            log.error("Error building message envelope document", e);
-        }
-
-        if("1.1".equals(xmlVersion)) {
+    private String escapeXMLEnvelope(String xmlVersion, String value) {
+        if ("1.1".equals(xmlVersion)) {
             return org.apache.commons.text.StringEscapeUtils.escapeXml11(value);
         } else {
             return org.apache.commons.text.StringEscapeUtils.escapeXml10(value);
         }
-
     }
 
     public boolean isEscapeXmlChars() {

--- a/modules/core/src/main/java/org/apache/synapse/util/PayloadHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/PayloadHelper.java
@@ -24,6 +24,9 @@ import java.util.Iterator;
 import javax.activation.DataHandler;
 
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.apache.axiom.om.OMAbstractFactory;
@@ -58,6 +61,13 @@ public class PayloadHelper {
 			TEXTPAYLOADTYPE = 2, MAPPAYLOADTYPE = 3;
 
 	public static final Log log = LogFactory.getLog(PayloadHelper.class);
+
+	public static final String BUILDER_NAMESPACE_FEATURE = "http://xml.org/sax/features/namespaces";
+	public static final String BUILDER_VALIDATION_FEATURE = "http://xml.org/sax/features/validation";
+	public static final String BUILDER_LOAD_DTD_FEATURE =
+			"http://apache.org/xml/features/nonvalidating/load-dtd-grammar";
+	public static final String BUILDER_LOAD_EXTERNAL_FEATURE =
+			"http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
 	// gets a indication of the payload type. Default is XML
 	// You cannot set the payload type. Instead, it is set automatically when
@@ -312,5 +322,22 @@ public class PayloadHelper {
 			}
 			setStAXPayload(mc.getEnvelope(), streamReader);
 		}
+	}
+
+	/**
+	 * Create DocumentBuilder for parsing XML payloads to check version
+	 */
+	public static DocumentBuilder createSimpleDocumentBuilder() throws ParserConfigurationException {
+		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+		//unnecessary features are turned off since we need document builder only to check XML version
+		documentBuilderFactory.setNamespaceAware(false);
+		documentBuilderFactory.setValidating(false);
+		documentBuilderFactory.setFeature(BUILDER_NAMESPACE_FEATURE, false);
+		documentBuilderFactory.setFeature(BUILDER_VALIDATION_FEATURE, false);
+		documentBuilderFactory.setFeature(BUILDER_LOAD_DTD_FEATURE, false);
+		documentBuilderFactory.setFeature(BUILDER_LOAD_EXTERNAL_FEATURE, false);
+
+		return documentBuilderFactory.newDocumentBuilder();
 	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/util/PayloadHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/PayloadHelper.java
@@ -325,7 +325,10 @@ public class PayloadHelper {
 	}
 
 	/**
-	 * Create DocumentBuilder for parsing XML payloads to check version
+	 * Creates DocumentBuilder for parsing XML payloads to check version.
+	 *
+	 * @return pre-configured Simple DocumentBuilder
+	 * @throws ParserConfigurationException Error creating Simple Document Builder
 	 */
 	public static DocumentBuilder createSimpleDocumentBuilder() throws ParserConfigurationException {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();


### PR DESCRIPTION
## Purpose

Resolves wso2/product-ei#5279

This PR refactors the PayloadFactory mediator code to improve the performance in the following ways.

- Initialize Document Builder only once.
- Turn off unnecessary features in DocumentBuilder
- Check XML version for every request. (Not for every argument in PF)
- Use stringToOM as a last resort inside isXML() check.

