### PR TITLE
Enable setCharacterEncoding property in XFormURLEncodedFormatter

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/formatters/XFormURLEncodedFormatter.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/formatters/XFormURLEncodedFormatter.java
@@ -91,7 +91,10 @@ public class XFormURLEncodedFormatter implements MessageFormatter {
         String encoding = format.getCharSetEncoding();
         String contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
 
-        if (encoding != null) {
+        String setEncoding = (String) messageContext.getProperty(
+                Constants.Configuration.SET_CONTENT_TYPE_CHARACTER_ENCODING);
+
+        if (encoding != null && !"false".equals(setEncoding)) {
             contentType += "; charset=" + encoding;
         }
 


### PR DESCRIPTION
### Purpose
setCharacterEncoding property should be checked before appending charset encoding to outgoing request.

## Approach
Prior to append charset encoding, setCharacterEncoding property will be checked. If the property is false, charset encoding will not be appended.

Related issue: https://github.com/wso2/product-ei/issues/4082 and https://github.com/wso2/product-ei/issues/4970