### PR TITLE
Fix GC issue of not clearing activeAggregates upon Malformed JSON

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
@@ -22,6 +22,7 @@ package org.apache.synapse.mediators.eip.aggregator;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import java.io.ByteArrayInputStream;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAP11Constants;
@@ -620,6 +621,8 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
                             aggregationExpression.toString(), e, synCtx);
                 } catch (SynapseException e) {
                     handleException(aggregate, "Error evaluating expression: " + aggregationExpression.toString() , e, synCtx);
+                } catch (JsonSyntaxException e) {
+                    handleException(aggregate, "Error reading JSON element: " + aggregationExpression.toString() , e, synCtx);
                 }
             }
         }
@@ -804,6 +807,7 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
     
     private void handleException(Aggregate aggregate, String msg, Exception exception, MessageContext msgContext) {
         aggregate.clear();
+        activeAggregates.clear();
         if (exception != null) {
             super.handleException(msg, exception, msgContext);
         } else {

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -294,8 +294,7 @@ public class SynapseJsonPath extends SynapsePath {
         }
         List result = new ArrayList();
         try {
-            Object object = jsonPath.read(jsonStream);
-            object = formatJsonPathResponse(jsonPath.read(jsonStream));
+            Object object = formatJsonPathResponse(jsonPath.read(jsonStream));
             if (object != null) {
                 if (object instanceof List && !jsonPath.isDefinite()) {
                     result = (List) object;


### PR DESCRIPTION
## Purpose
This fixes the issue of Messages not getting garbage collected in Aggregate mediator when the messages contain a malformed payload. 
When a malformed payload is received JsonSyntaxException is thrown. Upon the exception, we need to catch it and then handle the messages.

Fixes: https://github.com/wso2/product-ei/issues/5318