### PR TITLE
Do not update Context state if the current state is the same

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
@@ -165,6 +165,9 @@ public class SourceContext {
         SourceContext sourceContext = (SourceContext)
                 conn.getContext().getAttribute(CONNECTION_INFORMATION);
         if (sourceContext != null) {
+            if(sourceContext.getState() == state) {
+                return;
+            }
             if (sourceContext.getSourceConfiguration().isCorrelationLoggingEnabled()) {
                 long lastStateUpdateTime = sourceContext.getLastStateUpdatedTime();
                 String url = "", method = "";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
@@ -154,6 +154,9 @@ public class TargetContext {
         TargetContext targetContext = (TargetContext)
                 conn.getContext().getAttribute(CONNECTION_INFORMATION);
         if (targetContext != null) {
+            if(targetContext.getState() == state) {
+                return;
+            }
             targetContext.setState(state);
             if (targetContext.getTargetConfiguration().isCorrelationLoggingEnabled() && isCorrelationIdAvailable(conn)) {
                 long lastStateUpdateTime = targetContext.getLastStateUpdatedTime();


### PR DESCRIPTION
If `-DenableCorrelationLogs=true` is set and the endpoint called responds in a chunked way both `org.apache.synapse.transport.passthru.TargetContext`and `org.apache.synapse.transport.passthru.SourceContext` are called for each chunk and an entry in the log is written: this behavior can be responsable of slowdowns because of logger is not async or file system performance.
 
## Purpose
In a pass through request, if -DenableCorrelationLogs=true is set and the endpoint response is chunked avoid to write correlation log for each RESPONSE_BODY updateState to increase performance.

## Goals
Fix `org.apache.synapse.transport.passthru.TargetContext`and `org.apache.synapse.transport.passthru.SourceContext` just to return immediatly if the state parameter has the same value of the connection context.

