### PR TITLE
Changing FreeMarker dependency resolver from feature to orbit

### DIFF
--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -111,10 +111,6 @@
             <groupId>org.antlr.wso2</groupId>
             <artifactId>antlr-runtime</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -161,7 +157,6 @@
                                 <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
                                 <bundleDef>org.wso2.orbit.io.jaeger:jaeger-client:${jaeger-client.version}</bundleDef>
                                 <bundleDef>javax.annotation:javax.annotation-api</bundleDef>
-                                <bundleDef>org.freemarker:freemarker:${freemarker.version}</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>commons-dbcp.wso2:commons-dbcp</importBundleDef>


### PR DESCRIPTION
## Purpose
Removing the FreeMarker feature from synapse. FreeMarker dependency is getting from the orbit now.



## Related PRs
https://github.com/wso2/carbon-mediation/pull/1483
https://github.com/wso2/orbit/pull/442
