### PR TITLE
Fix the NPE thrown when correlation log is enabled

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2FlexibleMEPClient.java
@@ -60,6 +60,7 @@ import org.apache.synapse.unittest.ConfigModifier;
 import org.apache.synapse.util.MessageHelper;
 
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 import javax.mail.internet.ContentType;
@@ -155,6 +156,10 @@ public class Axis2FlexibleMEPClient {
         if (originalInMsgCtx.isPropertyTrue(PassThroughConstants.CORRELATION_LOG_STATE_PROPERTY)) {
             if (originalInMsgCtx.getProperty(CorrelationConstants.CORRELATION_ID) == null) {
                 originalInMsgCtx.setProperty(CorrelationConstants.CORRELATION_ID, UUID.randomUUID().toString());
+            }
+            if (headers == null) {
+                headers = new HashMap();
+                originalInMsgCtx.setProperty(MessageContext.TRANSPORT_HEADERS, headers);
             }
             headers.put(PassThroughConfiguration.getInstance().getCorrelationHeaderName(),
                     originalInMsgCtx.getProperty(CorrelationConstants.CORRELATION_ID).toString());


### PR DESCRIPTION
## Description 
Fix the issue in throwing a NullPointer Exception when invoking a proxy service that calls an endpoint when correlation logs are enabled and headers are removed.

Fixes https://github.com/wso2/product-ei/issues/5265