### PR TITLE
Freemarker support for PayloadFactory

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -380,7 +380,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-		</dependency>
+        </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -367,26 +367,30 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
-            <artifactId>libphonenumber</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.wso2.orbit.joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
+			<artifactId>libphonenumber</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.freemarker</groupId>
+			<artifactId>freemarker</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.agent</artifactId>
+			<classifier>runtime</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -367,30 +367,30 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
+            <artifactId>libphonenumber</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.wso2.orbit.joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.wso2.orbit.com.googlecode.libphonenumber</groupId>
-			<artifactId>libphonenumber</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.freemarker</groupId>
-			<artifactId>freemarker</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>org.jacoco.agent</artifactId>
-			<classifier>runtime</classifier>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito2</artifactId>
-			<scope>test</scope>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -166,7 +166,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         }
 
         addAllCommentChildrenToList(elem, payloadFactoryMediator.getCommentsList());
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
         return payloadFactoryMediator;
     }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -27,6 +27,7 @@ import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.transform.Argument;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 import org.apache.synapse.mediators.transform.pfutils.FreeMarkerTemplateProcessor;
+import org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor;
 import org.apache.synapse.mediators.transform.pfutils.TemplateProcessor;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
@@ -179,7 +180,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         }
         return templateProcessor;*/
 
-        return new FreeMarkerTemplateProcessor();
+        return new RegexTemplateProcessor();
     }
 
     public QName getTagQName() {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -41,6 +41,7 @@ import javax.xml.namespace.QName;
 
 import static org.apache.synapse.mediators.transform.pfutils.Constants.FREEMARKER_TEMPLATE_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.REGEX_TEMPLATE_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.XML_TYPE;
 
@@ -61,7 +62,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
-        TemplateProcessor templateProcessor = getTemplateProcessor(elem);
+        TemplateProcessor templateProcessor = getTemplateProcessor(elem, payloadFactoryMediator);
         processAuditStatus(payloadFactoryMediator, elem);
         String mediaTypeValue = elem.getAttributeValue(TYPE_Q);
         //for the backward compatibility.
@@ -175,13 +176,15 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         return payloadFactoryMediator;
     }
 
-    private TemplateProcessor getTemplateProcessor(OMElement elem) {
+    private TemplateProcessor getTemplateProcessor(OMElement elem, PayloadFactoryMediator payloadFactoryMediator ) {
 
         TemplateProcessor templateProcessor;
         String templateTypeValue = elem.getAttributeValue(TEMPLATE_TYPE_Q);
         if (templateTypeValue != null && templateTypeValue.equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE)) {
+            payloadFactoryMediator.setTemplateType(FREEMARKER_TEMPLATE_TYPE);
             templateProcessor = new FreeMarkerTemplateProcessor();
         } else {
+            payloadFactoryMediator.setTemplateType(REGEX_TEMPLATE_TYPE);
             templateProcessor = new RegexTemplateProcessor();
         }
         return templateProcessor;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -89,9 +89,11 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                     payloadFactoryMediator.setFormat(formatText);
                     templateProcessor.setFormat(formatText);
                 } else {
-                    String formatText = copy.getFirstElement().toString();
-                    payloadFactoryMediator.setFormat(formatText);
-                    templateProcessor.setFormat(formatText);
+                    if (payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE)) {
+                        payloadFactoryMediator.setFormat(PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText()));
+                    }else{
+                        payloadFactoryMediator.setFormat(copy.getFirstElement().toString());
+                    }
                 }
             } else {
                 ValueFactory keyFac = new ValueFactory();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -85,22 +85,24 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 OMElement copy = formatElem.cloneOMElement();
                 removeIndentations(copy);
 
+                String format;
                 if (mediaTypeValue != null &&
                         (mediaTypeValue.contains(JSON_TYPE) || mediaTypeValue.contains(TEXT_TYPE))) {
-                    String formatText = copy.getText();
-                    payloadFactoryMediator.setFormat(formatText);
-                    templateProcessor.setFormat(formatText);
+                    if (isFreeMarkerTemplate(payloadFactoryMediator)) {
+                        format = PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText());
+                    }else {
+                        format = copy.getText();
+                    }
+
                 } else {
-                    String format;
-                    if (payloadFactoryMediator.getTemplateType() != null &&
-                            payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE)) {
+                    if (isFreeMarkerTemplate(payloadFactoryMediator)) {
                         format = PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText());
                     } else {
                         format = copy.getFirstElement().toString();
                     }
-                    payloadFactoryMediator.setFormat(format);
-                    templateProcessor.setFormat(format);
                 }
