### PR TITLE
Stop suspending client input after request is read

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceRequest.java
@@ -138,8 +138,8 @@ public class SourceRequest {
 
                 // Update connection state
                 SourceContext.updateState(conn, ProtocolState.REQUEST_DONE);
-                // Suspend client input
-                conn.suspendInput();
+//                // Suspend client input
+//                conn.suspendInput();
             }
             return bytes;
         } else {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Stop suspending client input after request is read