### PR TITLE
Allow 'value' attribute in Class Mediator properties to have empty values

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorPropertyFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorPropertyFactory.java
@@ -73,9 +73,9 @@ public class MediatorPropertyFactory {
 
             // if a value is specified, use it, else look for an expression
             if (attValue != null) {
-
-                if (attValue.getAttributeValue() == null ||
-                    attValue.getAttributeValue().trim().length() == 0) {
+                // class mediator can have empty values for value attribute
+                if (mediator == null && (attValue.getAttributeValue() == null ||
+                    attValue.getAttributeValue().trim().isEmpty())) {
                     
                     String msg = "Entry attribute value (if specified) " +
                         "is required for a Log property";


### PR DESCRIPTION
## Purpose
$subject. 

Related issue: wso2/product-ei#5306

Related PR: https://github.com/wso2-support/wso2-synapse/pull/917