### PR TITLE
Retry JSON parsing to handle strings with spaces.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/PropertyMediator.java
@@ -524,8 +524,16 @@ public class PropertyMediator extends AbstractMediator {
         try {
             return jsonParser.parse(jsonPayload);
         } catch (JsonSyntaxException ex) {
-            log.error("Malformed JSON payload : " + jsonPayload, ex);
-            return null;
+            // Enclosing using quotes due to the following issue
+            // https://github.com/google/gson/issues/1286
+            String enclosed = "\"" + jsonPayload + "\"";
+            try {
+                return jsonParser.parse(enclosed);
+            } catch (JsonSyntaxException e) {
+                // log the original exception and discard the new exception
+                log.error("Malformed JSON payload : " + jsonPayload, ex);
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
GSON library stop parsing in white spaces and give malformed exceptions.
To handle this we need to enclose the string with qutotes.
Relates issue google/gson/issues/1286

## Purpose
> GSON library stop parsing in white spaces and give malformed exceptions.
To handle this we need to enclose the string with quotes.
Relates issue google/gson/issues/1286