+                payloadFactoryMediator.setFormat(format);
+                templateProcessor.setFormat(format);
             } else {
                 ValueFactory keyFac = new ValueFactory();
                 Value generatedKey = keyFac.createValue(XMLConfigConstants.KEY, formatElem);
@@ -178,6 +180,12 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
         return payloadFactoryMediator;
+    }
+
+    private boolean isFreeMarkerTemplate(PayloadFactoryMediator payloadFactoryMediator) {
+
+        return payloadFactoryMediator.getTemplateType() != null &&
+                payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE);
     }
 
     private TemplateProcessor getTemplateProcessor(OMElement elem, PayloadFactoryMediator payloadFactoryMediator) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -188,7 +188,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     private void removeIndentations(OMElement element) {
-        List<OMText> removables = new ArrayList<OMText>();
+        List<OMText> removables = new ArrayList<>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
             node.detach();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.synapse.mediators.transform.pfutils.Constants.FREEMARKER_TEMPLATE_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.XML_TYPE;
@@ -52,16 +53,18 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     private static final QName ATT_LITERAL = new QName("literal");
 
     private static final QName TYPE_Q = new QName("media-type");// media-type attribute in payloadFactory
-    private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");// escape xml chars attribute in payloadFactory
+    private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");
+// escape xml chars attribute in payloadFactory
+    private static final QName TEMPLATE_TYPE_Q = new QName("template-type");
 
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
-        TemplateProcessor templateProcessor = getTemplateProcessor();
+        TemplateProcessor templateProcessor = getTemplateProcessor(elem);
         processAuditStatus(payloadFactoryMediator, elem);
         String mediaTypeValue = elem.getAttributeValue(TYPE_Q);
         //for the backward compatibility.
-        if(mediaTypeValue != null) {
+        if (mediaTypeValue != null) {
             payloadFactoryMediator.setType(mediaTypeValue); //set the mediaType for the PF
             templateProcessor.setMediaType(mediaTypeValue);
         } else {
@@ -80,7 +83,8 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 OMElement copy = formatElem.cloneOMElement();
                 removeIndentations(copy);
 
-                if(mediaTypeValue != null && (mediaTypeValue.contains(JSON_TYPE) || mediaTypeValue.contains(TEXT_TYPE)))  {
+                if (mediaTypeValue != null &&
+                        (mediaTypeValue.contains(JSON_TYPE) || mediaTypeValue.contains(TEXT_TYPE))) {
                     String formatText = copy.getText();
                     payloadFactoryMediator.setFormat(formatText);
                     templateProcessor.setFormat(formatText);
@@ -155,7 +159,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                         }
                     }
 
-
                 } else {
                     handleException("Unsupported arg type. value or expression attribute required");
                 }
@@ -168,19 +171,16 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         return payloadFactoryMediator;
     }
 
-    private TemplateProcessor getTemplateProcessor() { //TODO :: implement this after studio fixes
+    private TemplateProcessor getTemplateProcessor(OMElement elem) { 
 
-/*        TemplateProcessor templateProcessor;
-
-        String useFreeMarkerPropertyValue = properties.getProperty(USE_FREEMARKER_TEMPLATE_IN_PAYLOAD_FACTORY);
-        if (useFreeMarkerPropertyValue != null && useFreeMarkerPropertyValue.equalsIgnoreCase("true")) {
+        TemplateProcessor templateProcessor;
+        String templateTypeValue = elem.getAttributeValue(TEMPLATE_TYPE_Q);
+        if (templateTypeValue != null && templateTypeValue.equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE)) {
             templateProcessor = new FreeMarkerTemplateProcessor();
         } else {
             templateProcessor = new RegexTemplateProcessor();
         }
-        return templateProcessor;*/
-
-        return new RegexTemplateProcessor();
+        return templateProcessor;
     }
 
     public QName getTagQName() {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -31,12 +31,11 @@ import org.apache.synapse.mediators.transform.pfutils.TemplateProcessor;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 
+import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-
-import javax.xml.namespace.QName;
 
 import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_TYPE;
@@ -52,8 +51,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     private static final QName ATT_LITERAL = new QName("literal");
 
     private static final QName TYPE_Q = new QName("media-type");// media-type attribute in payloadFactory
-    private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");
-// escape xml chars attribute in payloadFactory
+    private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");// escape xml chars attribute in payloadFactory
 
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
@@ -62,8 +60,8 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         processAuditStatus(payloadFactoryMediator, elem);
         String mediaTypeValue = elem.getAttributeValue(TYPE_Q);
         //for the backward compatibility.
-        if (mediaTypeValue != null) {
-            payloadFactoryMediator.setType(mediaTypeValue);
+        if(mediaTypeValue != null) {
+            payloadFactoryMediator.setType(mediaTypeValue); //set the mediaType for the PF
             templateProcessor.setMediaType(mediaTypeValue);
         } else {
             payloadFactoryMediator.setType(XML_TYPE);
@@ -71,7 +69,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         }
 
         boolean escapeXmlCharsValue = Boolean.parseBoolean(elem.getAttributeValue(ESCAPE_XML_CHARS_Q));
-//        payloadFactoryMediator.setEscapeXmlChars(escapeXmlCharsValue); //set the escape xml chars in json payloads for the PF
         templateProcessor.setEscapeXmlChars(escapeXmlCharsValue);
 
         OMElement formatElem = elem.getFirstChildWithName(FORMAT_Q);
@@ -82,8 +79,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 OMElement copy = formatElem.cloneOMElement();
                 removeIndentations(copy);
 
-                if (mediaTypeValue != null &&
-                        (mediaTypeValue.contains(JSON_TYPE) || mediaTypeValue.contains(TEXT_TYPE))) {
+                if(mediaTypeValue != null && (mediaTypeValue.contains(JSON_TYPE) || mediaTypeValue.contains(TEXT_TYPE)))  {
                     String formatText = copy.getText();
                     payloadFactoryMediator.setFormat(formatText);
                     templateProcessor.setFormat(formatText);
@@ -114,6 +110,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 Argument arg = new Argument();
                 String value;
 
+
                 boolean isLiteral = false;
                 String isLiteralString = argElem.getAttributeValue(ATT_LITERAL);
                 if (isLiteralString != null) {
@@ -126,7 +123,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 if ((value = argElem.getAttributeValue(ATT_VALUE)) != null) {
                     arg.setValue(value);
                     arg.setExpression(null);
-//                    payloadFactoryMediator.addPathArgument(arg);
                     templateProcessor.addPathArgument(arg);
                 } else if ((value = argElem.getAttributeValue(ATT_EXPRN)) != null) {
                     if (value.trim().length() == 0) {
@@ -135,9 +131,9 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                         try {
                             //set the evaluator
                             String evaluator = argElem.getAttributeValue(ATT_EVAL);
-                            if (evaluator != null && evaluator.equals(JSON_TYPE)) {
-                                if (value.startsWith("json-eval(")) {
-                                    value = value.substring(10, value.length() - 1);
+                            if(evaluator != null && evaluator.equals(JSON_TYPE)){
+                                if(value.startsWith("json-eval(")) {
+                                    value = value.substring(10, value.length()-1);
                                 }
                                 arg.setExpression(SynapseJsonPathFactory.getSynapseJsonPath(value));
                                 // we have to explicitly define the path type since we are not going to mark
@@ -157,6 +153,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                                     value, e);
                         }
                     }
+
 
                 } else {
                     handleException("Unsupported arg type. value or expression attribute required");
@@ -186,12 +183,10 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     public QName getTagQName() {
-
         return PAYLOAD_FACTORY_Q;
     }
 
     private void removeIndentations(OMElement element) {
-
         List<OMText> removables = new ArrayList<OMText>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
@@ -200,7 +195,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     private void removeIndentations(OMElement element, List<OMText> removables) {
-
         Iterator children = element.getChildren();
         while (children.hasNext()) {
             Object next = children.next();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -32,11 +32,12 @@ import org.apache.synapse.mediators.transform.pfutils.TemplateProcessor;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+
+import javax.xml.namespace.QName;
 
 import static org.apache.synapse.mediators.transform.pfutils.Constants.FREEMARKER_TEMPLATE_TYPE;
 import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_TYPE;
@@ -54,7 +55,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
 
     private static final QName TYPE_Q = new QName("media-type");// media-type attribute in payloadFactory
     private static final QName ESCAPE_XML_CHARS_Q = new QName("escapeXmlChars");
-// escape xml chars attribute in payloadFactory
+    // escape xml chars attribute in payloadFactory
     private static final QName TEMPLATE_TYPE_Q = new QName("template-type");
 
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
@@ -89,9 +90,11 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                     payloadFactoryMediator.setFormat(formatText);
                     templateProcessor.setFormat(formatText);
                 } else {
-                    if (payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE)) {
-                        payloadFactoryMediator.setFormat(PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText()));
-                    }else{
+                    if (payloadFactoryMediator.getTemplateType() != null &&
+                            payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE)) {
+                        payloadFactoryMediator
+                                .setFormat(PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText()));
+                    } else {
                         payloadFactoryMediator.setFormat(copy.getFirstElement().toString());
                     }
                 }
@@ -117,7 +120,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 Argument arg = new Argument();
                 String value;
 
-
                 boolean isLiteral = false;
                 String isLiteralString = argElem.getAttributeValue(ATT_LITERAL);
                 if (isLiteralString != null) {
@@ -138,9 +140,9 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                         try {
                             //set the evaluator
                             String evaluator = argElem.getAttributeValue(ATT_EVAL);
-                            if(evaluator != null && evaluator.equals(JSON_TYPE)){
-                                if(value.startsWith("json-eval(")) {
-                                    value = value.substring(10, value.length()-1);
+                            if (evaluator != null && evaluator.equals(JSON_TYPE)) {
+                                if (value.startsWith("json-eval(")) {
+                                    value = value.substring(10, value.length() - 1);
                                 }
                                 arg.setExpression(SynapseJsonPathFactory.getSynapseJsonPath(value));
                                 // we have to explicitly define the path type since we are not going to mark
@@ -173,7 +175,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         return payloadFactoryMediator;
     }
 
-    private TemplateProcessor getTemplateProcessor(OMElement elem) { 
+    private TemplateProcessor getTemplateProcessor(OMElement elem) {
 
         TemplateProcessor templateProcessor;
         String templateTypeValue = elem.getAttributeValue(TEMPLATE_TYPE_Q);
@@ -186,10 +188,12 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     public QName getTagQName() {
+
         return PAYLOAD_FACTORY_Q;
     }
 
     private void removeIndentations(OMElement element) {
+
         List<OMText> removables = new ArrayList<>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
@@ -198,6 +202,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     private void removeIndentations(OMElement element, List<OMText> removables) {
+
         Iterator children = element.getChildren();
         while (children.hasNext()) {
             Object next = children.next();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -91,13 +91,15 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                     payloadFactoryMediator.setFormat(formatText);
                     templateProcessor.setFormat(formatText);
                 } else {
+                    String format;
                     if (payloadFactoryMediator.getTemplateType() != null &&
                             payloadFactoryMediator.getTemplateType().equalsIgnoreCase(FREEMARKER_TEMPLATE_TYPE)) {
-                        payloadFactoryMediator
-                                .setFormat(PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText()));
+                        format = PayloadFactoryMediatorSerializer.removeCDATAFromPayload(copy.getText());
                     } else {
-                        payloadFactoryMediator.setFormat(copy.getFirstElement().toString());
+                        format = copy.getFirstElement().toString();
                     }
+                    payloadFactoryMediator.setFormat(format);
+                    templateProcessor.setFormat(format);
                 }
             } else {
                 ValueFactory keyFac = new ValueFactory();
@@ -176,7 +178,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         return payloadFactoryMediator;
     }
 
-    private TemplateProcessor getTemplateProcessor(OMElement elem, PayloadFactoryMediator payloadFactoryMediator ) {
+    private TemplateProcessor getTemplateProcessor(OMElement elem, PayloadFactoryMediator payloadFactoryMediator) {
 
         TemplateProcessor templateProcessor;
         String templateTypeValue = elem.getAttributeValue(TEMPLATE_TYPE_Q);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactory.java
@@ -66,7 +66,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
         processAuditStatus(payloadFactoryMediator, elem);
         String mediaTypeValue = elem.getAttributeValue(TYPE_Q);
         //for the backward compatibility.
-        if (mediaTypeValue != null) {
+        if(mediaTypeValue != null) {
             payloadFactoryMediator.setType(mediaTypeValue); //set the mediaType for the PF
             templateProcessor.setMediaType(mediaTypeValue);
         } else {
@@ -123,6 +123,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                 Argument arg = new Argument();
                 String value;
 
+
                 boolean isLiteral = false;
                 String isLiteralString = argElem.getAttributeValue(ATT_LITERAL);
                 if (isLiteralString != null) {
@@ -143,9 +144,9 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                         try {
                             //set the evaluator
                             String evaluator = argElem.getAttributeValue(ATT_EVAL);
-                            if (evaluator != null && evaluator.equals(JSON_TYPE)) {
-                                if (value.startsWith("json-eval(")) {
-                                    value = value.substring(10, value.length() - 1);
+                            if(evaluator != null && evaluator.equals(JSON_TYPE)){
+                                if(value.startsWith("json-eval(")) {
+                                    value = value.substring(10, value.length()-1);
                                 }
                                 arg.setExpression(SynapseJsonPathFactory.getSynapseJsonPath(value));
                                 // we have to explicitly define the path type since we are not going to mark
@@ -165,6 +166,7 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
                                     value, e);
                         }
                     }
+
 
                 } else {
                     handleException("Unsupported arg type. value or expression attribute required");
@@ -193,12 +195,10 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     public QName getTagQName() {
-
         return PAYLOAD_FACTORY_Q;
     }
 
     private void removeIndentations(OMElement element) {
-
         List<OMText> removables = new ArrayList<>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
@@ -207,7 +207,6 @@ public class PayloadFactoryMediatorFactory extends AbstractMediatorFactory {
     }
 
     private void removeIndentations(OMElement element, List<OMText> removables) {
-
         Iterator children = element.getChildren();
         while (children.hasNext()) {
             Object next = children.next();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -91,14 +91,14 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
                     OMElement formatElem = fac.createOMElement(FORMAT, synNS);
                 String type = mediator.getType();
                 if(type!=null && (type.contains(JSON_TYPE) || type.contains(TEXT))) {
-                     formatElem.setText(mediator.getFormat());
+                    if (isFreeMarkerTemplate(mediator)) {
+                        createCdataTag(mediator,formatElem);
+                    }else{
+                        formatElem.setText(mediator.getFormat());
+                    }
                 } else {
                     if (isFreeMarkerTemplate(mediator)) {
-                        String formatString = mediator.getFormat();
-                        formatString = removeCDATAFromPayload(formatString);
-                        OMTextImpl omText = (OMTextImpl) formatElem.getOMFactory().createOMText(formatElem, formatString,
-                                XMLStreamConstants.CDATA);
-                        formatElem.addChild(omText);
+                        createCdataTag(mediator, formatElem);
                     } else {    
                     formatElem.addChild(AXIOMUtil.stringToOM(mediator.getFormat()));
                 }
@@ -161,6 +161,15 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
         serializeComments(payloadFactoryElem, mediator.getCommentsList());
 
         return payloadFactoryElem;
+    }
+
+    private void createCdataTag(PayloadFactoryMediator mediator, OMElement formatElem) {
+
+        String formatString = mediator.getFormat();
+        formatString = removeCDATAFromPayload(formatString);
+        OMTextImpl omText = (OMTextImpl) formatElem.getOMFactory().createOMText(formatElem, formatString,
+                XMLStreamConstants.CDATA);
+        formatElem.addChild(omText);
     }
 
     private boolean isFreeMarkerTemplate(PayloadFactoryMediator mediator) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -40,6 +40,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
     private static final String EVALUATOR = "evaluator";
     private final String JSON_TYPE="json";
     private final String MEDIA_TYPE="media-type";
+    private final String TEMPLATE_TYPE="template-type";
     private final String ESCAPE_XML_CHARS="escapeXmlChars";
 
     private final String XML = "xml";
@@ -47,6 +48,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
     private final String TEXT = "text";
     private final String LITERAL = "literal";
 
+    private final String FREEMARKER = "freemarker";
     private String getEvaluator(String pathType) {
         if(pathType == SynapsePath.JSON_PATH) {
             return JSON;
@@ -70,6 +72,9 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
             payloadFactoryElem.addAttribute(fac.createOMAttribute(MEDIA_TYPE,null,mediator.getType()));
         }
 
+        if (mediator.getTemplateType() != null && mediator.getTemplateType().equalsIgnoreCase(FREEMARKER)) {
+            payloadFactoryElem.addAttribute(fac.createOMAttribute(TEMPLATE_TYPE, null, FREEMARKER));
+        }
         if (mediator.isEscapeXmlChars()) {
             payloadFactoryElem.addAttribute(fac.createOMAttribute(ESCAPE_XML_CHARS,null,
                     Boolean.toString(mediator.isEscapeXmlChars())));

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -25,9 +25,10 @@ import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.transform.Argument;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 
+import java.util.List;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
-import java.util.List;
 
 public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer {
 
@@ -107,7 +108,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
         }
 
         OMElement argumentsElem = fac.createOMElement(ARGS, synNS);
-        List<Argument> pathArgList = mediator.getPathArgumentList();
+        List<Argument> pathArgList = mediator.getTemplateProcessor().getPathArgumentList();
 
         if (null != pathArgList && pathArgList.size() > 0) {
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -20,12 +20,14 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.transform.Argument;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import java.util.List;
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -25,10 +25,9 @@ import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.transform.Argument;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 
-import java.util.List;
-
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
+import java.util.List;
 
 public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer {
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -92,7 +92,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
                 String type = mediator.getType();
                 if(type!=null && (type.contains(JSON_TYPE) || type.contains(TEXT))) {
                      formatElem.setText(mediator.getFormat());
-                } else{
+                } else {
                     if (isFreeMarkerTemplate(mediator)) {
                         String formatString = mediator.getFormat();
                         formatString = removeCDATAFromPayload(formatString);
@@ -174,7 +174,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
     public static String removeCDATAFromPayload(String inputPayload) {
         if (inputPayload.startsWith("<![CDATA[")) {
             inputPayload = inputPayload.substring(9);
-            int i = inputPayload.indexOf("]]>");
+            int i = inputPayload.lastIndexOf("]]>");
             if (i == -1)
                 throw new IllegalStateException("argument starts with <![CDATA[ but cannot find pairing ]]>");
             inputPayload = inputPayload.substring(0, i);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -31,72 +31,50 @@ import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.commons.json.JsonUtil;
-import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.Value;
+import org.apache.synapse.mediators.transform.pfutils.TemplateProcessor;
+import org.apache.synapse.mediators.transform.pfutils.TemplateProcessorException;
 import org.apache.synapse.util.AXIOMUtils;
-import org.apache.synapse.util.xpath.SynapseJsonPath;
-import org.apache.synapse.util.xpath.SynapseXPath;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.REGEX_TEMPLATE_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.XML_TYPE;
 
 public class PayloadFactoryMediator extends AbstractMediator {
+
     private Value formatKey = null;
     private boolean isFormatDynamic = false;
     private String formatRaw;
     private String mediaType = XML_TYPE;
+    private final static String XML_CONTENT_TYPE = "application/xml";
     private boolean escapeXmlChars = false;
     private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
     private final static String JSON_CONTENT_TYPE = "application/json";
-    private final static String XML_CONTENT_TYPE  = "application/xml";
-    private final static String TEXT_CONTENT_TYPE  = "text/plain";
-    private final static String SOAP11_CONTENT_TYPE  = "text/xml";
-    private final static String SOAP12_CONTENT_TYPE  = "application/soap+xml";
-    private final static String JSON_TYPE = "json";
-    private final static String XML_TYPE = "xml";
-    private final static String TEXT_TYPE = "text";
-    private final static String STRING_TYPE = "str";
+    private final static String TEXT_CONTENT_TYPE = "text/plain";
+    private final static String SOAP11_CONTENT_TYPE = "text/xml";
+    private final static String SOAP12_CONTENT_TYPE = "application/soap+xml";
+    private String templateType = REGEX_TEMPLATE_TYPE;
     private final static QName TEXT_ELEMENT = new QName("http://ws.apache.org/commons/ns/payload", "text");
-    private final static String ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES = "\\\\\"";
-    private final static String ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES = "\\\\\\\\\"";
-    private final static String ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES = "\\\\\\\\\\\\\\\\";
-    private final static String ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES = "\\\\\\$";
-    private final static String ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES = "\\\\\\\\\\$";
-    private final static String ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\b";
-    private final static String ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\f";
-    private final static String ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\n";
-    private final static String ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\r";
-    private final static String ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\t";
     public static final String QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON = "QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON";
-
-    private List<Argument> pathArgumentList = new ArrayList<Argument>();
-    private Pattern pattern = Pattern.compile("\\$(\\d)+");
-    private static Pattern validJsonNumber = Pattern.compile("^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$");
-
+    private TemplateProcessor templateProcessor;
     private static final Log log = LogFactory.getLog(PayloadFactoryMediator.class);
 
     public PayloadFactoryMediator() {
@@ -107,6 +85,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
     /**
      * Contains 2 paths - one when JSON Streaming is in use (mediateJsonStreamPayload) and the other for regular
      * builders (mediatePayload).
+     *
      * @param synCtx the current message for mediation
      * @return
      */
@@ -122,17 +101,101 @@ public class PayloadFactoryMediator extends AbstractMediator {
         return mediate(synCtx, format);
     }
 
+    private boolean mediate(MessageContext synCtx, String format) {
+
+        if (!isDoingXml(synCtx) && !isDoingJson(synCtx)) {
+            log.error("#mediate. Could not identify the payload format of the existing payload prior to mediate.");
+            return false;
+        }
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        StringBuffer result = new StringBuffer();
+        transform(result, synCtx, format);
+        String out = result.toString().trim();
+        if (log.isDebugEnabled()) {
+            log.debug("#mediate. Transformed payload format>>> " + out);
+        }
+        if (mediaType.equals(XML_TYPE)) {
+            try {
+                JsonUtil.removeJsonPayload(axis2MessageContext);
+                OMElement omXML = convertStringToOM(out);
+                if (!checkAndReplaceEnvelope(omXML,
+                        synCtx)) { // check if the target of the PF 'format' is the entire SOAP envelop, not just the body.
+                    axis2MessageContext.getEnvelope().getBody().addChild(omXML.getFirstElement());
+                }
+            } catch (XMLStreamException e) {
+                handleException("Error creating SOAP Envelope from source " + out, synCtx);
+            }
+        } else if (mediaType.equals(JSON_TYPE)) {
+            try {
+                JsonUtil.getNewJsonPayload(axis2MessageContext, out, true, true);
+            } catch (AxisFault axisFault) {
+                handleException("Error creating JSON Payload from source " + out, synCtx);
+            }
+        } else if (mediaType.equals(TEXT_TYPE)) {
+            JsonUtil.removeJsonPayload(axis2MessageContext);
+            axis2MessageContext.getEnvelope().getBody().addChild(getTextElement(out));
+        }
+        //need to honour a content-type of the payload media-type as output from the payload
+        //{re-merging patch https://wso2.org/jira/browse/ESBJAVA-3014}
+        setContentType(synCtx);
+        return true;
+    }
+
+    /**
+     * Calls the replace function. isFormatDynamic check is used to remove indentations which come from registry based
+     * configurations.
+     *
+     * @param result
+     * @param synCtx
+     * @param format
+     */
+    private void transform(StringBuffer result, MessageContext synCtx, String format) {
+
+        if (isFormatDynamic()) {
+            String key = formatKey.evaluateValue(synCtx);
+            Object entry = synCtx.getEntry(key);
+            if (entry == null) {
+                handleException("Key " + key + " not found ", synCtx);
+            }
+            String text = "";
+            if (entry instanceof OMElement) {
+                OMElement omElement = ((OMElement) entry).cloneOMElement();
+                removeIndentations(omElement);
+                text = omElement.toString();
+            } else if (entry instanceof OMText) {
+                text = ((OMText) entry).getText();
+            } else if (entry instanceof String) {
+                text = (String) entry;
+            }
+            processTemplate(result, synCtx, text, isFormatDynamic());
+        } else {
+            processTemplate(result, synCtx, format, isFormatDynamic());
+        }
+    }
+
+    private void processTemplate(StringBuffer result, MessageContext synCtx, String text, boolean isFormatDynamic) {
+
+        try {
+            result.append(templateProcessor.processTemplate(text, mediaType, synCtx, isFormatDynamic));
+        } catch (TemplateProcessorException e) {
+            handleException(e.getMessage(), synCtx);
+        }
+    }
+
     /**
      * Sets the content type based on the request content type and payload factory media type. This should be called
      * at the end before returning from the mediate() function.
+     *
      * @param synCtx
      */
     private void setContentType(MessageContext synCtx) {
+
         org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
         if (mediaType.equals(XML_TYPE)) {
             if (!XML_CONTENT_TYPE.equals(a2mc.getProperty(Constants.Configuration.MESSAGE_TYPE)) &&
                     !SOAP11_CONTENT_TYPE.equals(a2mc.getProperty(Constants.Configuration.MESSAGE_TYPE)) &&
-                    !SOAP12_CONTENT_TYPE.equals(a2mc.getProperty(Constants.Configuration.MESSAGE_TYPE)) ) {
+                    !SOAP12_CONTENT_TYPE.equals(a2mc.getProperty(Constants.Configuration.MESSAGE_TYPE))) {
                 a2mc.setProperty(Constants.Configuration.MESSAGE_TYPE, XML_CONTENT_TYPE);
                 a2mc.setProperty(Constants.Configuration.CONTENT_TYPE, XML_CONTENT_TYPE);
                 handleSpecialProperties(XML_CONTENT_TYPE, a2mc);
@@ -152,6 +215,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
     // This is copied from PropertyMediator, required to change Content-Type
     private void handleSpecialProperties(Object resultValue,
                                          org.apache.axis2.context.MessageContext axis2MessageCtx) {
+
         axis2MessageCtx.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, resultValue);
         Object o = axis2MessageCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         Map headers = (Map) o;
@@ -161,302 +225,8 @@ public class PayloadFactoryMediator extends AbstractMediator {
         }
     }
 
-    private boolean mediate(MessageContext synCtx, String format) {
-
-        if (!isDoingXml(synCtx) && !isDoingJson(synCtx)) {
-            log.error("#mediate. Could not identify the payload format of the existing payload prior to mediate.");
-            return false;
-        }
-        org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-        StringBuffer result = new StringBuffer();
-        regexTransform(result, synCtx, format);
-        String out = result.toString().trim();
-        if (log.isDebugEnabled()) {
-            log.debug("#mediate. Transformed payload format>>> " + out);
-        }
-        if (mediaType.equals(XML_TYPE)) {
-            try {
-                JsonUtil.removeJsonPayload(axis2MessageContext);
-                OMElement omXML = convertStringToOM(out);
-                if (!checkAndReplaceEnvelope(omXML, synCtx)) { // check if the target of the PF 'format' is the entire SOAP envelop, not just the body.
-                    axis2MessageContext.getEnvelope().getBody().addChild(omXML.getFirstElement());
-                }
-            } catch (XMLStreamException e) {
-                handleException("Error creating SOAP Envelope from source " + out, synCtx);
-            }
-        } else if  (mediaType.equals(JSON_TYPE)) {
-            try {
-                JsonUtil.getNewJsonPayload(axis2MessageContext, out, true, true);
-            } catch (AxisFault axisFault) {
-                handleException("Error creating JSON Payload from source " + out, synCtx);
-            }
-        } else if  (mediaType.equals(TEXT_TYPE)) {
-            JsonUtil.removeJsonPayload(axis2MessageContext);
-            axis2MessageContext.getEnvelope().getBody().addChild(getTextElement(out));
-        }
-        //need to honour a content-type of the payload media-type as output from the payload 
-        //{re-merging patch https://wso2.org/jira/browse/ESBJAVA-3014}
-        setContentType(synCtx);
-        return true;
-    }
-
-    /**
-     * Calls the replace function. isFormatDynamic check is used to remove indentations which come from registry based
-     * configurations.
-     *
-     * @param result
-     * @param synCtx
-     * @param format
-     */
-    private void regexTransform(StringBuffer result, MessageContext synCtx, String format) {
-        if (isFormatDynamic()) {
-            String key = formatKey.evaluateValue(synCtx);
-            Object entry = synCtx.getEntry(key);
-            if (entry == null) {
-                handleException("Key " + key + " not found ", synCtx);
-            }
-            String text = "";
-            if (entry instanceof OMElement) {
-                OMElement omElement = ((OMElement) entry).cloneOMElement();
-                removeIndentations(omElement);
-                text = omElement.toString();
-            } else if (entry instanceof OMText) {
-                text = ((OMText) entry).getText();
-            } else if (entry instanceof String) {
-                text = (String) entry;
-            }
-            replace(text, result, synCtx);
-        } else {
-            replace(format, result, synCtx);
-        }
-    }
-
-    /**
-     * Replace special characters of a JSON string.
-     * @param jsonString JSON string.
-     * @return
-     */
-    private String escapeSpecialCharactersOfJson(String jsonString) {
-        // This is to replace \" with \\" and \\$ with \$. Because for Matcher, $ sign is
-        // a special character and for JSON " is a special character.
-        //replacing other json special characters i.e \b, \f, \n \r, \t
-        return jsonString.replaceAll(ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES,
-                ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
-                .replaceAll(ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES, ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
-                .replaceAll("\\\\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
-    }
-
-    /**
-     * Replace special characters of a XML string.
-     * @param xmlString XML string.
-     * @return
-     */
-    private String escapeSpecialCharactersOfXml(String xmlString) {
-        return xmlString.replaceAll(ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES,
-                ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
-                .replaceAll("\\$", ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
-                .replaceAll("\\\\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\\\\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
-    }
-
-    /**
-     * Replaces the payload format with SynapsePath arguments which are evaluated using getArgValues().
-     *
-     * @param format
-     * @param result
-     * @param synCtx
-     */
-    private void replace(String format, StringBuffer result, MessageContext synCtx) {
-        HashMap<String, ArgumentDetails>[] argValues = getArgValues(synCtx);
-        HashMap<String, ArgumentDetails> replacement;
-        Map.Entry<String, ArgumentDetails> replacementEntry;
-        String replacementValue = null;
-        Matcher matcher;
-
-        if (JSON_TYPE.equals(mediaType) || TEXT_TYPE.equals(mediaType)) {
-            matcher = pattern.matcher(format);
-        } else {
-            matcher = pattern.matcher("<pfPadding>" + format + "</pfPadding>");
-        }
-        try {
-            while (matcher.find()) {
-                String matchSeq = matcher.group();
-                int argIndex;
-                try {
-                    argIndex = Integer.parseInt(matchSeq.substring(1, matchSeq.length()));
-                } catch (NumberFormatException e) {
-                    argIndex = Integer.parseInt(matchSeq.substring(2, matchSeq.length()-1));
-                }
-                replacement = argValues[argIndex-1];
-                replacementEntry =  replacement.entrySet().iterator().next();
-                if(mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(XML_TYPE)) {
-                    // XML to JSON conversion here
-                    try {
-                        replacementValue = "<jsonObject>" + replacementEntry.getKey() + "</jsonObject>";
-                        OMElement omXML = convertStringToOM(replacementValue);
-                        replacementValue = JsonUtil.toJsonString(omXML).toString();
-                        replacementValue = escapeSpecialCharactersOfJson(replacementValue);
-                    } catch (XMLStreamException e) {
-                        handleException("Error parsing XML for JSON conversion, please check your xPath expressions return valid XML: ", synCtx);
-                    } catch (AxisFault e) {
-                        handleException("Error converting XML to JSON", synCtx);
-                    } catch (OMException e) {
-                        //if the logic comes to this means, it was tried as a XML, which means it has
-                        // "<" as starting element and ">" as end element, so basically if the logic comes here, that means
-                        //value is a string value, that means No conversion required, as path evaluates to regular String.
-                        replacementValue = replacementEntry.getKey();
-
-                        // This is to replace " with \" and \\ with \\\\
-                        //replacing other json special characters i.e \b, \f, \n \r, \t
-                        replacementValue = escapeSpecialChars(replacementValue);
-
-                    }
-                } else if(mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) {
-                    // JSON to XML conversion here
-                    try {
-                        replacementValue = replacementEntry.getKey();
-                        replacementValue = escapeSpecialCharactersOfXml(replacementValue);
-                        OMElement omXML = JsonUtil.toXml(IOUtils.toInputStream(replacementValue), false);
-                        if (JsonUtil.isAJsonPayloadElement(omXML)) { // remove <jsonObject/> from result.
-                            Iterator children = omXML.getChildElements();
-                            String childrenStr = "";
-                            while (children.hasNext()) {
-                                childrenStr += (children.next()).toString().trim();
-                            }
-                            replacementValue = childrenStr;
-                        } else { ///~
-                            replacementValue = omXML.toString();
-                        }
-                        //replacementValue = omXML.toString();
-                    } catch (AxisFault e) {
-                        handleException("Error converting JSON to XML, please check your JSON Path expressions return valid JSON: ", synCtx);
-                    }
-                } else {
-                    // No conversion required, as path evaluates to regular String.
-                    replacementValue = replacementEntry.getKey();
-                    String trimmedReplacementValue = replacementValue.trim();
-                    //If media type is xml and replacement value is json convert it to xml format prior to replacement
-                    if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE)
-                            && isJson(trimmedReplacementValue)) {
-                        try {
-                            replacementValue = escapeSpecialCharactersOfXml(replacementValue);
-                            OMElement omXML = JsonUtil.toXml(IOUtils.toInputStream(replacementValue), false);
-                            if (JsonUtil.isAJsonPayloadElement(omXML)) { // remove <jsonObject/> from result.
-                                Iterator children = omXML.getChildElements();
-                                String childrenStr = "";
-                                while (children.hasNext()) {
-                                    childrenStr += (children.next()).toString().trim();
-                                }
-                                replacementValue = childrenStr;
-                            } else {
-                                replacementValue = omXML.toString();
-                            }
-                        } catch (AxisFault e) {
-                            handleException("Error converting JSON to XML, please check your JSON Path expressions"
-                                    + " return valid JSON: ", synCtx);
-                        }
-                    } else if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE) &&
-                            isEscapeXmlChars()) {
-                        //checks whether the escapeXmlChars attribute is true when media-type and evaluator is json and
-                        //escapes xml chars. otherwise json messages with non escaped xml characters will fail to build
-                        //in content aware mediators.
-                        replacementValue = escapeXMLSpecialChars(replacementValue);
-                    }
-                    else if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE) &&
-                            (!trimmedReplacementValue.startsWith("{") && !trimmedReplacementValue.startsWith("["))) {
-                        replacementValue = escapeSpecialChars(replacementValue);
-                        // Check for following property which will force the string to include quotes
-                        Object force_string_quote = synCtx.getProperty(QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON);
-                        // skip double quotes if replacement is boolean or null or valid json number
-                        if (force_string_quote != null && ((String) force_string_quote).equalsIgnoreCase("true")
-                                && !trimmedReplacementValue.equals("true") && !trimmedReplacementValue.equals("false")
-                                && !trimmedReplacementValue.equals("null")
-                                && !validJsonNumber.matcher(trimmedReplacementValue).matches()) {
-                            replacementValue = "\"" + replacementValue + "\"";
-                        }
-                    }
-                    else if ((mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) &&
-                            (!trimmedReplacementValue.startsWith("{") && !trimmedReplacementValue.startsWith("["))) {
-                        // This is to handle only the string value
-                        replacementValue = replacementValue.replaceAll("\"", ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES);
-                    }
-                }
-                matcher.appendReplacement(result, replacementValue);
-            }
-        } catch (ArrayIndexOutOfBoundsException e) {
-            log.error("#replace. Mis-match detected between number of formatters and arguments", e);
-        }
-        matcher.appendTail(result);
-    }
-
-    /**
-     * Helper method to replace required char values with escape characters.
-     *
-     * @param replaceString
-     * @return replacedString
-     */
-    private String escapeSpecialChars(String replaceString) {
-        return replaceString.replaceAll(Matcher.quoteReplacement("\\\\"), ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES)
-                .replaceAll("\"", ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
-                .replaceAll("\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
-    }
-
-    /**
-     * Helper method to replace required char values with escape characters for XML.
-     *
-     * @param replaceString
-     * @return replacedString
-     */
-    private String escapeXMLSpecialChars(String replaceString) {
-        return replaceString.replaceAll("\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
-                .replaceAll("\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
-    }
-
-    /**
-     * Helper function that takes a Map of String, ArgumentDetails where key contains the value of an evaluated SynapsePath
-     * expression and value contains the type of SynapsePath + deepcheck status in use.
-     *
-     * It returns the type of conversion required (XML | JSON | String) based on the actual returned value and the path
-     * type.
-     *
-     * @param entry
-     * @return
-     */
-    private String inferReplacementType(Map.Entry<String, ArgumentDetails> entry) {
-        if (entry.getValue().isLiteral()){
-            return STRING_TYPE;
-        } else if (entry.getValue().getPathType().equals(SynapsePath.X_PATH)
-           && entry.getValue().isXml()) {
-            return XML_TYPE;
-        } else if(entry.getValue().getPathType().equals(SynapsePath.X_PATH)
-                  && !entry.getValue().isXml()) {
-            return STRING_TYPE;
-        } else if(entry.getValue().getPathType().equals(SynapsePath.JSON_PATH)
-                  && isJson(entry.getKey())) {
-            return JSON_TYPE;
-        } else if(entry.getValue().getPathType().equals(SynapsePath.JSON_PATH)
-                  && !isJson((entry.getKey()))) {
-            return STRING_TYPE;
-        } else {
-            return STRING_TYPE;
-        }
-    }
-
     private boolean checkAndReplaceEnvelope(OMElement resultElement, MessageContext synCtx) {
+
         OMElement firstChild = resultElement.getFirstElement();
         QName resultQName = firstChild.getQName();
         if (resultQName.getLocalPart().equals("Envelope") && (
@@ -479,27 +249,12 @@ public class PayloadFactoryMediator extends AbstractMediator {
     }
 
     /**
-     * Helper function that returns true if value passed is of JSON type.
-     * @param value
-     * @return
-     */
-    private boolean isJson(String value) {
-        return !(value == null || value.trim().isEmpty()) && (value.trim().charAt(0) == '{' || value.trim().charAt(0) == '[');
-    }
-
-    /**
-     * Helper function that returns true if value passed is of JSON type and expression is JSON.
-     */
-    private boolean isJson(String value, SynapsePath expression) {
-        return !(value == null || value.trim().isEmpty()) && (value.trim().charAt(0) == '{'
-                || value.trim().charAt(0) == '[') && expression.getPathType().equals(SynapsePath.JSON_PATH);
-    }
-
-    /**
      * Helper function to remove indentations.
+     *
      * @param element
      */
     private void removeIndentations(OMElement element) {
+
         List<OMText> removables = new ArrayList<OMText>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
@@ -509,10 +264,12 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     /**
      * Helper function to remove indentations.
+     *
      * @param element
      * @param removables
      */
     private void removeIndentations(OMElement element, List<OMText> removables) {
+
         Iterator children = element.getChildren();
         while (children.hasNext()) {
             Object next = children.next();
@@ -527,103 +284,34 @@ public class PayloadFactoryMediator extends AbstractMediator {
         }
     }
 
-    /**
-     * Goes through SynapsePath argument list, evaluating each by calling stringValueOf and returns a HashMap String, String
-     * array where each item will contain a hash map with key "evaluated expression" and value "SynapsePath type".
-     * @param synCtx
-     * @return
-     */
-    private HashMap<String, ArgumentDetails>[] getArgValues(MessageContext synCtx) {
-        HashMap<String, ArgumentDetails>[] argValues = new HashMap[pathArgumentList.size()];
-        HashMap<String, ArgumentDetails> valueMap;
-        String value = "";
-        for (int i = 0; i < pathArgumentList.size(); ++i) {       /*ToDo use foreach*/
-            Argument arg = pathArgumentList.get(i);
-            ArgumentDetails details = new ArgumentDetails();
-            if (arg.getValue() != null) {
-                value = arg.getValue();
-                details.setXml(isXML(value));
-                if (!details.isXml()) {
-                    value = escapeXMLEnvelope(synCtx, value);
-                }
-                value = Matcher.quoteReplacement(value);
-            } else if (arg.getExpression() != null) {
-                value = arg.getExpression().stringValueOf(synCtx);
-                details.setLiteral(arg.isLiteral());
-                if (value != null) {
-                    // XML escape the result of an expression that produces a literal, if the target format
-                    // of the payload is XML.
-                    details.setXml(isXML(value));
-                    if (!details.isXml() && XML_TYPE.equals(getType()) && !isJson(value.trim(), arg.getExpression())) {
-                        value = escapeXMLEnvelope(synCtx, value);
-                    }
-                    value = Matcher.quoteReplacement(value);
-                } else {
-                    value = "";
-                }
-            } else {
-                handleException("Unexpected arg type detected", synCtx);
-            }
-            //value = value.replace(String.valueOf((char) 160), " ").trim();
-            valueMap = new HashMap<String, ArgumentDetails>();
-            if (null != arg.getExpression()) {
-                details.setPathType(arg.getExpression().getPathType());
-                valueMap.put(value, details);
-            } else {
-                details.setPathType(SynapsePath.X_PATH);
-                valueMap.put(value, details);
-            }
-            argValues[i] = valueMap;
-        }
-        return argValues;
-    }
-
     public String getFormat() {
+
         return formatRaw;
     }
 
     public void setFormat(String format) {
+
         this.formatRaw = format;
     }
 
-    public void addPathArgument(Argument arg) {
-        pathArgumentList.add(arg);
-    }
-
-    public List<Argument> getPathArgumentList() {
-        return pathArgumentList;
-    }
-
-    /**
-     * Helper function that returns true if value passed is of XML Type.
-     *
-     * @param value
-     * @return
-     */
-    private boolean isXML(String value) {
-        try {
-            value = value.trim();
-            if (!value.endsWith(">") || value.length() < 4) {
-                return false;
-            }
-            // validate xml
-            convertStringToOM(value);
-            return true;
-        } catch (XMLStreamException ignore) {
-            // means not a xml
-            return false;
-        } catch (OMException ignore) {
-            // means not a xml
-            return false;
-        }
-    }
-
     public String getType() {
+
         return mediaType;
     }
 
     public void setType(String type) {
+
         this.mediaType = type;
+    }
+
+    public String getTemplateType() {
+
+        return templateType;
+    }
+
+    public void setTemplateType(String templateType) {
+
+        this.templateType = templateType;
     }
 
     /**
@@ -632,6 +320,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @return return the key which is used to pick the format definition from the local registry
      */
     public Value getFormatKey() {
+
         return formatKey;
     }
 
@@ -641,44 +330,27 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @param key the local registry key
      */
     public void setFormatKey(Value key) {
+
         this.formatKey = key;
     }
 
-    public void setFormatDynamic(boolean formatDynamic) {
-        this.isFormatDynamic = formatDynamic;
-    }
-
     public boolean isFormatDynamic() {
+
         return isFormatDynamic;
     }
 
-    private boolean isDoingJson(MessageContext messageContext) {
-        return JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext());
-    }
+    public void setFormatDynamic(boolean formatDynamic) {
 
-    private boolean isDoingXml(MessageContext messageContext) {
-        return !isDoingJson(messageContext);
-    }
-
-	public String getInputType() {
-        if(pathArgumentList.size()>0) {
-            Object argument = pathArgumentList.get(0);
-            if (argument != null && argument instanceof SynapseXPath) {
-                return XML_TYPE;
-            }
-            else if (argument != null && argument instanceof SynapseJsonPath) {
-                return JSON_TYPE;
-            }
-        }
-        return null;
+        this.isFormatDynamic = formatDynamic;
     }
 
     public String getOutputType() {
+
         return mediaType;
     }
 
-
     private OMElement getTextElement(String content) {
+
         OMFactory factory = OMAbstractFactory.getOMFactory();
         OMElement textElement = factory.createOMElement(TEXT_ELEMENT);
         if (content == null) {
@@ -690,59 +362,17 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     @Override
     public boolean isContentAltering() {
+
         return true;
     }
 
-    /**
-     * Checks and returns XML version of the envelope
-     *
-     * @param msgCtx Message Context
-     * @return xmlVersion in XML Declaration
-     * @throws ParserConfigurationException failure in building message envelope document
-     * @throws IOException Error reading message envelope
-     * @throws SAXException Error parsing message envelope
-     */
-    private String checkXMLVersion(MessageContext msgCtx) throws IOException, SAXException, ParserConfigurationException {
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        InputSource inputSource = new InputSource(new StringReader(msgCtx.getEnvelope().toString()));
-        Document document = documentBuilder.parse(inputSource);
-        return document.getXmlVersion();
-    }
-
-    /**
-     * Escapes XML special characters
-     *
-     * @param msgCtx Message Context
-     * @param value XML String which needs to be escaped
-     * @return XML special char escaped string
-     */
-    private String escapeXMLEnvelope(MessageContext msgCtx, String value) {
-        String xmlVersion = "1.0"; //Default is set to 1.0
-
-        try {
-            xmlVersion = checkXMLVersion(msgCtx);
-        } catch (IOException e) {
-            log.error("Error reading message envelope", e);
-        } catch (SAXException e) {
-            log.error("Error parsing message envelope", e);
-        } catch (ParserConfigurationException e) {
-            log.error("Error building message envelope document", e);
-        }
-
-        if("1.1".equals(xmlVersion)) {
-            return org.apache.commons.text.StringEscapeUtils.escapeXml11(value);
-        } else {
-            return org.apache.commons.text.StringEscapeUtils.escapeXml10(value);
-        }
-
-    }
-
     public boolean isEscapeXmlChars() {
+
         return escapeXmlChars;
     }
 
     public void setEscapeXmlChars(boolean escapeXmlChars) {
+
         this.escapeXmlChars = escapeXmlChars;
     }
 
@@ -753,8 +383,29 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @return parsed OMElement
      */
     private OMElement convertStringToOM(String value) throws XMLStreamException, OMException {
+
         javax.xml.stream.XMLStreamReader xmlReader = inputFactory.createXMLStreamReader(new StringReader(value));
         StAXBuilder builder = new StAXOMBuilder(xmlReader);
         return builder.getDocumentElement();
+    }
+
+    public TemplateProcessor getTemplateProcessor() {
+
+        return templateProcessor;
+    }
+
+    public void setTemplateProcessor(TemplateProcessor templateProcessor) {
+
+        this.templateProcessor = templateProcessor;
+    }
+
+    private boolean isDoingJson(MessageContext messageContext) {
+
+        return JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext());
+    }
+
+    private boolean isDoingXml(MessageContext messageContext) {
+
+        return !isDoingJson(messageContext);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -59,7 +59,6 @@ import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_TYPE
 import static org.apache.synapse.mediators.transform.pfutils.Constants.XML_TYPE;
 
 public class PayloadFactoryMediator extends AbstractMediator {
-
     private Value formatKey = null;
     private boolean isFormatDynamic = false;
     private String formatRaw;
@@ -85,7 +84,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
     /**
      * Contains 2 paths - one when JSON Streaming is in use (mediateJsonStreamPayload) and the other for regular
      * builders (mediatePayload).
-     *
      * @param synCtx the current message for mediation
      * @return
      */
@@ -105,8 +103,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
             log.error("#mediate. Could not identify the payload format of the existing payload prior to mediate.");
             return false;
         }
-        org.apache.axis2.context.MessageContext axis2MessageContext =
-                ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
         StringBuilder result = new StringBuilder();
         transform(result, synCtx, format);
         String out = result.toString().trim();
@@ -117,24 +114,23 @@ public class PayloadFactoryMediator extends AbstractMediator {
             try {
                 JsonUtil.removeJsonPayload(axis2MessageContext);
                 OMElement omXML = convertStringToOM(out);
-                if (!checkAndReplaceEnvelope(omXML,
-                        synCtx)) { // check if the target of the PF 'format' is the entire SOAP envelop, not just the body.
+                if (!checkAndReplaceEnvelope(omXML, synCtx)) { // check if the target of the PF 'format' is the entire SOAP envelop, not just the body.
                     axis2MessageContext.getEnvelope().getBody().addChild(omXML.getFirstElement());
                 }
             } catch (XMLStreamException e) {
                 handleException("Error creating SOAP Envelope from source " + out, synCtx);
             }
-        } else if (mediaType.equals(JSON_TYPE)) {
+        } else if  (mediaType.equals(JSON_TYPE)) {
             try {
                 JsonUtil.getNewJsonPayload(axis2MessageContext, out, true, true);
             } catch (AxisFault axisFault) {
                 handleException("Error creating JSON Payload from source " + out, synCtx);
             }
-        } else if (mediaType.equals(TEXT_TYPE)) {
+        } else if  (mediaType.equals(TEXT_TYPE)) {
             JsonUtil.removeJsonPayload(axis2MessageContext);
             axis2MessageContext.getEnvelope().getBody().addChild(getTextElement(out));
         }
-        //need to honour a content-type of the payload media-type as output from the payload
+        //need to honour a content-type of the payload media-type as output from the payload 
         //{re-merging patch https://wso2.org/jira/browse/ESBJAVA-3014}
         setContentType(synCtx);
         return true;
@@ -149,7 +145,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @param format
      */
     private void transform(StringBuilder result, MessageContext synCtx, String format) {
-
         if (isFormatDynamic()) {
             String key = formatKey.evaluateValue(synCtx);
             Object entry = synCtx.getEntry(key);
@@ -224,7 +219,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
     }
 
     private boolean checkAndReplaceEnvelope(OMElement resultElement, MessageContext synCtx) {
-
         OMElement firstChild = resultElement.getFirstElement();
         QName resultQName = firstChild.getQName();
         if (resultQName.getLocalPart().equals("Envelope") && (
@@ -248,11 +242,9 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     /**
      * Helper function to remove indentations.
-     *
      * @param element
      */
     private void removeIndentations(OMElement element) {
-
         List<OMText> removables = new ArrayList<>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
@@ -262,12 +254,10 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     /**
      * Helper function to remove indentations.
-     *
      * @param element
      * @param removables
      */
     private void removeIndentations(OMElement element, List<OMText> removables) {
-
         Iterator children = element.getChildren();
         while (children.hasNext()) {
             Object next = children.next();
@@ -283,23 +273,19 @@ public class PayloadFactoryMediator extends AbstractMediator {
     }
 
     public String getFormat() {
-
         return formatRaw;
     }
 
     public void setFormat(String format) {
-
         this.formatRaw = format;
     }
 
     @Override
     public String getType() {
-
         return mediaType;
     }
 
     public void setType(String type) {
-
         this.mediaType = type;
     }
 
@@ -319,7 +305,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @return return the key which is used to pick the format definition from the local registry
      */
     public Value getFormatKey() {
-
         return formatKey;
     }
 
@@ -329,7 +314,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @param key the local registry key
      */
     public void setFormatKey(Value key) {
-
         this.formatKey = key;
     }
 
@@ -339,18 +323,16 @@ public class PayloadFactoryMediator extends AbstractMediator {
     }
 
     public void setFormatDynamic(boolean formatDynamic) {
-
         this.isFormatDynamic = formatDynamic;
     }
 
     @Override
     public String getOutputType() {
-
         return mediaType;
     }
 
-    private OMElement getTextElement(String content) {
 
+    private OMElement getTextElement(String content) {
         OMFactory factory = OMAbstractFactory.getOMFactory();
         OMElement textElement = factory.createOMElement(TEXT_ELEMENT);
         if (content == null) {
@@ -362,17 +344,14 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     @Override
     public boolean isContentAltering() {
-
         return true;
     }
 
     public boolean isEscapeXmlChars() {
-
         return escapeXmlChars;
     }
 
     public void setEscapeXmlChars(boolean escapeXmlChars) {
-
         this.escapeXmlChars = escapeXmlChars;
     }
 
@@ -383,7 +362,6 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @return parsed OMElement
      */
     private OMElement convertStringToOM(String value) throws XMLStreamException, OMException {
-
         javax.xml.stream.XMLStreamReader xmlReader = inputFactory.createXMLStreamReader(new StringReader(value));
         StAXBuilder builder = new StAXOMBuilder(xmlReader);
         return builder.getDocumentElement();

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -166,16 +166,16 @@ public class PayloadFactoryMediator extends AbstractMediator {
             } else if (entry instanceof String) {
                 text = (String) entry;
             }
-            processTemplate(result, synCtx, text, isFormatDynamic());
+            processTemplate(result, synCtx, text);
         } else {
-            processTemplate(result, synCtx, format, isFormatDynamic());
+            processTemplate(result, synCtx, format);
         }
     }
 
-    private void processTemplate(StringBuilder result, MessageContext synCtx, String text, boolean isFormatDynamic) {
+    private void processTemplate(StringBuilder result, MessageContext synCtx, String text) {
 
         try {
-            result.append(templateProcessor.processTemplate(text, mediaType, synCtx, isFormatDynamic));
+            result.append(templateProcessor.processTemplate(text, mediaType, synCtx));
         } catch (TemplateProcessorException e) {
             handleException(e.getMessage(), synCtx);
         }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -64,15 +64,15 @@ public class PayloadFactoryMediator extends AbstractMediator {
     private boolean isFormatDynamic = false;
     private String formatRaw;
     private String mediaType = XML_TYPE;
-    private final static String XML_CONTENT_TYPE = "application/xml";
+    private static final String XML_CONTENT_TYPE = "application/xml";
     private boolean escapeXmlChars = false;
     private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-    private final static String JSON_CONTENT_TYPE = "application/json";
-    private final static String TEXT_CONTENT_TYPE = "text/plain";
-    private final static String SOAP11_CONTENT_TYPE = "text/xml";
-    private final static String SOAP12_CONTENT_TYPE = "application/soap+xml";
+    private static final String JSON_CONTENT_TYPE = "application/json";
+    private static final String TEXT_CONTENT_TYPE = "text/plain";
+    private static final String SOAP11_CONTENT_TYPE = "text/xml";
+    private static final String SOAP12_CONTENT_TYPE = "application/soap+xml";
     private String templateType = REGEX_TEMPLATE_TYPE;
-    private final static QName TEXT_ELEMENT = new QName("http://ws.apache.org/commons/ns/payload", "text");
+    private static final QName TEXT_ELEMENT = new QName("http://ws.apache.org/commons/ns/payload", "text");
     public static final String QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON = "QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON";
     private TemplateProcessor templateProcessor;
     private static final Log log = LogFactory.getLog(PayloadFactoryMediator.class);
@@ -91,10 +91,8 @@ public class PayloadFactoryMediator extends AbstractMediator {
      */
     public boolean mediate(MessageContext synCtx) {
 
-        if (synCtx.getEnvironment().isDebuggerEnabled()) {
-            if (super.divertMediationRoute(synCtx)) {
-                return true;
-            }
+        if (synCtx.getEnvironment().isDebuggerEnabled() && super.divertMediationRoute(synCtx)) {
+            return true;
         }
 
         String format = formatRaw;
@@ -109,7 +107,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
         }
         org.apache.axis2.context.MessageContext axis2MessageContext =
                 ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         transform(result, synCtx, format);
         String out = result.toString().trim();
         if (log.isDebugEnabled()) {
@@ -150,7 +148,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @param synCtx
      * @param format
      */
-    private void transform(StringBuffer result, MessageContext synCtx, String format) {
+    private void transform(StringBuilder result, MessageContext synCtx, String format) {
 
         if (isFormatDynamic()) {
             String key = formatKey.evaluateValue(synCtx);
@@ -174,7 +172,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
         }
     }
 
-    private void processTemplate(StringBuffer result, MessageContext synCtx, String text, boolean isFormatDynamic) {
+    private void processTemplate(StringBuilder result, MessageContext synCtx, String text, boolean isFormatDynamic) {
 
         try {
             result.append(templateProcessor.processTemplate(text, mediaType, synCtx, isFormatDynamic));
@@ -255,7 +253,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
      */
     private void removeIndentations(OMElement element) {
 
-        List<OMText> removables = new ArrayList<OMText>();
+        List<OMText> removables = new ArrayList<>();
         removeIndentations(element, removables);
         for (OMText node : removables) {
             node.detach();
@@ -294,6 +292,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
         this.formatRaw = format;
     }
 
+    @Override
     public String getType() {
 
         return mediaType;
@@ -344,6 +343,7 @@ public class PayloadFactoryMediator extends AbstractMediator {
         this.isFormatDynamic = formatDynamic;
     }
 
+    @Override
     public String getOutputType() {
 
         return mediaType;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
@@ -19,6 +19,9 @@
 
 package org.apache.synapse.mediators.transform.pfutils;
 
+/**
+ * Constants to use by the PayloadFactory mediator
+ */
 public class Constants {
 
     private Constants() {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
@@ -29,7 +29,7 @@ public class Constants {
     public static final int JSON_PAYLOAD_TYPE = 1;
     public static final int TEXT_PAYLOAD_TYPE = 2;
     public static final int NOT_SUPPORTING_PAYLOAD_TYPE = -1;
-    public static final String REGEX_TEMPLATE_TYPE = "REGEX";
+    public static final String REGEX_TEMPLATE_TYPE = "DEFAULT";
     public static final String FREEMARKER_TEMPLATE_TYPE = "FREEMARKER";
     public static final String PAYLOAD_INJECTING_NAME = "payload";
     public static final String ARGS_INJECTING_NAME = "args";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.transform.pfutils;
+
+public class Constants {
+
+    public final static int XML_PAYLOAD_TYPE = 0;
+    public final static int JSON_PAYLOAD_TYPE = 1;
+    public final static int TEXT_PAYLOAD_TYPE = 2;
+    public final static int NOT_SUPPORTING_PAYLOAD_TYPE = -1;
+
+    public final static String REGEX_TEMPLATE_TYPE = "REGEX";
+    public final static String FREEMARKER_TEMPLATE_TYPE = "FREEMARKER";
+
+    public final static String PAYLOAD_INJECTING_NAME = "payload";
+    public final static String ARGS_INJECTING_NAME = "args";
+    public final static String ARGS_INJECTING_PREFIX = "arg";
+    public final static String CTX_PROPERTY_INJECTING_NAME = "ctx";
+    public final static String AXIS2_PROPERTY_INJECTING_NAME = "axis2";
+    public final static String TRANSPORT_PROPERTY_INJECTING_NAME = "trp";
+
+    public static final String JSON_TYPE = "json";
+    public static final String XML_TYPE = "xml";
+    public static final String TEXT_TYPE = "text";
+
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
@@ -21,21 +21,22 @@ package org.apache.synapse.mediators.transform.pfutils;
 
 public class Constants {
 
-    public final static int XML_PAYLOAD_TYPE = 0;
-    public final static int JSON_PAYLOAD_TYPE = 1;
-    public final static int TEXT_PAYLOAD_TYPE = 2;
-    public final static int NOT_SUPPORTING_PAYLOAD_TYPE = -1;
+    private Constants() {
 
-    public final static String REGEX_TEMPLATE_TYPE = "REGEX";
-    public final static String FREEMARKER_TEMPLATE_TYPE = "FREEMARKER";
+    }
 
-    public final static String PAYLOAD_INJECTING_NAME = "payload";
-    public final static String ARGS_INJECTING_NAME = "args";
-    public final static String ARGS_INJECTING_PREFIX = "arg";
-    public final static String CTX_PROPERTY_INJECTING_NAME = "ctx";
-    public final static String AXIS2_PROPERTY_INJECTING_NAME = "axis2";
-    public final static String TRANSPORT_PROPERTY_INJECTING_NAME = "trp";
-
+    public static final int XML_PAYLOAD_TYPE = 0;
+    public static final int JSON_PAYLOAD_TYPE = 1;
+    public static final int TEXT_PAYLOAD_TYPE = 2;
+    public static final int NOT_SUPPORTING_PAYLOAD_TYPE = -1;
+    public static final String REGEX_TEMPLATE_TYPE = "REGEX";
+    public static final String FREEMARKER_TEMPLATE_TYPE = "FREEMARKER";
+    public static final String PAYLOAD_INJECTING_NAME = "payload";
+    public static final String ARGS_INJECTING_NAME = "args";
+    public static final String ARGS_INJECTING_PREFIX = "arg";
+    public static final String CTX_PROPERTY_INJECTING_NAME = "ctx";
+    public static final String AXIS2_PROPERTY_INJECTING_NAME = "axis2";
+    public static final String TRANSPORT_PROPERTY_INJECTING_NAME = "trp";
     public static final String JSON_TYPE = "json";
     public static final String XML_TYPE = "xml";
     public static final String TEXT_TYPE = "text";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/Constants.java
@@ -1,21 +1,21 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
  */
+
 
 package org.apache.synapse.mediators.transform.pfutils;
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -1,0 +1,353 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.transform.pfutils;
+
+import com.google.gson.Gson;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
+import org.apache.axiom.om.OMText;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.transform.ArgumentDetails;
+import org.apache.synapse.util.PayloadHelper;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import static org.apache.synapse.mediators.transform.pfutils.Constants.ARGS_INJECTING_NAME;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.ARGS_INJECTING_PREFIX;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.AXIS2_PROPERTY_INJECTING_NAME;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.CTX_PROPERTY_INJECTING_NAME;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.JSON_PAYLOAD_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.NOT_SUPPORTING_PAYLOAD_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.PAYLOAD_INJECTING_NAME;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.TEXT_PAYLOAD_TYPE;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.TRANSPORT_PROPERTY_INJECTING_NAME;
+import static org.apache.synapse.mediators.transform.pfutils.Constants.XML_PAYLOAD_TYPE;
+import static org.apache.synapse.util.PayloadHelper.TEXTELT;
+import static org.apache.synapse.util.PayloadHelper.getXMLPayload;
+
+public class FreeMarkerTemplateProcessor extends TemplateProcessor {
+
+    private final Configuration cfg;
+    private final Gson gson;
+    private Template freeMarkerTemplate;
+
+    public FreeMarkerTemplateProcessor() {
+
+        cfg = new Configuration(Configuration.VERSION_2_3_30);
+        gson = new Gson();
+    }
+
+    @Override
+    public void executePreProcessing() {
+
+        compileFreeMarkerTemplate(getFormat(), getMediaType());
+    }
+
+    @Override
+    public String processTemplate(String templateString, String mediaType, MessageContext messageContext,
+                                  boolean isFormatDynamic) {
+
+        try {
+            if (isFormatDynamic) {
+                compileFreeMarkerTemplate(templateString, mediaType);
+            }
+
+            Map<String, Object> data = new HashMap<>();
+            int payloadType = getPayloadType(messageContext);
+            injectPayloadVariables(messageContext, payloadType, data);
+            injectArgs(messageContext, mediaType, data);
+            injectProperties(messageContext, data);
+
+            Writer out = new StringWriter();
+            freeMarkerTemplate.process(data, out);
+            return out.toString();
+        } catch (IOException | TemplateException e) {
+            handleException("Error parsing FreeMarking template");
+        } catch (SAXException | ParserConfigurationException e) {
+            handleException("Error reading payload data");
+        }
+
+        return "";
+    }
+
+    private void compileFreeMarkerTemplate(String templateString, String mediaType) {
+
+        try {
+            if (XML_TYPE.equals(mediaType)) {
+                templateString = "<pfPadding>" + templateString + "</pfPadding>";
+            }
+
+            freeMarkerTemplate = new Template("synapse-template", templateString, cfg);
+        } catch (IOException e) {
+            handleException("Error parsing FreeMarking template");
+        }
+    }
+
+    /**
+     * Inject argument values to freemarker
+     *
+     * @param messageContext Message context
+     * @param mediaType      Output media type
+     * @param data           Freemarker data input
+     */
+    private void injectArgs(MessageContext messageContext, String mediaType, Map<String, Object> data) {
+
+        HashMap<String, Object> argsValues = new HashMap<>();
+        HashMap<String, ArgumentDetails>[] argValues = getArgValues(mediaType, messageContext);
+        for (int i = 0; i < argValues.length; i++) {
+            HashMap<String, ArgumentDetails> argValue = argValues[i];
+            Map.Entry<String, ArgumentDetails> argumentDetailsEntry = argValue.entrySet().iterator().next();
+            String replacementValue = prepareReplacementValue(mediaType, messageContext, argumentDetailsEntry);
+            argsValues.put(ARGS_INJECTING_PREFIX + (i + 1), replacementValue);
+        }
+        data.put(ARGS_INJECTING_NAME, argsValues);
+    }
+
+    /**
+     * Inject  payload in to FreeMarker
+     *
+     * @param messageContext MessageContext
+     * @param payloadType    Input payload type
+     * @param data           FreeMarker data input
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    private void injectPayloadVariables(MessageContext messageContext, int payloadType, Map<String, Object> data)
+            throws SAXException, IOException, ParserConfigurationException {
+
+        if (payloadType == XML_PAYLOAD_TYPE) {
+            injectXmlPayload(messageContext, data);
+        } else if (payloadType == JSON_PAYLOAD_TYPE) {
+            injectJsonPayload((Axis2MessageContext) messageContext, data);
+        } else if (payloadType == TEXT_PAYLOAD_TYPE) {
+            injectTextPayload(messageContext, data);
+        }
+    }
+
+    /**
+     * Inject a JSON payload in the FreeMarker
+     *
+     * @param messageContext Message context
+     * @param data           FreeMarker data input
+     */
+    private void injectJsonPayload(Axis2MessageContext messageContext, Map<String, Object> data) {
+
+        org.apache.axis2.context.MessageContext axis2MessageContext = messageContext.getAxis2MessageContext();
+        String jsonPayloadString = JsonUtil.jsonPayloadToString(axis2MessageContext);
+        if (JsonUtil.hasAJsonObject(axis2MessageContext)) {
+            injectJsonObject(data, jsonPayloadString);
+        } else {
+            injectJsonArray(data, jsonPayloadString);
+        }
+    }
+
+    /**
+     * Inject a JSON array in to FreeMarker
+     *
+     * @param data              FreeMarker data input
+     * @param jsonPayloadString JSON payload string
+     */
+    private void injectJsonArray(Map<String, Object> data, String jsonPayloadString) {
+
+        List<Object> array = new ArrayList<>();
+        array = gson.fromJson(jsonPayloadString, array.getClass());
+        data.put(PAYLOAD_INJECTING_NAME, array);
+    }
+
+    /**
+     * Inject a JSON object in to FreeMarker
+     *
+     * @param data              FreeMarker data input
+     * @param jsonPayloadString JSON payload string
+     */
+    private void injectJsonObject(Map<String, Object> data, String jsonPayloadString) {
+
+        Map<String, Object> map = new HashMap<>();
+        map = (Map<String, Object>) gson.fromJson(jsonPayloadString, map.getClass());
+        data.put(PAYLOAD_INJECTING_NAME, map);
+    }
+
+    /**
+     * Inject an XML payload in to FreeMarker
+     *
+     * @param messageContext Message context
+     * @param data           FreeMarker data input
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    private void injectXmlPayload(MessageContext messageContext, Map<String, Object> data)
+            throws SAXException, IOException, ParserConfigurationException {
+
+        data.put(PAYLOAD_INJECTING_NAME, freemarker.ext.dom.NodeModel.parse(
+                new InputSource(new StringReader(
+                        messageContext.getEnvelope().getBody().getFirstElement().toString()))));
+    }
+
+    /**
+     * Inject an Text payload in to FreeMarker
+     *
+     * @param messageContext Message context
+     * @param data           FreeMarker data input
+     */
+    private void injectTextPayload(MessageContext messageContext, Map<String, Object> data) {
+
+        String textPayload;
+        OMElement el = getXMLPayload(messageContext.getEnvelope());
+        if (el == null || !el.getQName().equals(TEXTELT)) {
+            textPayload = "";
+        } else {
+            textPayload = getTextValue(el);
+        }
+
+        data.put(PAYLOAD_INJECTING_NAME, textPayload);
+    }
+
+    /**
+     * Get text value from OMNode
+     *
+     * @param node OMNode to get text value
+     * @return text value of the node
+     */
+    private String getTextValue(OMNode node) {
+
+        switch (node.getType()) {
+            case OMNode.ELEMENT_NODE:
+                StringBuilder sb = new StringBuilder();
+                Iterator<OMNode> children = ((OMElement) node).getChildren();
+                while (children.hasNext()) {
+                    sb.append(getTextValue(children.next()));
+                }
+                return sb.toString();
+            case OMNode.TEXT_NODE:
+                String text = ((OMText) node).getText();
+                return StringEscapeUtils.escapeXml11(text);
+            default:
+                return "";
+        }
+    }
+
+    private void injectProperties(MessageContext synCtx, Map<String, Object> data) {
+
+        injectCtxProperties(synCtx, data);
+        injectAxis2Properties(synCtx, data);
+        injectTransportProperties(synCtx, data);
+    }
+
+    private void injectCtxProperties(MessageContext synCtx, Map<String, Object> data) {
+
+        Map<String, String> properties = new HashMap<>();
+        Set propertyKeys = synCtx.getPropertyKeySet();
+        for (Object propertyKey : propertyKeys) {
+            String propertyKeyString = propertyKey.toString();
+            Object propertyValue = synCtx.getProperty(propertyKeyString);
+            if (propertyValue != null) {
+                properties.put(propertyKeyString, propertyValue.toString());
+            }
+        }
+        data.put(CTX_PROPERTY_INJECTING_NAME, properties);
+    }
+
+    private void injectAxis2Properties(MessageContext synCtx, Map<String, Object> data) {
+
+        Map<String, String> properties = new HashMap<>();
+        org.apache.axis2.context.MessageContext axis2MessageContext
+                = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        Iterator<String> propertyNames = axis2MessageContext.getPropertyNames();
+        while (propertyNames.hasNext()) {
+            String propertyName = propertyNames.next();
+            Object propertyValue = axis2MessageContext.getProperty(propertyName);
+            if (propertyValue != null) {
+                properties.put(propertyName, propertyValue.toString());
+            }
+        }
+        data.put(AXIS2_PROPERTY_INJECTING_NAME, properties);
+    }
+
+    private void injectTransportProperties(MessageContext synCtx, Map<String, Object> data) {
+
+        Map<String, String> properties = new HashMap<>();
+        org.apache.axis2.context.MessageContext axis2MessageContext
+                = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        Object headers = axis2MessageContext.getProperty(
+                org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+        if (headers instanceof Map) {
+            Map headersMap = (Map) headers;
+            for (Object propertyKey : headersMap.keySet()) {
+                Object propertyValue = headersMap.get(propertyKey);
+                if (propertyValue != null) {
+                    properties.put(propertyKey.toString(), propertyValue.toString());
+                }
+            }
+        }
+        data.put(TRANSPORT_PROPERTY_INJECTING_NAME, properties);
+    }
+
+    /**
+     * Get the input payload type
+     *
+     * @param messageContext Message context
+     * @return Type of the input paylaod
+     */
+    private int getPayloadType(MessageContext messageContext) {
+
+        int payloadType = PayloadHelper.getPayloadType(messageContext);
+        if (payloadType == PayloadHelper.XMLPAYLOADTYPE) {
+            if (JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext())) {
+                return JSON_PAYLOAD_TYPE;
+            } else if (PayloadHelper.getTextPayload(messageContext) != null) {
+                return TEXT_PAYLOAD_TYPE;
+            } else {
+                return XML_PAYLOAD_TYPE;
+            }
+        } else if (payloadType == PayloadHelper.TEXTPAYLOADTYPE) {
+            return TEXT_PAYLOAD_TYPE;
+        } else {
+            handleException("Invalid payload type. Supports only XML, JSON and TEXT payloads");
+        }
+
+        return NOT_SUPPORTING_PAYLOAD_TYPE;
+    }
+
+    private boolean isTextPayload(MessageContext mc) {
+
+        return PayloadHelper.getTextPayload(mc) != null;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -21,7 +21,6 @@ package org.apache.synapse.mediators.transform.pfutils;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import freemarker.core.InvalidReferenceException;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -80,7 +79,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
         cfg = new Configuration(Configuration.VERSION_2_3_30);
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         cfg.setLogTemplateExceptions(false);
-        
+
         gson = new Gson();
     }
 
@@ -197,13 +196,11 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
                 injectJsonPayload((Axis2MessageContext) messageContext, data);
             } else if (payloadType == TEXT_PAYLOAD_TYPE) {
                 injectTextPayload(messageContext, data);
-            }else{
+            } else {
                 data.put(PAYLOAD_INJECTING_NAME, "");
             }
         }
     }
-
-
 
     /**
      * Inject a JSON payload in the FreeMarker
@@ -398,7 +395,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
         } catch (NullPointerException e) {
             return NOT_SUPPORTING_PAYLOAD_TYPE;
         }
-        
+
         if (payloadType == PayloadHelper.XMLPAYLOADTYPE) {
             if (JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext())) {
                 return JSON_PAYLOAD_TYPE;
@@ -409,7 +406,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
             }
         } else if (payloadType == PayloadHelper.TEXTPAYLOADTYPE) {
             return TEXT_PAYLOAD_TYPE;
-        } 
+        }
 
         return NOT_SUPPORTING_PAYLOAD_TYPE;
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -25,6 +25,7 @@ import freemarker.core.InvalidReferenceException;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMText;
@@ -77,6 +78,9 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     public FreeMarkerTemplateProcessor() {
 
         cfg = new Configuration(Configuration.VERSION_2_3_30);
+        cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        cfg.setLogTemplateExceptions(false);
+        
         gson = new Gson();
     }
 
@@ -118,15 +122,13 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
 
     private String generateTemplateErrorMessage(TemplateException e) {
 
-        StringBuilder errorMessage = new StringBuilder();
-        errorMessage.append("Error parsing FreeMarker template \n");
-        errorMessage.append("Syntax error or invalid reference : ");
-        errorMessage.append(e.getBlamedExpressionString());
-        errorMessage.append(" At line: ");
-        errorMessage.append(e.getLineNumber());
-        errorMessage.append(" column: ");
-        errorMessage.append(e.getColumnNumber());
-        return errorMessage.toString();
+        return "Error parsing FreeMarker template, " +
+                "Syntax error or invalid reference : " +
+                e.getBlamedExpressionString() +
+                " At line: " +
+                e.getLineNumber() +
+                " column: " +
+                e.getColumnNumber();
 
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -84,19 +84,15 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     }
 
     @Override
-    public void executePreProcessing() {
+    public void init() {
 
         compileFreeMarkerTemplate(getFormat(), getMediaType());
     }
 
     @Override
-    public String processTemplate(String templateString, String mediaType, MessageContext messageContext,
-                                  boolean isFormatDynamic) {
+    public String processTemplate( String template, String mediaType, MessageContext messageContext) {
 
         try {
-            if (isFormatDynamic) {
-                compileFreeMarkerTemplate(templateString, mediaType);
-            }
 
             Map<String, Object> data = new HashMap<>();
             int payloadType = getPayloadType(messageContext);
@@ -243,8 +239,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private void injectJsonObject(Map<String, Object> data, String jsonPayloadString) {
 
         Map<String, Object> map;
-        Type type = new TypeToken<Map<String, Object>>() {
-        }.getType();
+        Type type = new TypeToken<Map<String, Object>>() {}.getType();
         map = gson.fromJson(jsonPayloadString, type);
         data.put(PAYLOAD_INJECTING_NAME, map);
     }
@@ -409,10 +404,5 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
         }
 
         return NOT_SUPPORTING_PAYLOAD_TYPE;
-    }
-
-    private boolean isTextPayload(MessageContext mc) {
-
-        return PayloadHelper.getTextPayload(mc) != null;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -403,9 +403,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
         if (payloadType == PayloadHelper.XMLPAYLOADTYPE) {
             if (JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext())) {
                 return JSON_PAYLOAD_TYPE;
-            } else if (PayloadHelper.getTextPayload(messageContext) != null) {
-                return TEXT_PAYLOAD_TYPE;
-            } else {
+            }  else {
                 return XML_PAYLOAD_TYPE;
             }
         } else if (payloadType == PayloadHelper.TEXTPAYLOADTYPE) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -21,6 +21,7 @@ package org.apache.synapse.mediators.transform.pfutils;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import freemarker.core.InvalidReferenceException;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -194,9 +195,13 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
                 injectJsonPayload((Axis2MessageContext) messageContext, data);
             } else if (payloadType == TEXT_PAYLOAD_TYPE) {
                 injectTextPayload(messageContext, data);
+            }else{
+                data.put(PAYLOAD_INJECTING_NAME, "");
             }
         }
     }
+
+
 
     /**
      * Inject a JSON payload in the FreeMarker
@@ -385,7 +390,13 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
      */
     private int getPayloadType(MessageContext messageContext) {
 
-        int payloadType = PayloadHelper.getPayloadType(messageContext);
+        int payloadType = 0;
+        try {
+            payloadType = PayloadHelper.getPayloadType(messageContext);
+        } catch (NullPointerException e) {
+            return NOT_SUPPORTING_PAYLOAD_TYPE;
+        }
+        
         if (payloadType == PayloadHelper.XMLPAYLOADTYPE) {
             if (JsonUtil.hasAJsonPayload(((Axis2MessageContext) messageContext).getAxis2MessageContext())) {
                 return JSON_PAYLOAD_TYPE;
@@ -396,9 +407,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
             }
         } else if (payloadType == PayloadHelper.TEXTPAYLOADTYPE) {
             return TEXT_PAYLOAD_TYPE;
-        } else {
-            handleException("Invalid payload type. Supports only XML, JSON and TEXT payloads");
-        }
+        } 
 
         return NOT_SUPPORTING_PAYLOAD_TYPE;
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -1,21 +1,21 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
  */
+
 
 package org.apache.synapse.mediators.transform.pfutils;
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -28,6 +28,8 @@ import freemarker.template.TemplateExceptionHandler;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMText;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.commons.json.JsonUtil;
@@ -74,6 +76,8 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private boolean usingPropertyTransport;
     private boolean usingArgs;
 
+    private static final Log log = LogFactory.getLog(FreeMarkerTemplateProcessor.class);
+
     public FreeMarkerTemplateProcessor() {
 
         cfg = new Configuration(Configuration.VERSION_2_3_30);
@@ -90,7 +94,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     }
 
     @Override
-    public String processTemplate( String template, String mediaType, MessageContext messageContext) {
+    public String processTemplate(String template, String mediaType, MessageContext messageContext) {
 
         try {
 
@@ -117,13 +121,17 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
 
     private String generateTemplateErrorMessage(TemplateException e) {
 
-        return "Error parsing FreeMarker template, " +
-                "Syntax error or invalid reference : " +
-                e.getBlamedExpressionString() +
-                " At line: " +
-                e.getLineNumber() +
-                " column: " +
-                e.getColumnNumber();
+        if (log.isDebugEnabled()) {
+            return e.getMessageWithoutStackTop();
+        } else {
+            return "Error parsing FreeMarker template, " +
+                    "Syntax error or invalid reference : " +
+                    e.getBlamedExpressionString() +
+                    " At line: " +
+                    e.getLineNumber() +
+                    " column: " +
+                    e.getColumnNumber();
+        }
 
     }
 
@@ -239,7 +247,8 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private void injectJsonObject(Map<String, Object> data, String jsonPayloadString) {
 
         Map<String, Object> map;
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>() {
+        }.getType();
         map = gson.fromJson(jsonPayloadString, type);
         data.put(PAYLOAD_INJECTING_NAME, map);
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -35,7 +35,7 @@ public class RegexTemplateProcessor extends TemplateProcessor {
     private final Pattern pattern = Pattern.compile("\\$(\\d)+");
 
     @Override
-    public String processTemplate(String template, String mediaType, MessageContext synCtx, boolean isFormatDynamic) {
+    public String processTemplate(String template, String mediaType, MessageContext synCtx) {
 
         StringBuffer result = new StringBuffer();
         replace(template, result, mediaType, synCtx);
@@ -43,7 +43,7 @@ public class RegexTemplateProcessor extends TemplateProcessor {
     }
 
     @Override
-    public void executePreProcessing() {
+    public void init() {
         // nothing to do since no pre processing is needed
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -1,0 +1,97 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.transform.pfutils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.mediators.transform.ArgumentDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexTemplateProcessor extends TemplateProcessor {
+
+    private static final Log log = LogFactory.getLog(RegexTemplateProcessor.class);
+    private final Pattern pattern = Pattern.compile("\\$(\\d)+");
+
+    @Override
+    public String processTemplate(String template, String mediaType, MessageContext synCtx, boolean isFormatDynamic) {
+
+        StringBuffer result = new StringBuffer();
+        replace(template, result, mediaType, synCtx);
+        return result.toString();
+    }
+
+    @Override
+    public void executePreProcessing() {
+        // nothing to do since no pre processing is needed
+    }
+
+    /**
+     * Replaces the payload format with SynapsePath arguments which are evaluated using getArgValues().
+     *
+     * @param format
+     * @param result
+     * @param synCtx
+     */
+    private void replace(String format, StringBuffer result, String mediaType, MessageContext synCtx) {
+
+        HashMap<String, ArgumentDetails>[] argValues = getArgValues(mediaType, synCtx);
+        HashMap<String, ArgumentDetails> replacement;
+        Map.Entry<String, ArgumentDetails> replacementEntry;
+        String replacementValue;
+        Matcher matcher;
+
+        if (JSON_TYPE.equals(mediaType) || TEXT_TYPE.equals(mediaType)) {
+            matcher = pattern.matcher(format);
+        } else {
+            matcher = pattern.matcher("<pfPadding>" + format + "</pfPadding>");
+        }
+        try {
+            while (matcher.find()) {
+                String matchSeq = matcher.group();
+                replacement = getReplacementValue(argValues, matchSeq);
+                replacementEntry = replacement.entrySet().iterator().next();
+                replacementValue = prepareReplacementValue(mediaType, synCtx, replacementEntry);
+                matcher.appendReplacement(result, replacementValue);
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            log.error("#replace. Mis-match detected between number of formatters and arguments", e);
+        }
+        matcher.appendTail(result);
+    }
+
+    private HashMap<String, ArgumentDetails> getReplacementValue(HashMap<String, ArgumentDetails>[] argValues,
+                                                                 String matchSeq) {
+
+        HashMap<String, ArgumentDetails> replacement;
+        int argIndex;
+        try {
+            argIndex = Integer.parseInt(matchSeq.substring(1));
+        } catch (NumberFormatException e) {
+            argIndex = Integer.parseInt(matchSeq.substring(2, matchSeq.length() - 1));
+        }
+        replacement = argValues[argIndex - 1];
+        return replacement;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * TemplateProcessor implementation for Regex based templates
+ */
 public class RegexTemplateProcessor extends TemplateProcessor {
 
     private static final Log log = LogFactory.getLog(RegexTemplateProcessor.class);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -1,21 +1,21 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
  */
+
 
 package org.apache.synapse.mediators.transform.pfutils;
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -84,16 +84,14 @@ public abstract class TemplateProcessor {
      * @param template        Template string
      * @param mediaType       Output media type
      * @param synCtx          MessageContext
-     * @param isFormatDynamic Is the template is dynamic
      * @return The processed output
      */
-    public abstract String processTemplate(String template, String mediaType, MessageContext synCtx,
-                                           boolean isFormatDynamic);
+    public abstract String processTemplate(String template, String mediaType, MessageContext synCtx);
 
     /**
      * Execute pre-processing steps if needed
      */
-    public abstract void executePreProcessing();
+    public abstract void init();
 
     /**
      * Goes through SynapsePath argument list, evaluating each by calling stringValueOf and returns a HashMap String, String

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -1,0 +1,554 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.transform.pfutils;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMException;
+import org.apache.axiom.om.impl.builder.StAXBuilder;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.axis2.AxisFault;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.mediators.transform.Argument;
+import org.apache.synapse.mediators.transform.ArgumentDetails;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import static org.apache.synapse.mediators.transform.PayloadFactoryMediator.QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON;
+
+public abstract class TemplateProcessor {
+
+    protected final static String JSON_TYPE = "json";
+    protected final static String XML_TYPE = "xml";
+    protected final static String TEXT_TYPE = "text";
+    protected final static String STRING_TYPE = "str";
+    protected final static String ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES = "\\\\\"";
+    protected final static String ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES = "\\\\\\\\\"";
+    protected final static String ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES = "\\\\\\\\\\\\\\\\";
+    protected final static String ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES = "\\\\\\$";
+    protected final static String ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES = "\\\\\\\\\\$";
+    protected final static String ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\b";
+    protected final static String ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\f";
+    protected final static String ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\n";
+    protected final static String ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\r";
+    protected final static String ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\t";
+    private static final Pattern validJsonNumber = Pattern.compile("^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$");
+    private static final Log log = LogFactory.getLog(TemplateProcessor.class);
+    protected final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    private final List<Argument> pathArgumentList = new ArrayList<>();
+    private boolean escapeXmlChars = false;
+    private String format;
+    private String mediaType = XML_TYPE;
+
+    /**
+     * Process the given template and return the output as String
+     *
+     * @param template        Template string
+     * @param mediaType       Output media type
+     * @param synCtx          MessageContext
+     * @param isFormatDynamic Is the template is dynamic
+     * @return The processed output
+     */
+    public abstract String processTemplate(String template, String mediaType, MessageContext synCtx,
+                                           boolean isFormatDynamic);
+
+    /**
+     * Execute pre-processing steps if needed
+     */
+    public abstract void executePreProcessing();
+
+    /**
+     * Goes through SynapsePath argument list, evaluating each by calling stringValueOf and returns a HashMap String, String
+     * array where each item will contain a hash map with key "evaluated expression" and value "SynapsePath type".
+     *
+     * @param synCtx
+     * @return
+     */
+    protected HashMap<String, ArgumentDetails>[] getArgValues(String mediaType, MessageContext synCtx) {
+
+        HashMap<String, ArgumentDetails>[] argValues = new HashMap[pathArgumentList.size()];
+        HashMap<String, ArgumentDetails> valueMap;
+        String value = "";
+        for (int i = 0; i < pathArgumentList.size(); ++i) {       /*ToDo use foreach*/
+            Argument arg = pathArgumentList.get(i);
+            ArgumentDetails details = new ArgumentDetails();
+            if (arg.getValue() != null) {
+                value = arg.getValue();
+                details.setXml(isXML(value));
+                if (!details.isXml()) {
+                    value = escapeXMLEnvelope(synCtx, value);
+                }
+                value = Matcher.quoteReplacement(value);
+            } else if (arg.getExpression() != null) {
+                value = arg.getExpression().stringValueOf(synCtx);
+                details.setLiteral(arg.isLiteral());
+                if (value != null) {
+                    // XML escape the result of an expression that produces a literal, if the target format
+                    // of the payload is XML.
+                    details.setXml(isXML(value));
+                    if (!details.isXml() && XML_TYPE.equals(mediaType) && !isJson(value.trim(), arg.getExpression())) {
+                        value = escapeXMLEnvelope(synCtx, value);
+                    }
+                    value = Matcher.quoteReplacement(value);
+                } else {
+                    value = "";
+                }
+            } else {
+                handleException("Unexpected arg type detected");
+            }
+            //value = value.replace(String.valueOf((char) 160), " ").trim();
+            valueMap = new HashMap<>();
+            if (null != arg.getExpression()) {
+                details.setPathType(arg.getExpression().getPathType());
+                valueMap.put(value, details);
+            } else {
+                details.setPathType(SynapsePath.X_PATH);
+                valueMap.put(value, details);
+            }
+            argValues[i] = valueMap;
+        }
+        return argValues;
+    }
+
+    /**
+     * Preprocess and converty types of the given arg value.
+     *
+     * @param mediaType        Output media type
+     * @param synCtx           Message context
+     * @param replacementEntry Argument
+     * @return Preprocessed value
+     */
+    protected String prepareReplacementValue(String mediaType, MessageContext synCtx,
+                                             Map.Entry<String, ArgumentDetails> replacementEntry) {
+
+        String replacementValue = null;
+
+        if (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(XML_TYPE)) {
+            // XML to JSON conversion here
+            replacementValue = convertXmlArgumentToJson(replacementEntry, replacementValue);
+        } else if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) {
+            // JSON to XML conversion here
+            replacementValue = convertJsonArgumentToXml(replacementEntry, replacementValue);
+        } else {
+            // No conversion required, as path evaluates to regular String.
+            replacementValue = replacementEntry.getKey();
+            String trimmedReplacementValue = replacementValue.trim();
+            //If media type is xml and replacement value is json convert it to xml format prior to replacement
+            if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE)
+                    && isJson(trimmedReplacementValue)) {
+                replacementValue = convertJsonStringToXml(replacementValue);
+            } else if (mediaType.equals(JSON_TYPE) &&
+                    inferReplacementType(replacementEntry).equals(JSON_TYPE) &&
+                    isEscapeXmlChars()) {
+                //checks whether the escapeXmlChars attribute is true when media-type and evaluator is json and
+                //escapes xml chars. otherwise json messages with non escaped xml characters will fail to build
+                //in content aware mediators.
+                replacementValue = escapeXMLSpecialChars(replacementValue);
+            } else if (mediaType.equals(JSON_TYPE) &&
+                    inferReplacementType(replacementEntry).equals(STRING_TYPE) &&
+                    (!trimmedReplacementValue.startsWith("{") && !trimmedReplacementValue.startsWith("["))) {
+                replacementValue = escapeSpecialChars(replacementValue);
+                // Check for following property which will force the string to include quotes
+                Object force_string_quote = synCtx.getProperty(QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON);
+                // skip double quotes if replacement is boolean or null or valid json number
+                if (force_string_quote != null && ((String) force_string_quote).equalsIgnoreCase("true")
+                        && !trimmedReplacementValue.equals("true") && !trimmedReplacementValue.equals("false")
+                        && !trimmedReplacementValue.equals("null")
+                        && !validJsonNumber.matcher(trimmedReplacementValue).matches()) {
+                    replacementValue = "\"" + replacementValue + "\"";
+                }
+            } else if (
+                    (mediaType.equals(JSON_TYPE) && inferReplacementType(replacementEntry).equals(JSON_TYPE)) &&
+                            (!trimmedReplacementValue.startsWith("{") &&
+                                    !trimmedReplacementValue.startsWith("["))) {
+                // This is to handle only the string value
+                replacementValue =
+                        replacementValue.replaceAll("\"", ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES);
+            }
+        }
+        return replacementValue;
+    }
+
+    /**
+     * Convert Json string value to XML
+     *
+     * @param replacementValue Replacement value string
+     * @return Converted value
+     */
+    private String convertJsonStringToXml(String replacementValue) {
+
+        try {
+            replacementValue = escapeSpecialCharactersOfXml(replacementValue);
+            OMElement omXML = JsonUtil.toXml(IOUtils.toInputStream(replacementValue), false);
+            if (JsonUtil.isAJsonPayloadElement(omXML)) { // remove <jsonObject/> from result.
+                Iterator children = omXML.getChildElements();
+                String childrenStr = "";
+                while (children.hasNext()) {
+                    childrenStr += (children.next()).toString().trim();
+                }
+                replacementValue = childrenStr;
+            } else {
+                replacementValue = omXML.toString();
+            }
+        } catch (AxisFault e) {
+            handleException("Error converting JSON to XML, please check your JSON Path expressions"
+                    + " return valid JSON: ");
+        }
+        return replacementValue;
+    }
+
+    /**
+     * Convert JSON argument to XML
+     *
+     * @param replacementEntry Argument
+     * @param replacementValue Replacement Value
+     * @return
+     */
+    private String convertJsonArgumentToXml(Map.Entry<String, ArgumentDetails> replacementEntry,
+                                            String replacementValue) {
+
+        try {
+            replacementValue = replacementEntry.getKey();
+            replacementValue = escapeSpecialCharactersOfXml(replacementValue);
+            OMElement omXML = JsonUtil.toXml(IOUtils.toInputStream(replacementValue), false);
+            if (JsonUtil.isAJsonPayloadElement(omXML)) { // remove <jsonObject/> from result.
+                Iterator children = omXML.getChildElements();
+                String childrenStr = "";
+                while (children.hasNext()) {
+                    childrenStr += (children.next()).toString().trim();
+                }
+                replacementValue = childrenStr;
+            } else { ///~
+                replacementValue = omXML.toString();
+            }
+            //replacementValue = omXML.toString();
+        } catch (AxisFault e) {
+            handleException(
+                    "Error converting JSON to XML, please check your JSON Path expressions return valid JSON: ");
+        }
+        return replacementValue;
+    }
+
+    /**
+     * Convert XML argument to JSON
+     *
+     * @param replacementEntry Entity
+     * @param replacementValue Replacement value
+     * @return Converted value
+     */
+    private String convertXmlArgumentToJson(Map.Entry<String, ArgumentDetails> replacementEntry,
+                                            String replacementValue) {
+
+        try {
+            replacementValue = "<jsonObject>" + replacementEntry.getKey() + "</jsonObject>";
+            OMElement omXML = convertStringToOM(replacementValue);
+            replacementValue = JsonUtil.toJsonString(omXML).toString();
+            replacementValue = escapeSpecialCharactersOfJson(replacementValue);
+        } catch (XMLStreamException e) {
+            handleException(
+                    "Error parsing XML for JSON conversion, please check your xPath expressions return valid XML: ");
+        } catch (AxisFault e) {
+            handleException("Error converting XML to JSON");
+        } catch (OMException e) {
+            //if the logic comes to this means, it was tried as a XML, which means it has
+            // "<" as starting element and ">" as end element, so basically if the logic comes here, that means
+            //value is a string value, that means No conversion required, as path evaluates to regular String.
+            replacementValue = replacementEntry.getKey();
+
+            // This is to replace " with \" and \\ with \\\\
+            //replacing other json special characters i.e \b, \f, \n \r, \t
+            replacementValue = escapeSpecialChars(replacementValue);
+
+        }
+        return replacementValue;
+    }
+
+    /**
+     * Helper function that takes a Map of String, ArgumentDetails where key contains the value of an evaluated
+     * SynapsePath expression and value contains the type of SynapsePath + deepcheck status in use.
+     * <p>
+     * It returns the type of conversion required (XML | JSON | String) based on the actual returned value and the path
+     * type.
+     *
+     * @param entry
+     * @return
+     */
+    protected String inferReplacementType(Map.Entry<String, ArgumentDetails> entry) {
+
+        if (entry.getValue().isLiteral()) {
+            return STRING_TYPE;
+        } else if (entry.getValue().getPathType().equals(SynapsePath.X_PATH)
+                && entry.getValue().isXml()) {
+            return XML_TYPE;
+        } else if (entry.getValue().getPathType().equals(SynapsePath.X_PATH)
+                && !entry.getValue().isXml()) {
+            return STRING_TYPE;
+        } else if (entry.getValue().getPathType().equals(SynapsePath.JSON_PATH)
+                && isJson(entry.getKey())) {
+            return JSON_TYPE;
+        } else if (entry.getValue().getPathType().equals(SynapsePath.JSON_PATH)
+                && !isJson((entry.getKey()))) {
+            return STRING_TYPE;
+        } else {
+            return STRING_TYPE;
+        }
+    }
+
+    /**
+     * Helper function that returns true if value passed is of JSON type.
+     *
+     * @param value
+     * @return
+     */
+    protected boolean isJson(String value) {
+
+        return !(value == null || value.trim().isEmpty()) &&
+                (value.trim().charAt(0) == '{' || value.trim().charAt(0) == '[');
+    }
+
+    /**
+     * Helper function that returns true if value passed is of JSON type and expression is JSON.
+     */
+    private boolean isJson(String value, SynapsePath expression) {
+
+        return !(value == null || value.trim().isEmpty()) && (value.trim().charAt(0) == '{'
+                || value.trim().charAt(0) == '[') && expression.getPathType().equals(SynapsePath.JSON_PATH);
+    }
+
+    /**
+     * Helper function that returns true if value passed is of XML Type.
+     *
+     * @param value
+     * @return
+     */
+    protected boolean isXML(String value) {
+
+        try {
+            value = value.trim();
+            if (!value.endsWith(">") || value.length() < 4) {
+                return false;
+            }
+            // validate xml
+            convertStringToOM(value);
+            return true;
+        } catch (XMLStreamException | OMException ignore) {
+            // means not a xml
+            return false;
+        }
+    }
+
+    /**
+     * Converts String to OMElement
+     *
+     * @param value String value to convert
+     * @return parsed OMElement
+     */
+    protected OMElement convertStringToOM(String value) throws XMLStreamException, OMException {
+
+        javax.xml.stream.XMLStreamReader xmlReader = inputFactory.createXMLStreamReader(new StringReader(value));
+        StAXBuilder builder = new StAXOMBuilder(xmlReader);
+        return builder.getDocumentElement();
+    }
+
+    /**
+     * Helper method to replace required char values with escape characters.
+     *
+     * @param replaceString
+     * @return replacedString
+     */
+    protected String escapeSpecialChars(String replaceString) {
+
+        return replaceString.replaceAll(Matcher.quoteReplacement("\\\\"), ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES)
+                .replaceAll("\"", ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
+                .replaceAll("\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
+    }
+
+    /**
+     * Replace special characters of a JSON string.
+     *
+     * @param jsonString JSON string.
+     * @return
+     */
+    protected String escapeSpecialCharactersOfJson(String jsonString) {
+        // This is to replace \" with \\" and \\$ with \$. Because for Matcher, $ sign is
+        // a special character and for JSON " is a special character.
+        //replacing other json special characters i.e \b, \f, \n \r, \t
+        return jsonString.replaceAll(ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES,
+                ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
+                .replaceAll(ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES, ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
+                .replaceAll("\\\\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
+    }
+
+    /**
+     * Replace special characters of a XML string.
+     *
+     * @param xmlString XML string.
+     * @return
+     */
+    protected String escapeSpecialCharactersOfXml(String xmlString) {
+
+        return xmlString.replaceAll(ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES,
+                ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
+                .replaceAll("\\$", ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
+                .replaceAll("\\\\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\\\\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
+    }
+
+    /**
+     * Helper method to replace required char values with escape characters for XML.
+     *
+     * @param replaceString
+     * @return replacedString
+     */
+    protected String escapeXMLSpecialChars(String replaceString) {
+
+        return replaceString.replaceAll("\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\r", ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES)
+                .replaceAll("\t", ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES);
+    }
+
+    /**
+     * Escapes XML special characters
+     *
+     * @param msgCtx Message Context
+     * @param value  XML String which needs to be escaped
+     * @return XML special char escaped string
+     */
+    protected String escapeXMLEnvelope(MessageContext msgCtx, String value) {
+
+        String xmlVersion = "1.0"; //Default is set to 1.0
+
+        try {
+            xmlVersion = checkXMLVersion(msgCtx);
+        } catch (IOException e) {
+            log.error("Error reading message envelope", e);
+        } catch (SAXException e) {
+            log.error("Error parsing message envelope", e);
+        } catch (ParserConfigurationException e) {
+            log.error("Error building message envelope document", e);
+        }
+
+        if ("1.1".equals(xmlVersion)) {
+            return org.apache.commons.text.StringEscapeUtils.escapeXml11(value);
+        } else {
+            return org.apache.commons.text.StringEscapeUtils.escapeXml10(value);
+        }
+
+    }
+
+    /**
+     * Checks and returns XML version of the envelope
+     *
+     * @param msgCtx Message Context
+     * @return xmlVersion in XML Declaration
+     * @throws ParserConfigurationException failure in building message envelope document
+     * @throws IOException                  Error reading message envelope
+     * @throws SAXException                 Error parsing message envelope
+     */
+    private String checkXMLVersion(MessageContext msgCtx)
+            throws IOException, SAXException, ParserConfigurationException {
+
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        InputSource inputSource = new InputSource(new StringReader(msgCtx.getEnvelope().toString()));
+        Document document = documentBuilder.parse(inputSource);
+        return document.getXmlVersion();
+    }
+
+    protected boolean isEscapeXmlChars() {
+
+        return escapeXmlChars;
+    }
+
+    public void setEscapeXmlChars(boolean escapeXmlChars) {
+
+        this.escapeXmlChars = escapeXmlChars;
+    }
+
+    public void addPathArgument(Argument arg) {
+
+        pathArgumentList.add(arg);
+    }
+
+    public List<Argument> getPathArgumentList() {
+
+        return pathArgumentList;
+    }
+
+    public String getFormat() {
+
+        return format;
+    }
+
+    public void setFormat(String format) {
+
+        this.format = format;
+    }
+
+    public String getMediaType() {
+
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+
+        this.mediaType = mediaType;
+    }
+
+    protected void handleException(String msg) {
+
+        throw new TemplateProcessorException(msg);
+    }
+
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -56,20 +56,20 @@ import static org.apache.synapse.mediators.transform.PayloadFactoryMediator.QUOT
 
 public abstract class TemplateProcessor {
 
-    protected final static String JSON_TYPE = "json";
-    protected final static String XML_TYPE = "xml";
-    protected final static String TEXT_TYPE = "text";
-    protected final static String STRING_TYPE = "str";
-    protected final static String ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES = "\\\\\"";
-    protected final static String ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES = "\\\\\\\\\"";
-    protected final static String ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES = "\\\\\\\\\\\\\\\\";
-    protected final static String ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES = "\\\\\\$";
-    protected final static String ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES = "\\\\\\\\\\$";
-    protected final static String ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\b";
-    protected final static String ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\f";
-    protected final static String ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\n";
-    protected final static String ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\r";
-    protected final static String ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\t";
+    protected static final String JSON_TYPE = "json";
+    protected static final String XML_TYPE = "xml";
+    protected static final String TEXT_TYPE = "text";
+    protected static final String STRING_TYPE = "str";
+    protected static final String ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES = "\\\\\"";
+    protected static final String ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES = "\\\\\\\\\"";
+    protected static final String ESCAPE_BACK_SLASH_WITH_SIXTEEN_BACK_SLASHES = "\\\\\\\\\\\\\\\\";
+    protected static final String ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES = "\\\\\\$";
+    protected static final String ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES = "\\\\\\\\\\$";
+    protected static final String ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\b";
+    protected static final String ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\f";
+    protected static final String ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\n";
+    protected static final String ESCAPE_CRETURN_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\r";
+    protected static final String ESCAPE_TAB_WITH_EIGHT_BACK_SLASHES = "\\\\\\\\t";
     private static final Pattern validJsonNumber = Pattern.compile("^-?(0|([1-9]\\d*))(\\.\\d+)?([eE][+-]?\\d+)?$");
     private static final Log log = LogFactory.getLog(TemplateProcessor.class);
     protected final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -99,7 +99,7 @@ public abstract class TemplateProcessor {
      * Goes through SynapsePath argument list, evaluating each by calling stringValueOf and returns a HashMap String, String
      * array where each item will contain a hash map with key "evaluated expression" and value "SynapsePath type".
      *
-     * @param synCtx
+     * @param synCtx MessageContext
      * @return
      */
     protected HashMap<String, ArgumentDetails>[] getArgValues(String mediaType, MessageContext synCtx) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -54,6 +54,9 @@ import javax.xml.stream.XMLStreamException;
 
 import static org.apache.synapse.mediators.transform.PayloadFactoryMediator.QUOTE_STRING_IN_PAYLOAD_FACTORY_JSON;
 
+/**
+ * Abstract TemplateProcessor. This is the class using by the 
+ */
 public abstract class TemplateProcessor {
 
     protected static final String JSON_TYPE = "json";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -1,21 +1,21 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
  */
+
 
 package org.apache.synapse.mediators.transform.pfutils;
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
@@ -19,6 +19,10 @@
 
 package org.apache.synapse.mediators.transform.pfutils;
 
+/**
+ * This will throw when there's an exception occurs in the template processing step in any implementation of the 
+ * TemplateProcessor
+ */
 public class TemplateProcessorException extends RuntimeException {
 
     public TemplateProcessorException(String message) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.transform.pfutils;
+
+public class TemplateProcessorException extends RuntimeException {
+
+    public TemplateProcessorException(String message) {
+
+        super(message);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorException.java
@@ -1,21 +1,21 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
  */
+
 
 package org.apache.synapse.mediators.transform.pfutils;
 

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
@@ -101,7 +101,5 @@ public class PayloadFactoryMediatorFactoryTest {
         assertNotNull(payloadFactoryMediator);
         mediaType = payloadFactoryMediator.getType();
         assertEquals("Media type is not xml", "xml", mediaType);
-    }  
-    
-
+    }
 }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
@@ -102,5 +102,6 @@ public class PayloadFactoryMediatorFactoryTest {
         mediaType = payloadFactoryMediator.getType();
         assertEquals("Media type is not xml", "xml", mediaType);
     }  
-   
+    
+
 }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorFactoryTest.java
@@ -101,5 +101,6 @@ public class PayloadFactoryMediatorFactoryTest {
         assertNotNull(payloadFactoryMediator);
         mediaType = payloadFactoryMediator.getType();
         assertEquals("Media type is not xml", "xml", mediaType);
-    }
+    }  
+   
 }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializerTest.java
@@ -23,6 +23,7 @@ import org.apache.synapse.SynapseException;
 import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.transform.Argument;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
+import org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 import org.junit.Assert;
@@ -60,6 +61,7 @@ public class PayloadFactoryMediatorSerializerTest {
     public void testSerializeSpecificMediator2() {
         PayloadFactoryMediatorSerializer serializer = new PayloadFactoryMediatorSerializer();
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         payloadFactoryMediator.setFormat(format);
         OMElement element = serializer.serializeSpecificMediator(payloadFactoryMediator);
         Assert.assertNotNull(element);
@@ -76,6 +78,7 @@ public class PayloadFactoryMediatorSerializerTest {
     public void testSerializeSpecificMediator3() {
         PayloadFactoryMediatorSerializer serializer = new PayloadFactoryMediatorSerializer();
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         payloadFactoryMediator.setFormat(format);
         payloadFactoryMediator.setFormatDynamic(true);
         payloadFactoryMediator.setFormatKey(new Value("testKey"));
@@ -95,16 +98,17 @@ public class PayloadFactoryMediatorSerializerTest {
     public void testSerializeSpecificMediator4() throws JaxenException {
         PayloadFactoryMediatorSerializer serializer = new PayloadFactoryMediatorSerializer();
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         Argument argument = new Argument();
         argument.setValue("TestArgument1");
-        payloadFactoryMediator.addPathArgument(argument);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument);
         payloadFactoryMediator.setFormat(format);
         OMElement element = serializer.serializeSpecificMediator(payloadFactoryMediator);
         MediatorFactory mediatorFactory = new PayloadFactoryMediatorFactory();
         Mediator mediator = mediatorFactory.createMediator(element, null);
         Assert.assertNotNull(element);
         Assert.assertEquals("Path argument added is not serialized", "TestArgument1",
-                ((PayloadFactoryMediator) mediator).getPathArgumentList().get(0).getValue());
+                ((PayloadFactoryMediator) mediator).getTemplateProcessor().getPathArgumentList().get(0).getValue());
     }
 
     /**
@@ -115,16 +119,18 @@ public class PayloadFactoryMediatorSerializerTest {
     public void testSerializeSpecificMediator5() throws JaxenException {
         PayloadFactoryMediatorSerializer serializer = new PayloadFactoryMediatorSerializer();
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         Argument argument = new Argument();
         argument.setExpression(new SynapseXPath("//name"));
-        payloadFactoryMediator.addPathArgument(argument);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument);
         payloadFactoryMediator.setFormat(format);
         OMElement element = serializer.serializeSpecificMediator(payloadFactoryMediator);
         MediatorFactory mediatorFactory = new PayloadFactoryMediatorFactory();
         Mediator mediator = mediatorFactory.createMediator(element, null);
         Assert.assertNotNull(element);
         Assert.assertEquals("Expression added for path argument is not serialized", "//name",
-                ((PayloadFactoryMediator) mediator).getPathArgumentList().get(0).getExpression().toString()
+                ((PayloadFactoryMediator) mediator).getTemplateProcessor().getPathArgumentList().get(0).getExpression()
+                        .toString()
         );
     }
 

--- a/modules/core/src/test/java/org/apache/synapse/mediators/elementary/EnrichMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/elementary/EnrichMediatorTest.java
@@ -20,11 +20,11 @@
 package org.apache.synapse.mediators.elementary;
 
 import junit.framework.TestCase;
+
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 import org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor;
-
 import java.util.ArrayList;
 
 public class EnrichMediatorTest extends TestCase {
@@ -50,10 +50,10 @@ public class EnrichMediatorTest extends TestCase {
 		enrichMediator1.mediate(msgCtxt1);
 
 		String expectedPropVal =
-				"<?xml version='1.0' encoding='utf-8'?>" +
-						"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-						"<soapenv:Body>" + xml1 +
-						"</soapenv:Body></soapenv:Envelope>";
+		                         "<?xml version='1.0' encoding='utf-8'?>" +
+		                                 "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+		                                 "<soapenv:Body>" + xml1 +
+		                                 "</soapenv:Body></soapenv:Envelope>";
 
 		// assert the property
 		assertEquals(expectedPropVal, ((ArrayList) msgCtxt1.getProperty(key)).get(0).toString());
@@ -65,8 +65,8 @@ public class EnrichMediatorTest extends TestCase {
 		payloadFacMediator.mediate(msgCtxt1);
 
 		String expectedPayload =
-				"<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-						format + "</soapenv:Body>";
+		                         "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+		                                 format + "</soapenv:Body>";
 		// assert the new payload
 		assertEquals(expectedPayload, msgCtxt1.getEnvelope().getBody().toString());
 
@@ -97,10 +97,10 @@ public class EnrichMediatorTest extends TestCase {
 		enrichMediator1.mediate(msgCtxt1);
 
 		String expectedPropVal =
-				"<?xml version='1.0' encoding='utf-8'?>" +
-						"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-						"<soapenv:Body>" + xml1 +
-						"</soapenv:Body></soapenv:Envelope>";
+		                         "<?xml version='1.0' encoding='utf-8'?>" +
+		                                 "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+		                                 "<soapenv:Body>" + xml1 +
+		                                 "</soapenv:Body></soapenv:Envelope>";
 
 		// assert the property
 		assertEquals(expectedPropVal, ((ArrayList) msgCtxt1.getProperty(key)).get(0).toString());
@@ -112,8 +112,8 @@ public class EnrichMediatorTest extends TestCase {
 		payloadFacMediator.mediate(msgCtxt1);
 
 		String expectedPayload =
-				"<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-						format + "</soapenv:Body>";
+		                         "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+		                                 format + "</soapenv:Body>";
 
 		// assert the new payload
 		assertEquals(expectedPayload, msgCtxt1.getEnvelope().getBody().toString());

--- a/modules/core/src/test/java/org/apache/synapse/mediators/elementary/EnrichMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/elementary/EnrichMediatorTest.java
@@ -20,10 +20,11 @@
 package org.apache.synapse.mediators.elementary;
 
 import junit.framework.TestCase;
-
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
+import org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor;
+
 import java.util.ArrayList;
 
 public class EnrichMediatorTest extends TestCase {
@@ -49,22 +50,23 @@ public class EnrichMediatorTest extends TestCase {
 		enrichMediator1.mediate(msgCtxt1);
 
 		String expectedPropVal =
-		                         "<?xml version='1.0' encoding='utf-8'?>" +
-		                                 "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-		                                 "<soapenv:Body>" + xml1 +
-		                                 "</soapenv:Body></soapenv:Envelope>";
+				"<?xml version='1.0' encoding='utf-8'?>" +
+						"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+						"<soapenv:Body>" + xml1 +
+						"</soapenv:Body></soapenv:Envelope>";
 
 		// assert the property
 		assertEquals(expectedPropVal, ((ArrayList) msgCtxt1.getProperty(key)).get(0).toString());
 
 		PayloadFactoryMediator payloadFacMediator = new PayloadFactoryMediator();
+		payloadFacMediator.setTemplateProcessor(new RegexTemplateProcessor());
 		payloadFacMediator.setType("xml");
 		payloadFacMediator.setFormat(format);
 		payloadFacMediator.mediate(msgCtxt1);
 
 		String expectedPayload =
-		                         "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-		                                 format + "</soapenv:Body>";
+				"<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+						format + "</soapenv:Body>";
 		// assert the new payload
 		assertEquals(expectedPayload, msgCtxt1.getEnvelope().getBody().toString());
 
@@ -95,22 +97,23 @@ public class EnrichMediatorTest extends TestCase {
 		enrichMediator1.mediate(msgCtxt1);
 
 		String expectedPropVal =
-		                         "<?xml version='1.0' encoding='utf-8'?>" +
-		                                 "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-		                                 "<soapenv:Body>" + xml1 +
-		                                 "</soapenv:Body></soapenv:Envelope>";
+				"<?xml version='1.0' encoding='utf-8'?>" +
+						"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+						"<soapenv:Body>" + xml1 +
+						"</soapenv:Body></soapenv:Envelope>";
 
 		// assert the property
 		assertEquals(expectedPropVal, ((ArrayList) msgCtxt1.getProperty(key)).get(0).toString());
 
 		PayloadFactoryMediator payloadFacMediator = new PayloadFactoryMediator();
+		payloadFacMediator.setTemplateProcessor(new RegexTemplateProcessor());
 		payloadFacMediator.setType("xml");
 		payloadFacMediator.setFormat(format);
 		payloadFacMediator.mediate(msgCtxt1);
 
 		String expectedPayload =
-		                         "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
-		                                 format + "</soapenv:Body>";
+				"<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+						format + "</soapenv:Body>";
 
 		// assert the new payload
 		assertEquals(expectedPayload, msgCtxt1.getEnvelope().getBody().toString());

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/PayloadFactoryMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/PayloadFactoryMediatorTest.java
@@ -21,6 +21,7 @@ package org.apache.synapse.mediators.transform;
 import junit.framework.TestCase;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.mediators.TestUtils;
+import org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor;
 import org.apache.synapse.util.xpath.SynapseXPath;
 
 import java.text.SimpleDateFormat;
@@ -31,7 +32,7 @@ import java.util.Calendar;
  */
 public class PayloadFactoryMediatorTest extends TestCase {
 
-    private static String format = "<p:addCustomer xmlns:p=\"http://ws"
+    private static final String format = "<p:addCustomer xmlns:p=\"http://ws"
             + ".wso2.org/dataservice\">\n"
             + " <xs:name xmlns:xs=\"http://ws.wso2.org/dataservice\">$1</xs:name>\n"
             + " <xs:request_time xmlns:xs=\"http://ws"
@@ -41,16 +42,17 @@ public class PayloadFactoryMediatorTest extends TestCase {
             + " <xs:address xmlns:xs=\"http://ws.wso2.org/dataservice\">$4</xs:address>\n"
             + " </p:addCustomer>";
 
-    private static String inputPayload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
-            + "   <soapenv:Header/>\n"
-            + "   <soapenv:Body>\n"
-            + "        <addCustomer>\n"
-            + "            <name>Smith</name>\n"
-            + "            <tpNumber>0834558649</tpNumber>\n"
-            + "            <address>No. 456, Gregory Road, Los Angeles</address>\n"
-            + "        </addCustomer>\n"
-            + "   </soapenv:Body>\n"
-            + "</soapenv:Envelope>  ";
+    private static final String inputPayload =
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                    + "   <soapenv:Header/>\n"
+                    + "   <soapenv:Body>\n"
+                    + "        <addCustomer>\n"
+                    + "            <name>Smith</name>\n"
+                    + "            <tpNumber>0834558649</tpNumber>\n"
+                    + "            <address>No. 456, Gregory Road, Los Angeles</address>\n"
+                    + "        </addCustomer>\n"
+                    + "   </soapenv:Body>\n"
+                    + "</soapenv:Envelope>  ";
 
     /**
      * Test payloadFactory Mediator with static arguments set
@@ -59,6 +61,7 @@ public class PayloadFactoryMediatorTest extends TestCase {
     public void testWithStaticArguments() throws Exception {
 
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         payloadFactoryMediator.setFormat(format);
 
         //prepare arguments
@@ -72,10 +75,10 @@ public class PayloadFactoryMediatorTest extends TestCase {
         argument4.setValue("Colombo, Sri Lanka");
 
         //add arguments
-        payloadFactoryMediator.addPathArgument(argument1);
-        payloadFactoryMediator.addPathArgument(argument2);
-        payloadFactoryMediator.addPathArgument(argument3);
-        payloadFactoryMediator.addPathArgument(argument4);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument1);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument2);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument3);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument4);
 
         //do mediation
         MessageContext synCtx = TestUtils.getAxis2MessageContext(inputPayload, null);
@@ -100,6 +103,7 @@ public class PayloadFactoryMediatorTest extends TestCase {
     public void testWithExpressionsAsArguments() throws Exception {
 
         PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
         payloadFactoryMediator.setFormat(format);
         //prepare arguments
         Argument argument1 = new Argument();
@@ -112,10 +116,10 @@ public class PayloadFactoryMediatorTest extends TestCase {
         argument4.setExpression(new SynapseXPath("//address"));
 
         //add arguments
-        payloadFactoryMediator.addPathArgument(argument1);
-        payloadFactoryMediator.addPathArgument(argument2);
-        payloadFactoryMediator.addPathArgument(argument3);
-        payloadFactoryMediator.addPathArgument(argument4);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument1);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument2);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument3);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument4);
 
         //do mediation
         MessageContext synCtx = TestUtils.getAxis2MessageContext(inputPayload, null);

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/PayloadFactoryMediatorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/PayloadFactoryMediatorTest.java
@@ -42,17 +42,16 @@ public class PayloadFactoryMediatorTest extends TestCase {
             + " <xs:address xmlns:xs=\"http://ws.wso2.org/dataservice\">$4</xs:address>\n"
             + " </p:addCustomer>";
 
-    private static final String inputPayload =
-            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
-                    + "   <soapenv:Header/>\n"
-                    + "   <soapenv:Body>\n"
-                    + "        <addCustomer>\n"
-                    + "            <name>Smith</name>\n"
-                    + "            <tpNumber>0834558649</tpNumber>\n"
-                    + "            <address>No. 456, Gregory Road, Los Angeles</address>\n"
-                    + "        </addCustomer>\n"
-                    + "   </soapenv:Body>\n"
-                    + "</soapenv:Envelope>  ";
+    private static String inputPayload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+            + "   <soapenv:Header/>\n"
+            + "   <soapenv:Body>\n"
+            + "        <addCustomer>\n"
+            + "            <name>Smith</name>\n"
+            + "            <tpNumber>0834558649</tpNumber>\n"
+            + "            <address>No. 456, Gregory Road, Los Angeles</address>\n"
+            + "        </addCustomer>\n"
+            + "   </soapenv:Body>\n"
+            + "</soapenv:Envelope>  ";
 
     /**
      * Test payloadFactory Mediator with static arguments set

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
@@ -31,7 +31,7 @@ import java.util.Calendar;
 /**
  * Unit tests for FreeMarker Template Processor
  */
-public class FreeMarkerTemplateProcessorTest extends TestCase {
+public class FreeMarkerTemplateProcessorTest extends TestCase { //todo :: try to test property injection
 
     private static final String template = "<p:addCustomer xmlns:p=\"http://ws.wso2.org/dataservice\">\n" +
             " <xs:name xmlns:xs=\"http://ws.wso2.org/dataservice\">${args.arg1}</xs:name>\n" +

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
@@ -1,0 +1,317 @@
+package org.apache.synapse.mediators.transform.pfutils;
+
+import junit.framework.TestCase;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.mediators.TestUtils;
+import org.apache.synapse.mediators.transform.Argument;
+import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
+import org.apache.synapse.util.xpath.SynapseXPath;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+/**
+ * Unit tests for FreeMarker Template Processor
+ */
+public class FreeMarkerTemplateProcessorTest extends TestCase {
+
+    private static final String template = "<p:addCustomer xmlns:p=\"http://ws.wso2.org/dataservice\">\n" +
+            " <xs:name xmlns:xs=\"http://ws.wso2.org/dataservice\">${args.arg1}</xs:name>\n" +
+            " <xs:request_time xmlns:xs=\"http://ws.wso2.org/dataservice\">${args.arg2}</xs:request_time>\n" +
+            " <xs:tp_number xmlns:xs=\"http://ws.wso2.org/dataservice\">${args.arg3}</xs:tp_number>\n" +
+            " <xs:address xmlns:xs=\"http://ws.wso2.org/dataservice\">${args.arg4}</xs:address>\n" +
+            " </p:addCustomer>";
+
+    private static final String inputPayload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap" +
+            ".org/soap/envelope/\">\n"
+            + "   <soapenv:Header/>\n"
+            + "   <soapenv:Body>\n"
+            + "        <addCustomer>\n"
+            + "            <name>Smith</name>\n"
+            + "            <tpNumber>0834558649</tpNumber>\n"
+            + "            <address>No. 456, Gregory Road, Los Angeles</address>\n"
+            + "        </addCustomer>\n"
+            + "   </soapenv:Body>\n"
+            + "</soapenv:Envelope>  ";
+
+    /**
+     * Test FreeMarkerTemplateProcessor with static arguments set
+     *
+     * @throws Exception in case of argument evaluation issue
+     */
+    public void testWithStaticArgumentsFreeMarker() throws Exception {
+
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
+        payloadFactoryMediator.setFormat(template);
+        templateProcessor.setFormat(template);
+        templateProcessor.executePreProcessing();
+        payloadFactoryMediator.setTemplateProcessor(templateProcessor);
+
+        //prepare arguments
+        Argument argument1 = new Argument();
+        argument1.setValue("John");
+        Argument argument2 = new Argument();
+        argument2.setValue("2017.09.26");
+        Argument argument3 = new Argument();
+        argument3.setValue("1234564632");
+        Argument argument4 = new Argument();
+        argument4.setValue("Colombo, Sri Lanka");
+
+        //add arguments
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument1);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument2);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument3);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument4);
+
+        //do mediation
+        MessageContext synCtx = TestUtils.getAxis2MessageContext(inputPayload, null);
+        payloadFactoryMediator.mediate(synCtx);
+
+        String expectedEnv = "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap"
+                + ".org/soap/envelope/\"><p:addCustomer xmlns:p=\"http://ws.wso2.org/dataservice\">\n"
+                + " <xs:name xmlns:xs=\"http://ws.wso2.org/dataservice\">John</xs:name>\n"
+                + " <xs:request_time xmlns:xs=\"http://ws.wso2.org/dataservice\">2017.09.26</xs:request_time>\n"
+                + " <xs:tp_number xmlns:xs=\"http://ws.wso2.org/dataservice\">1234564632</xs:tp_number>\n"
+                + " <xs:address xmlns:xs=\"http://ws.wso2.org/dataservice\">Colombo, Sri Lanka</xs:address>\n"
+                + " </p:addCustomer></soapenv:Body>";
+
+        assertEquals("FreeMarker Template Processor has not "
+                + "set expected format", expectedEnv, synCtx.getEnvelope().getBody().toString());
+    }
+
+    /**
+     * Test FreeMarkerTemplateProcessor with dynamic expressions set
+     *
+     * @throws Exception in case of argument evaluation issue
+     */
+    public void testWithExpressionsAsArguments() throws Exception {
+
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
+        payloadFactoryMediator.setFormat(template);
+        templateProcessor.setFormat(template);
+        templateProcessor.executePreProcessing();
+        payloadFactoryMediator.setTemplateProcessor(templateProcessor);
+
+        //prepare arguments
+        Argument argument1 = new Argument();
+        argument1.setExpression(new SynapseXPath("//name"));
+        Argument argument2 = new Argument();
+        argument2.setExpression(new SynapseXPath("get-property('SYSTEM_DATE', 'yyyy.MM.dd')"));
+        Argument argument3 = new Argument();
+        argument3.setExpression(new SynapseXPath("//tpNumber"));
+        Argument argument4 = new Argument();
+        argument4.setExpression(new SynapseXPath("//address"));
+
+        //add arguments
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument1);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument2);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument3);
+        payloadFactoryMediator.getTemplateProcessor().addPathArgument(argument4);
+
+        //do mediation
+        MessageContext synCtx = TestUtils.getAxis2MessageContext(inputPayload, null);
+        payloadFactoryMediator.mediate(synCtx);
+
+        String expectedEnvelope = "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap"
+                + ".org/soap/envelope/\"><p:addCustomer xmlns:p=\"http://ws.wso2.org/dataservice\">\n"
+                + " <xs:name xmlns:xs=\"http://ws.wso2.org/dataservice\">Smith</xs:name>\n"
+                + " <xs:request_time xmlns:xs=\"http://ws.wso2.org/dataservice\">"
+                + new SimpleDateFormat("yyyy.MM.dd").format(Calendar.getInstance().getTime())
+                + "</xs:request_time>\n"
+                + " <xs:tp_number xmlns:xs=\"http://ws.wso2.org/dataservice\">0834558649</xs:tp_number>\n"
+                + " <xs:address xmlns:xs=\"http://ws.wso2.org/dataservice\">No. 456, Gregory Road, Los "
+                + "Angeles</xs:address>\n"
+                + " </p:addCustomer></soapenv:Body>";
+
+        assertEquals("FreeMarker Template Processor has not "
+                + "set expected format", expectedEnvelope, synCtx.getEnvelope().getBody().toString());
+    }
+
+    /**
+     * Test FreeMarkerTemplateProcessor with JSON payload
+     */
+    public void testWithJSONPayload() throws Exception {
+
+        final String jsonInputPayload = "{\n" +
+                "  \"hotelName\": \"Kingsbury\",\n" +
+                "  \"hotelCode\": \"001\",\n" +
+                "  \"rooms\": [\n" +
+                "    {\n" +
+                "      \"code\": \"LX\",\n" +
+                "      \"available\": 23\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"code\": \"SUITE\",\n" +
+                "      \"available\": 3\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"code\": \"SV\",\n" +
+                "      \"available\": 10\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"agent\" : {\n" +
+                "    \"name\": \"walkers tours\",\n" +
+                "    \"id\": \"1567\"\n" +
+                "  }\n" +
+                "}";
+
+        final String jsonToXmlTemplate = "<contract xmlns=\"\">\n" +
+                "<agent-info>\n" +
+                "    <id>agn${payload.agent.id}</id>\n" +
+                "    <name>${payload.agent.name?capitalize}</name>\n" +
+                "</agent-info>\n" +
+                "<hotel-info>\n" +
+                "    <id>htl${payload.hotelCode}</id>\n" +
+                "    <name>${payload.hotelName?capitalize}</name>\n" +
+                "    <#list payload.rooms as room>\n" +
+                "         <room>\n" +
+                "             <id>${room.code}</id>\n" +
+                "             <number-of-available-rooms>${room.available}</number-of-available-rooms>\n" +
+                "         </room>\n" +
+                "    </#list>\n" +
+                "</hotel-info>\n" +
+                "</contract>";
+
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
+        payloadFactoryMediator.setFormat(jsonToXmlTemplate);
+        templateProcessor.setFormat(jsonToXmlTemplate);
+        templateProcessor.executePreProcessing();
+        payloadFactoryMediator.setTemplateProcessor(templateProcessor);
+
+        //do mediation
+        MessageContext synCtx = TestUtils.getTestContextJson(jsonInputPayload, null);
+        payloadFactoryMediator.mediate(synCtx);
+
+        String expectedEnvelope =
+                "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><contract>\n" +
+                        "<agent-info>\n" +
+                        "    <id>agn1567</id>\n" +
+                        "    <name>Walkers Tours</name>\n" +
+                        "</agent-info>\n" +
+                        "<hotel-info>\n" +
+                        "    <id>htl001</id>\n" +
+                        "    <name>Kingsbury</name>\n" +
+                        "         <room>\n" +
+                        "             <id>LX</id>\n" +
+                        "             <number-of-available-rooms>23</number-of-available-rooms>\n" +
+                        "         </room>\n" +
+                        "         <room>\n" +
+                        "             <id>SUITE</id>\n" +
+                        "             <number-of-available-rooms>3</number-of-available-rooms>\n" +
+                        "         </room>\n" +
+                        "         <room>\n" +
+                        "             <id>SV</id>\n" +
+                        "             <number-of-available-rooms>10</number-of-available-rooms>\n" +
+                        "         </room>\n" +
+                        "</hotel-info>\n" +
+                        "</contract></soapenv:Body>";
+
+        assertEquals("FreeMarker Template Processor has not "
+                + "set expected format", expectedEnvelope, synCtx.getEnvelope().getBody().toString());
+    }
+
+    /**
+     * Test FreeMarkerTemplateProcessor with XML payload
+     */
+    public void testWithXMLPayload() throws Exception {
+
+        final String xmlInput = "<contract>\n" +
+                "    <hotelName>Kingsbury</hotelName>\n" +
+                "    <hotelCode>001</hotelCode>\n" +
+                "    <agent>\n" +
+                "        <name>walkers tours</name>\n" +
+                "        <id>1567</id>\n" +
+                "    </agent>\n" +
+                "    <rooms>\n" +
+                "        <room>\n" +
+                "            <code>LX</code>\n" +
+                "            <available>23</available>\n" +
+                "        </room>\n" +
+                "        <room>\n" +
+                "            <code>SUITE</code>\n" +
+                "            <available>33</available>\n" +
+                "        </room>\n" +
+                "        <room>\n" +
+                "            <code>SV</code>\n" +
+                "            <available>10</available>\n" +
+                "        </room>\n" +
+                "    </rooms>\n" +
+                "</contract>";
+
+        final String xmlToJsonTemplate = "{\n" +
+                "  \"agentInfo\": {\n" +
+                "    \"id\": \"agn${payload.contract.agent.id}\",\n" +
+                "    \"name\": \"${payload.contract.agent.name?capitalize}\"\n" +
+                "  },\n" +
+                "  \"hotelInfo\": {\n" +
+                "    \"id\": \"htl${payload.contract.hotelCode}\",\n" +
+                "    \"name\": \"${payload.contract.hotelName?capitalize}\"\n" +
+                "  },\n" +
+                "  \"roomInfo\": [\n" +
+                "    <#list payload.contract.rooms.room as room>\n" +
+                "    {\n" +
+                "      \"room-code\": \"${room.code}\",\n" +
+                "      \"available-rooms\": ${room.available}\n" +
+                "    }<#if room_has_next>,</#if>\n" +
+                "    </#list>\n" +
+                "  ]\n" +
+                "}\n";
+
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
+        payloadFactoryMediator.setFormat(xmlToJsonTemplate);
+        payloadFactoryMediator.setType("json");
+        templateProcessor.setMediaType("json");
+        templateProcessor.setFormat(xmlToJsonTemplate);
+        templateProcessor.executePreProcessing();
+        payloadFactoryMediator.setTemplateProcessor(templateProcessor);
+
+        //do mediation
+        MessageContext synCtx = TestUtils.getAxis2MessageContext(xmlInput, null);
+        payloadFactoryMediator.mediate(synCtx);
+
+        String expectedEnvelope =
+                "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><jsonObject><agentInfo><id>" +
+                        "agn1567</id><name>Walkers Tours</name></agentInfo><hotelInfo><id>htl001</id><name>Kingsbury" +
+                        "</name></hotelInfo><roomInfo><room-code>LX</room-code><available-rooms>23</available-rooms>" +
+                        "</roomInfo><roomInfo><room-code>SUITE</room-code><available-rooms>33</available-rooms>" +
+                        "</roomInfo><roomInfo><room-code>SV</room-code><available-rooms>10</available-rooms></roomInfo>" +
+                        "</jsonObject></soapenv:Body>";
+
+        assertEquals("FreeMarker Template Processor has not "
+                + "set expected format", expectedEnvelope, synCtx.getEnvelope().getBody().toString());
+    }
+
+    /**
+     * Test FreeMarkerTemplateProcessor with Text payload
+     */
+    public void testWithTextPayload() throws Exception {
+
+        final String textInput = "<text xmlns=\"http://ws.apache.org/commons/ns/payload\">hello</text>";
+
+        final String xmlToJsonTemplate = "{\n" +
+                "  \"text\" : \"${payload}\"\n" +
+                "}";
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
+        payloadFactoryMediator.setFormat(xmlToJsonTemplate);
+        payloadFactoryMediator.setType("json");
+        templateProcessor.setMediaType("json");
+        templateProcessor.setFormat(xmlToJsonTemplate);
+        templateProcessor.executePreProcessing();
+        payloadFactoryMediator.setTemplateProcessor(templateProcessor);
+
+        //do mediation
+        MessageContext synCtx = TestUtils.getAxis2MessageContext(textInput, null);
+        payloadFactoryMediator.mediate(synCtx);
+
+        String expectedEnvelope =
+                "<soapenv:Body xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><jsonObject><text>hello</text></jsonObject></soapenv:Body>";
+
+        assertEquals("FreeMarker Template Processor has not "
+                + "set expected format", expectedEnvelope, synCtx.getEnvelope().getBody().toString());
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
@@ -1,3 +1,21 @@
+/*
+ *Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
 package org.apache.synapse.mediators.transform.pfutils;
 
 import junit.framework.TestCase;

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
@@ -66,7 +66,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(template);
         templateProcessor.setFormat(template);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //prepare arguments
@@ -112,7 +112,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(template);
         templateProcessor.setFormat(template);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //prepare arguments
@@ -199,7 +199,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(jsonToXmlTemplate);
         templateProcessor.setFormat(jsonToXmlTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation
@@ -287,7 +287,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         payloadFactoryMediator.setType("json");
         templateProcessor.setMediaType("json");
         templateProcessor.setFormat(xmlToJsonTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation
@@ -322,7 +322,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         payloadFactoryMediator.setType("json");
         templateProcessor.setMediaType("json");
         templateProcessor.setFormat(xmlToJsonTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation
@@ -354,7 +354,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(propertyInjectionTemplate);
         templateProcessor.setFormat(propertyInjectionTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation
@@ -401,7 +401,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(propertyInjectionTemplate);
         templateProcessor.setFormat(propertyInjectionTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation
@@ -460,7 +460,7 @@ public class FreeMarkerTemplateProcessorTest extends TestCase {
         TemplateProcessor templateProcessor = new FreeMarkerTemplateProcessor();
         payloadFactoryMediator.setFormat(propertyInjectionTemplate);
         templateProcessor.setFormat(propertyInjectionTemplate);
-        templateProcessor.executePreProcessing();
+        templateProcessor.init();
         payloadFactoryMediator.setTemplateProcessor(templateProcessor);
 
         //do mediation

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *WSO2 Inc. licenses this file to you under the Apache License,
  *Version 2.0 (the "License"); you may not use this file except

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -111,6 +111,10 @@
             <groupId>org.antlr.wso2</groupId>
             <artifactId>antlr-runtime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -157,6 +161,7 @@
                                 <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
                                 <bundleDef>org.wso2.orbit.io.jaeger:jaeger-client:${jaeger-client.version}</bundleDef>
                                 <bundleDef>javax.annotation:javax.annotation-api</bundleDef>
+                                <bundleDef>org.freemarker:freemarker:${freemarker.version}</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>commons-dbcp.wso2:commons-dbcp</importBundleDef>

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/TestSamplesHandlerSuite.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/TestSamplesHandlerSuite.java
@@ -53,6 +53,7 @@ import org.apache.synapse.samples.framework.tests.endpoint.Sample56;
 import org.apache.synapse.samples.framework.tests.endpoint.Sample58;
 import org.apache.synapse.samples.framework.tests.endpoint.Sample59;
 import org.apache.synapse.samples.framework.tests.mediation.Sample17;
+import org.apache.synapse.samples.framework.tests.mediation.Sample19;
 import org.apache.synapse.samples.framework.tests.mediation.Sample363;
 import org.apache.synapse.samples.framework.tests.mediation.Sample500;
 import org.apache.synapse.samples.framework.tests.message.Sample0;
@@ -262,6 +263,7 @@ public class TestSamplesHandlerSuite extends TestSuite {
         sampleClassRepo.put("15", Sample15.class);
         sampleClassRepo.put("16", Sample16.class);
         sampleClassRepo.put("17", Sample17.class);
+        sampleClassRepo.put("18", Sample19.class);
 
         sampleClassRepo.put("350", Sample350.class);
         sampleClassRepo.put("351", Sample351.class);

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/TestSamplesHandlerSuite.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/TestSamplesHandlerSuite.java
@@ -263,7 +263,7 @@ public class TestSamplesHandlerSuite extends TestSuite {
         sampleClassRepo.put("15", Sample15.class);
         sampleClassRepo.put("16", Sample16.class);
         sampleClassRepo.put("17", Sample17.class);
-        sampleClassRepo.put("18", Sample19.class);
+        sampleClassRepo.put("19", Sample19.class);
 
         sampleClassRepo.put("350", Sample350.class);
         sampleClassRepo.put("351", Sample351.class);

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/mediation/Sample19.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/mediation/Sample19.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.samples.framework.tests.mediation;
+
+import org.apache.synapse.samples.framework.SampleClientResult;
+import org.apache.synapse.samples.framework.SynapseTestCase;
+import org.apache.synapse.samples.framework.clients.StockQuoteSampleClient;
+
+/**
+ * Test case for Sample 19: Transforming / Replacing Message Content with PayloadFactory Mediator FreeMarker 
+ * Templating Engine
+ */
+public class Sample19 extends SynapseTestCase {
+
+    public Sample19() {
+        super(19);
+    }
+
+    public void testPayloadFactoryMediator() {
+        String addUrl = "http://localhost:9000/services/SimpleStockQuoteService";
+        String trpUrl = "http://localhost:8280/";
+        StockQuoteSampleClient client = getStockQuoteClient();
+
+        log.info("Running test: Transforming message content with Payload Factory mediator");
+        SampleClientResult result = client.requestCustomQuote(addUrl, trpUrl, null, "IBM");
+        assertResponseReceived(result);
+    }
+}
+

--- a/modules/integration/src/test/resources/sample19.xml
+++ b/modules/integration/src/test/resources/sample19.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0'?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<synapseSample>
+    <sampleID>19</sampleID>
+    <sampleName>Transforming / Replacing Message Content with PayloadFactory Mediator</sampleName>
+    <synapseConfig>
+        <axis2Repo>modules/integration/target/test_repos/synapse</axis2Repo>
+        <axis2Xml>modules/integration/target/test_repos/synapse/conf/axis2_def.xml</axis2Xml>
+        <synapseXml>repository/conf/sample/synapse_sample_19.xml</synapseXml>
+    </synapseConfig>
+    <backEndServerConfig>
+        <axis2Server id='0'>
+            <axis2Repo>modules/integration/target/test_repos/axis2Server</axis2Repo>
+            <axis2Xml>modules/integration/target/test_repos/axis2Server/conf/axis2_def.xml</axis2Xml>
+        </axis2Server>
+    </backEndServerConfig>
+    <clientConfig>
+        <clientRepo>modules/integration/target/test_repos/axis2Client</clientRepo>
+    </clientConfig>
+</synapseSample>

--- a/modules/integration/src/test/resources/sample19.xml
+++ b/modules/integration/src/test/resources/sample19.xml
@@ -20,7 +20,8 @@
 
 <synapseSample>
     <sampleID>19</sampleID>
-    <sampleName>Transforming / Replacing Message Content with PayloadFactory Mediator</sampleName>
+    <sampleName>Transforming / Replacing Message Content with PayloadFactory Mediator FreeMarker Template 
+        Engine</sampleName>
     <synapseConfig>
         <axis2Repo>modules/integration/target/test_repos/synapse</axis2Repo>
         <axis2Xml>modules/integration/target/test_repos/synapse/conf/axis2_def.xml</axis2Xml>

--- a/pom.xml
+++ b/pom.xml
@@ -1172,7 +1172,7 @@
               <groupId>javax.annotation</groupId>
               <artifactId>javax.annotation-api</artifactId>
               <version>${javax.annotation.verion}</version>
-          </dependency>
+           </dependency>
           <dependency>
               <groupId>org.freemarker</groupId>
               <artifactId>freemarker</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1172,7 +1172,12 @@
               <groupId>javax.annotation</groupId>
               <artifactId>javax.annotation-api</artifactId>
               <version>${javax.annotation.verion}</version>
-           </dependency>
+          </dependency>
+          <dependency>
+              <groupId>org.freemarker</groupId>
+              <artifactId>freemarker</artifactId>
+              <version>${freemarker.version}</version>
+          </dependency>
       </dependencies>
    </dependencyManagement>
     <reporting>
@@ -1391,6 +1396,7 @@
        <com.hierynomus.smbj.version>0.10.0.wso2v2</com.hierynomus.smbj.version>
        <com.hierynomus.asn1.version>0.4.0.wso2v2</com.hierynomus.asn1.version>
        <net.engio.mbassador.version>1.3.2.wso2v2</net.engio.mbassador.version>
+       <freemarker.version>2.3.30</freemarker.version>
    </properties>
    <developers>
       <!-- If you are a committer and your name is not listed here, please include/edit -->

--- a/repository/conf/sample/synapse_sample_19.xml
+++ b/repository/conf/sample/synapse_sample_19.xml
@@ -22,7 +22,7 @@
     <sequence name="main">
         <in>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the request message -->
-            <payloadFactory media-type="xml">
+            <payloadFactory media-type="xml" template-type="freemarker">
                 <format>
                     <m:getQuote xmlns:m="http://services.samples">
                         <m:request>
@@ -37,7 +37,7 @@
         </in>
         <out>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the response message -->
-            <payloadFactory media-type="xml">
+            <payloadFactory media-type="xml" template-type="freemarker">
                 <format>
                     <m:CheckPriceResponse xmlns:m="http://services.samples/xsd">
                         <m:Code>${args.arg1}</m:Code>

--- a/repository/conf/sample/synapse_sample_19.xml
+++ b/repository/conf/sample/synapse_sample_19.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <sequence name="main">
+        <in>
+            <!-- using payloadFactory mediator FreeMarker templating engine to transform the request message -->
+            <payloadFactory media-type="xml">
+                <format>
+                    <m:getQuote xmlns:m="http://services.samples">
+                        <m:request>
+                            <m:symbol>${args.arg1}</m:symbol>
+                        </m:request>
+                    </m:getQuote>
+                </format>
+                <args>
+                    <arg xmlns:m0="http://services.samples" expression="//m0:Code"/>
+                </args>
+            </payloadFactory>
+        </in>
+        <out>
+            <!-- using payloadFactory mediator FreeMarker templating engine to transform the response message -->
+            <payloadFactory media-type="xml">
+                <format>
+                    <m:CheckPriceResponse xmlns:m="http://services.samples/xsd">
+                        <m:Code>${args.arg1}</m:Code>
+                        <m:Price>${args.arg2}</m:Price>
+                    </m:CheckPriceResponse>
+                </format>
+                <args>
+                    <arg xmlns:m0="http://services.samples/xsd" expression="//m0:symbol"/>
+                    <arg xmlns:m0="http://services.samples/xsd" expression="//m0:last"/>
+                </args>
+            </payloadFactory>
+        </out>
+        <send/>
+    </sequence>
+</definitions>

--- a/repository/conf/sample/synapse_sample_19.xml
+++ b/repository/conf/sample/synapse_sample_19.xml
@@ -23,8 +23,8 @@
         <in>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the request message -->
             <payloadFactory media-type="xml" template-type="freemarker">
-                <format><![CDATA[
-                    <m:getQuote xmlns:m="http://services.samples">
+                <format>
+           <![CDATA[<m:getQuote xmlns:m="http://services.samples">
                         <m:request>
                             <m:symbol>${args.arg1}</m:symbol>
                         </m:request>
@@ -38,8 +38,8 @@
         <out>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the response message -->
             <payloadFactory media-type="xml" template-type="freemarker">
-                <format><![CDATA[
-                    <m:CheckPriceResponse xmlns:m="http://services.samples/xsd">
+                <format>
+           <![CDATA[<m:CheckPriceResponse xmlns:m="http://services.samples/xsd">
                         <m:Code>${args.arg1}</m:Code>
                         <m:Price>${args.arg2}</m:Price>
                     </m:CheckPriceResponse>]]>

--- a/repository/conf/sample/synapse_sample_19.xml
+++ b/repository/conf/sample/synapse_sample_19.xml
@@ -23,12 +23,12 @@
         <in>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the request message -->
             <payloadFactory media-type="xml" template-type="freemarker">
-                <format>
+                <format><![CDATA[
                     <m:getQuote xmlns:m="http://services.samples">
                         <m:request>
                             <m:symbol>${args.arg1}</m:symbol>
                         </m:request>
-                    </m:getQuote>
+                    </m:getQuote>]]>
                 </format>
                 <args>
                     <arg xmlns:m0="http://services.samples" expression="//m0:Code"/>
@@ -38,11 +38,11 @@
         <out>
             <!-- using payloadFactory mediator FreeMarker templating engine to transform the response message -->
             <payloadFactory media-type="xml" template-type="freemarker">
-                <format>
+                <format><![CDATA[
                     <m:CheckPriceResponse xmlns:m="http://services.samples/xsd">
                         <m:Code>${args.arg1}</m:Code>
                         <m:Price>${args.arg2}</m:Price>
-                    </m:CheckPriceResponse>
+                    </m:CheckPriceResponse>]]>
                 </format>
                 <args>
                     <arg xmlns:m0="http://services.samples/xsd" expression="//m0:symbol"/>


### PR DESCRIPTION
## Purpose

This PR adds FreeMarker support for the PayloadFactory mediator. A new attribute is added to the synapse syntax of the PayloadFactory mediator to switch between default script implementation and FreeMarker implementation. For backward compatibility, if that attribute is not set, then the default implementation would get selected. 


## Samples
A sample synapse syntax is as bellow,

```xml
<payloadFactory media-type="xml" template-type="freemarker">
                <format><![CDATA[<name>${payload.name}</name>]]></format>
                <args/>
</payloadFactory>
```
