### PR TITLE
Throw excpetion in write functions if the consumer is broken.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -545,7 +545,12 @@ public class Pipe {
             try {
                 setInputMode(outputBuffer);
                 int remaining = len;
-
+                // if there is a consumer error or a stale connection, there is no point of trying to write.
+                // ex: when client connection is closed while writing back the response
+                if (consumerError || isStale) {
+                    buffer.clear();
+                    throw new IOException("Consumer error or stale connection has occurred.");
+                }
                 if (consumerIoControl instanceof NHttpServerConnection) {
                     if (((NHttpServerConnection) consumerIoControl).isStale()) {
                         isStale = true;


### PR DESCRIPTION
If the consumer connection is stale or there exists a consumer error, then an error has to be thrown and prevent any future writes for that same consumer.
Fixes: https://github.com/wso2/product-ei/issues/5331

