### PR TITLE
Add json-eval support for DB report mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractDBMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractDBMediatorFactory.java
@@ -323,24 +323,24 @@ public abstract class AbstractDBMediatorFactory extends AbstractMediatorFactory 
             while (paramIter.hasNext()) {
 
                 OMElement paramElt = (OMElement) paramIter.next();
-                String xpath = getAttribute(paramElt, ATT_EXPRN);
+                String strPath = getAttribute(paramElt, ATT_EXPRN);
                 String value = getAttribute(paramElt, ATT_VALUE);
 
-                if (xpath != null || value != null) {
+                if (strPath != null || value != null) {
 
-                    SynapseXPath xp = null;
-                    if (xpath != null) {
+                    SynapsePath path = null;
+                    if (strPath != null) {
                         try {
-                            xp = SynapseXPathFactory.getSynapseXPath(paramElt, ATT_EXPRN);
+                            path = SynapsePathFactory.getSynapsePath(paramElt, ATT_EXPRN);
 
                         } catch (JaxenException e) {
-                            handleException("Invalid XPath specified for the source attribute : " +
-                                    xpath);
+                            handleException("Invalid XPath/JsonPath specified for the source attribute : " +
+                                    strPath);
                         }
                     }
                     statement.addParameter(
                             value,
-                            xp,
+                            path,
                             getAttribute(paramElt, ATT_TYPE));
                 }
             }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractDBMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractDBMediatorSerializer.java
@@ -233,8 +233,8 @@ public abstract class AbstractDBMediatorSerializer extends AbstractMediatorSeria
             paramElt.addAttribute(
                 fac.createOMAttribute("value", nullNS, param.getPropertyName()));
         }
-        if (param.getXpath() != null) {
-            SynapseXPathSerializer.serializeXPath(param.getXpath(), paramElt, "expression");
+        if (param.getPath() != null) {
+            SynapsePathSerializer.serializePath(param.getPath(), paramElt, "expression");
         }
 
         switch (param.getType()) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
@@ -23,7 +23,6 @@ import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.dbcp.datasources.PerUserPoolDataSource;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;
@@ -37,10 +36,7 @@ import org.apache.synapse.commons.datasource.DatasourceMBeanRepository;
 import org.apache.synapse.commons.datasource.RepositoryBasedDataSourceFinder;
 import org.apache.synapse.commons.datasource.factory.DataSourceFactory;
 import org.apache.synapse.commons.jmx.MBeanRepository;
-import org.apache.synapse.mediators.Value;
 import org.apache.synapse.util.resolver.SecureVaultResolver;
-import org.apache.synapse.util.xpath.SynapseXPath;
-import org.jaxen.JaxenException;
 import org.wso2.securevault.secret.SecretManager;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -62,8 +58,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * This abstract DB mediator will perform common DB connection pooling etc. for all DB mediators
@@ -392,7 +386,7 @@ public abstract class AbstractDBMediator extends AbstractMediator implements Man
                 continue;
             }
             String value = (param.getPropertyName() != null ?
-                    param.getPropertyName() : param.getXpath().stringValueOf(msgCtx));
+                    param.getPropertyName() : param.getPath().stringValueOf(msgCtx));
 
             if (synLog.isTraceOrDebugEnabled()) {
                 synLog.traceOrDebug("Setting as parameter : " + column + " value : " + value +

--- a/modules/core/src/main/java/org/apache/synapse/mediators/db/Statement.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/db/Statement.java
@@ -20,7 +20,7 @@
 package org.apache.synapse.mediators.db;
 
 import org.apache.synapse.SynapseException;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.config.xml.SynapsePath;
 
 import java.sql.Types;
 import java.util.ArrayList;
@@ -46,8 +46,8 @@ public class Statement {
         return rawStatement;
     }
 
-    public void addParameter(String propertyName, SynapseXPath xpath, String type){
-        parameters.add(new Parameter(propertyName, xpath, type));
+    public void addParameter(String propertyName, SynapsePath path, String type){
+        parameters.add(new Parameter(propertyName, path, type));
     }
 
     public void addResult(String propertyName, String column) {
@@ -64,13 +64,13 @@ public class Statement {
 
     public static class Parameter {
         String propertyName = null;
-        SynapseXPath xpath = null;
+        SynapsePath path = null;
         int type = 0;
 
-        Parameter(String value, SynapseXPath xpath, String type) {
+        Parameter(String value, SynapsePath path, String type) {
 
             this.propertyName = value;
-            this.xpath = xpath; 
+            this.path = path;
             if ("CHAR".equals(type)) {
                 this.type = Types.CHAR;
             } else if ("VARCHAR".equals(type)) {
@@ -112,8 +112,8 @@ public class Statement {
             return propertyName;
         }
 
-        public SynapseXPath getXpath() {
-            return xpath;
+        public SynapsePath getPath() {
+            return path;
         }
 
         public int getType() {

--- a/modules/core/src/test/java/org/apache/synapse/mediators/db/DBReportMediatorJsonTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/db/DBReportMediatorJsonTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.synapse.mediators.db;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.config.xml.DBReportMediatorFactory;
+import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.apache.synapse.mediators.AbstractMediatorTestCase;
+import org.apache.synapse.mediators.TestUtils;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class DBReportMediatorJsonTest extends AbstractMediatorTestCase {
+
+    private static DBReportMediator report;
+
+    public void testReportMediatorJsonPath() throws Exception {
+        MessageContext synCtx = TestUtils.getTestContextJson(
+                "{\"from\":\"me\",\"count\":5,\"to\":\"you\",\"category\":\"GOLD\"}", null);
+        assertTrue(report.mediate(synCtx));
+        Connection con = report.getDataSource().getConnection();
+        ResultSet rs = con.createStatement().executeQuery(
+                "select fromepr, cnt, toepr, category from audit");
+        if (rs.next()) {
+            assertEquals("me", rs.getString("fromepr"));
+            assertEquals(5, rs.getInt("cnt"));
+            assertEquals("you", rs.getString("toepr"));
+            assertEquals("GOLD", rs.getString("category"));
+        } else {
+            fail("DB report json use case failed");
+        }
+        assertEquals("Validate updated raw count", synCtx.getProperty("DBREPORT_MODIFIED_RAW_COUNT"), 1);
+    }
+
+    public static Test suite() {
+        return new TestSetup(new TestSuite(DBReportMediatorJsonTest.class)) {
+
+            @Override
+            protected void setUp() throws Exception {
+
+                String baseDir = System.getProperty("basedir");
+                if (baseDir == null) {
+                    baseDir = ".";
+                }
+
+                report = (DBReportMediator)
+                        new DBReportMediatorFactory().createMediator(createOMElement(
+                                "<dbreport xmlns=\"http://ws.apache.org/ns/synapse\">\n" +
+                                        "  <connection>\n" +
+                                        "    <pool>\n" +
+                                        "      <driver>org.apache.derby.jdbc.EmbeddedDriver</driver>\n" +
+                                        "      <url>jdbc:derby:" + baseDir + "/target/derbyDB;create=true</url>\n" +
+                                        "      <user>user</user>\n" +
+                                        "      <password>pass</password>\n" +
+                                        "      <property name=\"initialsize\" value=\"2\"/>\n" +
+                                        "      <property name=\"isolation\" value=\"Connection.TRANSACTION_SERIALIZABLE\"/>\n" +
+                                        "    </pool>\n" +
+                                        "  </connection>\n" +
+                                        "  <statement>\n" +
+                                        "    <sql>insert into audit values(?, ?, ?, ?)</sql>\n" +
+                                        "    <parameter expression=\"json-eval($.from)\" type=\"VARCHAR\"/>\n" +
+                                        "    <parameter expression=\"json-eval($.count)\" type=\"INTEGER\"/>\n" +
+                                        "    <parameter expression=\"json-eval($.to)\" type=\"VARCHAR\"/>\n" +
+                                        "    <parameter value=\"GOLD\" type=\"VARCHAR\"/>\n" +
+                                        "  </statement>\n" +
+                                        "</dbreport>"
+                                                                                    ), new Properties());
+
+                report.init(new Axis2SynapseEnvironment(new SynapseConfiguration()));
+
+                java.sql.Statement s = report.getDataSource().getConnection().createStatement();
+                try {
+                    s.execute("drop table audit");
+                } catch (SQLException ignore) {}
+                s.execute("create table audit(fromepr varchar(10), cnt int, toepr varchar(10), category varchar(10))");
+                s.close();
+            }
+
+            @Override
+            protected void tearDown() throws Exception {
+
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Purpose
This PR fixes [https://github.com/wso2/micro-integrator/issues/1633](https://github.com/wso2/micro-integrator/issues/1633)
With this users can now use json path expressions as parameters in DB report mediator. Ex:
`<dbreport>
                <connection>
                    <pool>
                        <dsName>CARBON_DS</dsName>
                    </pool>
                </connection>
                <statement>
                    <sql><![CDATA[update company set price=100 where name =?]]></sql>
                    <parameter expression="json-eval($.name)" type="VARCHAR"/>
                </statement>
            </dbreport>`


## Documentation
https://ei.docs.wso2.com/en/7.2.0/micro-integrator/references/mediators/dB-Report-Mediator/#database-write-operation-within-a-transaction

## Automation tests
 - Unit tests 
   Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK8