### PR TITLE
Add Stream Interceptor 

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
@@ -190,6 +190,10 @@ public class ClientWorker implements Runnable {
                 response.getConnection());
         responseMsgCtx.setProperty(CorrelationConstants.CORRELATION_ID,
                 outMsgCtx.getProperty(CorrelationConstants.CORRELATION_ID));
+        responseMsgCtx.setProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE,
+                                   outMsgCtx.getProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE));
+        response.getConnection().getContext().setAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT,
+                                                           responseMsgCtx);
     }
 
     private void initTenantInfo() {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DefaultStreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DefaultStreamInterceptor.java
@@ -21,8 +21,8 @@ package org.apache.synapse.transport.passthru;
 import org.apache.axis2.context.MessageContext;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Default class implementing the methods of {@link StreamInterceptor}. A stream interceptor can be written by
@@ -31,8 +31,7 @@ import java.util.Map;
  */
 public abstract class DefaultStreamInterceptor implements StreamInterceptor {
 
-    private String name;
-    private Map<String, Object> properties = new HashMap<String, Object>();
+    private Properties properties = new Properties();
 
     public boolean interceptSourceRequest(MessageContext axisCtx) {
         return false;
@@ -74,11 +73,4 @@ public abstract class DefaultStreamInterceptor implements StreamInterceptor {
         return properties;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DefaultStreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DefaultStreamInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.passthru;
+
+import org.apache.axis2.context.MessageContext;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default class implementing the methods of {@link StreamInterceptor}. A stream interceptor can be written by
+ * extending and overding the necessary methods of this class.
+ * For an example see{@link SampleStreamInterceptor}
+ */
+public abstract class DefaultStreamInterceptor implements StreamInterceptor {
+
+    private String name;
+    private Map<String, Object> properties = new HashMap<String, Object>();
+
+    public boolean interceptSourceRequest(MessageContext axisCtx) {
+        return false;
+    }
+
+    public boolean sourceRequest(ByteBuffer buffer, MessageContext axisCtx) {
+        return true;
+    }
+
+    public boolean interceptTargetRequest(MessageContext axisCtx) {
+        return false;
+    }
+
+    public void targetRequest(ByteBuffer buffer, MessageContext axisCtx) {
+
+    }
+
+    public boolean interceptTargetResponse(MessageContext axisCtx) {
+        return false;
+    }
+
+    public boolean targetResponse(ByteBuffer buffer, MessageContext axisCtx) {
+        return true;
+    }
+
+    public boolean interceptSourceResponse(MessageContext axisCtx) {
+        return false;
+    }
+
+    public void sourceResponse(ByteBuffer buffer, MessageContext axisCtx) {
+
+    }
+
+    public void addProperty(String name, Object value) {
+        properties.put(name, value);
+    }
+
+    public Map getProperties() {
+        return properties;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.nio.NHttpClientConnection;
+import org.apache.http.protocol.HttpContext;
 import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.transport.http.conn.ProxyConfig;
 import org.apache.synapse.transport.http.conn.SynapseDebugInfoHolder;
@@ -254,8 +255,10 @@ public class DeliveryAgent {
     private void tryNextMessage(MessageContext messageContext, HttpRoute route, NHttpClientConnection conn) {
         if (conn != null) {
             try {
-                conn.getContext().setAttribute(CorrelationConstants.CORRELATION_ID,
-                        messageContext.getProperty(CorrelationConstants.CORRELATION_ID));
+                HttpContext ctx = conn.getContext();
+                ctx.setAttribute(CorrelationConstants.CORRELATION_ID,
+                                 messageContext.getProperty(CorrelationConstants.CORRELATION_ID));
+                ctx.setAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT, messageContext);
                 TargetContext.updateState(conn, ProtocolState.REQUEST_READY);
                 TargetContext.get(conn).setRequestMsgCtx(messageContext);
                 if (log.isDebugEnabled()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -22,6 +22,8 @@ public class PassThroughConstants {
     public static final int DEFAULT_MAX_CONN_PER_HOST_PORT = Integer.MAX_VALUE;
     
     public static final String REQUEST_MESSAGE_CONTEXT = "REQUEST_MESSAGE_CONTEXT";
+    public static final String RESPONSE_MESSAGE_CONTEXT = "RESPONSE_MESSAGE_CONTEXT";
+    public static final String SYNAPSE_ARTIFACT_TYPE = "SYNAPSE_ARTIFACT_TYPE";
     public static final String CONNECTION_POOL = "CONNECTION_POOL";
     public static final String TUNNEL_HANDLER = "TUNNEL_HANDLER";
     public static final String CONNECTION_INIT_TIME = "CONNECTION_INIT_TIME";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -74,6 +74,7 @@ import org.apache.synapse.transport.passthru.jmx.TransportView;
 
 import org.apache.synapse.transport.passthru.util.ActiveConnectionMonitor;
 import org.apache.synapse.transport.passthru.util.SessionContextUtil;
+import org.apache.synapse.transport.passthru.util.StreamInterceptorsLoader;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -127,6 +128,8 @@ public class PassThroughHttpListener implements TransportListener {
     private TransportInDescription pttInDescription;
 
     private ConfigurationContext configurationContext;
+
+    private List<StreamInterceptor> interceptors;
 
     /**
      * HttpListener Running port
@@ -184,7 +187,8 @@ public class PassThroughHttpListener implements TransportListener {
         ServerConnFactoryBuilder connFactoryBuilder = initConnFactoryBuilder(transportInDescription, host, cfgCtx);
         connFactory = connFactoryBuilder.build(sourceConfiguration.getHttpParams());
 
-        handler = new SourceHandler(sourceConfiguration);
+        interceptors = StreamInterceptorsLoader.getInterceptors();
+        handler = new SourceHandler(sourceConfiguration , interceptors);
         passThroughListeningIOReactorManager = PassThroughListeningIOReactorManager.getInstance();
 
         // register to receive updates on services for lifetime management

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -26,7 +26,6 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.synapse.transport.passthru.config.BaseConfiguration;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
-import org.apache.synapse.transport.passthru.util.RelayUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -165,8 +164,8 @@ public class Pipe {
     }
 
     /**
-     * Same as {@link Pipe#consume(org.apache.http.nio.ContentEncoder)} but this gives a copy of data which has been
-     * consumed.
+     * Consume the data from the buffer. Same as {@link Pipe#consume(org.apache.http.nio.ContentEncoder)} but this gives
+     * a copy of data which has been consumed.
      *
      * @param encoder encoder used to write
      * @return a buffer with data written (consumed)
@@ -191,12 +190,12 @@ public class Pipe {
             setOutputMode(consumerBuffer);
             // clone original buffer
             ByteBuffer originalBuffer = consumerBuffer.getByteBuffer();
-            ByteBuffer duplicate = RelayUtils.cloneBuffer(originalBuffer);
             int bytesWritten = encoder.write(originalBuffer);
+            ByteBuffer duplicate = originalBuffer.duplicate();
             // replicate positions of original buffer in duplicated buffer
             int position = originalBuffer.position();
             duplicate.limit(position);
-            if (position - bytesWritten > 0) {
+            if (bytesWritten > 0) {
                 duplicate.position(position - bytesWritten);
             }
             consumePostActions(consumerBuffer, encoder, bytesWritten);
@@ -282,7 +281,7 @@ public class Pipe {
                 // clone original buffer
                 ByteBuffer originalBuffer = buffer.getByteBuffer();
                 bytesRead = decoder.read(originalBuffer);
-                duplicate = originalBuffer.duplicate(); //RelayUtils.cloneBuffer(originalBuffer);
+                duplicate = originalBuffer.duplicate();
                 // replicate positions of original buffer in duplicated buffer
                 int position = originalBuffer.position();
                 duplicate.limit(position);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SampleStreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SampleStreamInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.passthru;
+
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ * Sample stream interceptor, which intercepts source and target request to print the stream passing via the engine.
+ * <pre>
+ * {@code
+ * <interceptors xmlns:svns="http://org.wso2.securevault/configuration">
+ *     <interceptor name="SampleStreamInterceptor" class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
+ *         <parameter name="charset" value="ISO-8859-1"/>
+ *         <parameter name="enableInterception" value="true"/>
+ *     </interceptor>
+ * </interceptors>
+ * }
+ * </pre>
+ */
+public class SampleStreamInterceptor extends DefaultStreamInterceptor {
+
+    private static final Log log = LogFactory.getLog(SampleStreamInterceptor.class);
+
+    private static final String INPUT = ">>>";
+    private static final String OUTPUT = "<<<";
+
+    private String charset = Charset.defaultCharset().toString();
+    private boolean enableInterception = false;
+
+    @Override
+    public boolean interceptSourceRequest(MessageContext axisCtx) {
+        return enableInterception;
+    }
+
+    @Override
+    public boolean sourceRequest(ByteBuffer buffer, MessageContext ctx) {
+        printStream(buffer, INPUT);
+        return true;
+    }
+
+    @Override
+    public boolean interceptTargetRequest(MessageContext axisCtx) {
+        return enableInterception;
+    }
+
+    @Override
+    public void targetRequest(ByteBuffer buffer, MessageContext ctx) {
+        printStream(buffer, OUTPUT);
+    }
+
+    @Override
+    public boolean interceptTargetResponse(MessageContext axisCtx) {
+        return enableInterception;
+    }
+
+    @Override
+    public boolean targetResponse(ByteBuffer buffer, MessageContext ctx) {
+        printStream(buffer, INPUT);
+        return true;
+    }
+
+    @Override
+    public boolean interceptSourceResponse(MessageContext axisCtx) {
+        return enableInterception;
+    }
+
+    @Override
+    public void sourceResponse(ByteBuffer buffer, MessageContext ctx) {
+        printStream(buffer, OUTPUT);
+    }
+
+    private void printStream(ByteBuffer stream, String direction) {
+
+        Charset charsetValue = Charset.forName(this.charset);
+        String text = charsetValue.decode(stream).toString();
+        log.info(direction + " " + text);
+    }
+
+    public void setCharset(String charset) {
+
+        this.charset = charset;
+        if (log.isDebugEnabled()) {
+            log.debug("Charset : " + charset);
+        }
+    }
+
+    public void setEnableInterception(boolean enableInterception) {
+        this.enableInterception = enableInterception;
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SampleStreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SampleStreamInterceptor.java
@@ -30,7 +30,7 @@ import java.nio.charset.Charset;
  * <pre>
  * {@code
  * <interceptors xmlns:svns="http://org.wso2.securevault/configuration">
- *     <interceptor name="SampleStreamInterceptor" class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
+ *     <interceptor class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
  *         <parameter name="charset" value="ISO-8859-1"/>
  *         <parameter name="enableInterception" value="true"/>
  *     </interceptor>

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -127,6 +127,7 @@ public class ServerWorker implements Runnable {
                                request.getConnection().getContext().getAttribute(SynapseDebugInfoHolder.SYNAPSE_WIRE_LOG_HOLDER_PROPERTY));
         request.getConnection().getContext().setAttribute(NhttpConstants.SERVER_WORKER_INIT_TIME,
                 System.currentTimeMillis());
+        request.getConnection().getContext().setAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT, msgContext);
     }
 
     public ServerWorker(final SourceRequest request,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -16,9 +16,17 @@
 
 package org.apache.synapse.transport.passthru;
 
+import org.apache.axis2.context.MessageContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.*;
+import org.apache.http.ConnectionClosedException;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.nio.ContentDecoder;
 import org.apache.http.nio.ContentEncoder;
@@ -33,8 +41,8 @@ import org.apache.http.params.DefaultedHttpParams;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
-import org.apache.synapse.commons.jmx.ThreadingView;
 import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.commons.jmx.ThreadingView;
 import org.apache.synapse.commons.logger.ContextAwareLogger;
 import org.apache.synapse.commons.transaction.TranscationManger;
 import org.apache.synapse.commons.util.MiscellaneousUtil;
@@ -46,14 +54,16 @@ import org.apache.synapse.transport.passthru.jmx.LatencyCollector;
 import org.apache.synapse.transport.passthru.jmx.LatencyView;
 import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
 
-import javax.net.ssl.SSLException;
-import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import javax.net.ssl.SSLException;
+import javax.ws.rs.HttpMethod;
 
 /**
  * This is the class where transport interacts with the client. This class
@@ -82,9 +92,16 @@ public class SourceHandler implements NHttpServerEventHandler {
     public static final String MESSAGE_SIZE_VALIDATION = "message.size.validation.enabled";
     public static final String VALID_MAX_MESSAGE_SIZE = "valid.max.message.size.in.bytes";
 
-    public SourceHandler(SourceConfiguration sourceConfiguration) {
+    private List<StreamInterceptor> streamInterceptors;
+    private boolean interceptStream;
+    private int noOfInterceptors;
+
+    public SourceHandler(SourceConfiguration sourceConfiguration, List<StreamInterceptor> streamInterceptors) {
         this.sourceConfiguration = sourceConfiguration;
         this.metrics = sourceConfiguration.getMetrics();
+        this.streamInterceptors = streamInterceptors;
+        this.interceptStream = !streamInterceptors.isEmpty();
+        this.noOfInterceptors = streamInterceptors.size();
 
         String strNamePostfix = "";
         if (sourceConfiguration.getInDescription() != null &&
@@ -211,7 +228,49 @@ public class SourceHandler implements NHttpServerEventHandler {
 
             SourceRequest request = SourceContext.getRequest(conn);
 
-            int readBytes = request.read(conn, decoder);
+            int readBytes = 0;
+            boolean interceptionEnabled = false;
+            Boolean[] interceptorResults = new Boolean[noOfInterceptors];
+            if (interceptStream) {
+                int index = 0;
+                for (StreamInterceptor interceptor : streamInterceptors) {
+                    interceptorResults[index] = interceptor.interceptSourceRequest((MessageContext) conn.getContext()
+                            .getAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT));
+                    if (!interceptionEnabled && interceptorResults[index]) {
+                        interceptionEnabled = true;
+                    }
+                    index++;
+                }
+                if (interceptionEnabled) {
+                    ByteBuffer bytesSentDuplicate = request.copyAndRead(conn, decoder);
+                    if (bytesSentDuplicate != null) {
+                        readBytes = bytesSentDuplicate.position();
+                        index = 0;
+                        for (StreamInterceptor interceptor : streamInterceptors) {
+                            if (interceptorResults[index]) {
+                                boolean proceed = interceptor.sourceRequest(bytesSentDuplicate.duplicate(),
+                                                                            (MessageContext) conn.getContext()
+                                                                                    .getAttribute(
+                                                                                            PassThroughConstants.REQUEST_MESSAGE_CONTEXT));
+                                if (!proceed) {
+                                    log.info("Dropping source connection since request is blocked by : " + interceptor
+                                            .getName());
+                                    dropSourceConnection(conn);
+                                    conn.getContext().setAttribute(PassThroughConstants.SOURCE_CONNECTION_DROPPED,
+                                                                   true);
+                                    request.getPipe().forceProducerComplete(decoder);
+                                    break;
+                                }
+                            }
+                            index++;
+                        }
+                    }
+                } else {
+                    readBytes = request.read(conn, decoder);
+                }
+            } else {
+                readBytes = request.read(conn, decoder);
+            }
             if (isMessageSizeValidationEnabled) {
                 HttpContext httpContext = conn.getContext();
                 //this is introduced as some transports which extends passthrough source handler which have overloaded
@@ -324,7 +383,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                         }
                     }
                 }
-            
+
                 response.start(conn);
                 conn.getContext().setAttribute(PassThroughConstants.RES_TO_CLIENT_WRITE_START_TIME,
                         System.currentTimeMillis());
@@ -397,8 +456,39 @@ public class SourceHandler implements NHttpServerEventHandler {
 
             SourceResponse response = SourceContext.getResponse(conn);
 
-            int bytesSent = response.write(conn, encoder);
-            
+            int bytesSent = -1;
+            boolean interceptionEnabled = false;
+            Boolean[] interceptorResults = new Boolean[noOfInterceptors];
+            if (interceptStream) {
+                int index = 0;
+                for (StreamInterceptor interceptor : streamInterceptors) {
+                    interceptorResults[index] = interceptor.interceptSourceResponse((MessageContext) conn.getContext()
+                            .getAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT));
+                    if (!interceptionEnabled && interceptorResults[index]) {
+                        interceptionEnabled = true;
+                    }
+                    index++;
+                }
+                if (interceptionEnabled) {
+                    ByteBuffer bytesSentDuplicate = response.copyAndWrite(conn, encoder);
+                    if (bytesSentDuplicate != null) {
+                        bytesSent = bytesSentDuplicate.position();
+                        index = 0;
+                        for (StreamInterceptor interceptor : streamInterceptors) {
+                            if (interceptorResults[index]) {
+                                interceptor.sourceResponse(bytesSentDuplicate.duplicate(),
+                                                           (MessageContext) conn.getContext().getAttribute(
+                                                                   PassThroughConstants.RESPONSE_MESSAGE_CONTEXT));
+                            }
+                            index++;
+                        }
+                    }
+                } else {
+                    bytesSent = response.write(conn, encoder);
+                }
+            } else {
+                bytesSent = response.write(conn, encoder);
+            }
 			if (encoder.isCompleted()) {
                 HttpContext context = conn.getContext();
                 long departure = System.currentTimeMillis();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/StreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/StreamInterceptor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.passthru;
+
+import org.apache.axis2.context.MessageContext;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Interface For Stream Interceptors
+ * <p/>
+ * Interceptors are invoked when the data is received to the synapse engine or when data is sent out
+ * of the engine.
+ * <p/>
+ * After a connection is established, the data is read chunk wise/ whenever available. The same applies when the data
+ * leaves the engine as well. There are two requests coming into the engine and two responses going out from the
+ * engine. Interceptors will be invoked in all of these four phases
+ */
+public interface StreamInterceptor {
+
+    /**
+     * Logic to determine whether to intercept the source request
+     *
+     * @param axisCtx associated axis2MsgCtx of the request
+     * @return intercept source request or not
+     */
+    boolean interceptSourceRequest(MessageContext axisCtx);
+
+    /**
+     * Handles the request data coming in to the engine from the client
+     *
+     * @param buffer  copy of data entering in
+     * @param axisCtx associated axis2MsgCtx
+     * @return whether to continue reading the data or to close the connection
+     */
+    boolean sourceRequest(ByteBuffer buffer, MessageContext axisCtx);
+
+    /**
+     * Logic to determine whether to intercept the target request
+     *
+     * @param axisCtx associated axis2MsgCtx of the request
+     * @return intercept target request or not
+     */
+    boolean interceptTargetRequest(MessageContext axisCtx);
+
+    /**
+     * Handles the request data leaving out of the engine
+     *
+     * @param buffer  copy of data being send out
+     * @param axisCtx associated axis2MsgCtx
+     */
+    void targetRequest(ByteBuffer buffer, MessageContext axisCtx);
+
+    /**
+     * Logic to determine whether to intercept the target response
+     *
+     * @param axisCtx associated axis2MsgCtx of the response
+     * @return intercept target response or not
+     */
+    boolean interceptTargetResponse(MessageContext axisCtx);
+
+    /**
+     * Handles the response data coming in to the engine from the back end
+     *
+     * @param buffer  copy of data entering in
+     * @param axisCtx associated axis2MsgCtx
+     * @return whether to continue reading the data or to close the connection
+     */
+    boolean targetResponse(ByteBuffer buffer, MessageContext axisCtx);
+
+    /**
+     * Logic to determine whether to intercept the source response
+     *
+     * @param axisCtx associated axis2MsgCtx of the response
+     * @return intercept source response or not
+     */
+    boolean interceptSourceResponse(MessageContext axisCtx);
+
+    /**
+     * Handles the response data leaving out of the engine
+     *
+     * @param buffer  copy of data leaving
+     * @param axisCtx associated axis2MsgCtx
+     */
+    void sourceResponse(ByteBuffer buffer, MessageContext axisCtx);
+
+    /**
+     * Add an interceptor property
+     *
+     * @param name  property name
+     * @param value property value
+     */
+    void addProperty(String name, Object value);
+
+    /**
+     * Get all interceptor properties
+     *
+     * @return Map of handler properties
+     */
+    Map getProperties();
+
+    /**
+     * Get the name of the interceptor
+     *
+     * @return handler name
+     */
+    String getName();
+
+    /**
+     * Set the interceptor name
+     *
+     * @param name handler name
+     */
+    void setName(String name);
+
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/StreamInterceptor.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/StreamInterceptor.java
@@ -116,18 +116,4 @@ public interface StreamInterceptor {
      */
     Map getProperties();
 
-    /**
-     * Get the name of the interceptor
-     *
-     * @return handler name
-     */
-    String getName();
-
-    /**
-     * Set the interceptor name
-     *
-     * @param name handler name
-     */
-    void setName(String name);
-
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -51,7 +51,10 @@ import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsColl
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -86,14 +89,27 @@ public class TargetHandler implements NHttpClientEventHandler {
     public static final String MESSAGE_SIZE_VALIDATION = "message.size.validation.enabled";
     public static final String VALID_MAX_MESSAGE_SIZE = "valid.max.message.size.in.bytes";
 
+    private List<StreamInterceptor> streamInterceptors;
+    private boolean interceptStream;
+    private int noOfInterceptors;
+
+    public TargetHandler(DeliveryAgent deliveryAgent, ClientConnFactory connFactory,
+                         TargetConfiguration configuration) {
+        this(deliveryAgent, connFactory, configuration, new ArrayList<StreamInterceptor>());
+    }
+
     public TargetHandler(DeliveryAgent deliveryAgent,
                          ClientConnFactory connFactory,
-                         TargetConfiguration configuration) {
+                         TargetConfiguration configuration,
+                         List<StreamInterceptor> interceptors) {
         this.deliveryAgent = deliveryAgent;
         this.connFactory = connFactory;
         this.targetConfiguration = configuration;
         this.targetErrorHandler = new TargetErrorHandler(targetConfiguration);
         this.metrics = targetConfiguration.getMetrics();
+        this.streamInterceptors = interceptors;
+        this.interceptStream = !streamInterceptors.isEmpty();
+        this.noOfInterceptors = streamInterceptors.size();
 
         Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);
         String validationProperty = MiscellaneousUtil.getProperty(props, MESSAGE_SIZE_VALIDATION, "false");
@@ -225,7 +241,40 @@ public class TargetHandler implements NHttpClientEventHandler {
 
             TargetRequest request = TargetContext.getRequest(conn);
             if (request.hasEntityBody()) {
-                int bytesWritten = request.write(conn, encoder);
+                int bytesWritten = -1;
+                boolean interceptionEnabled = false;
+                Boolean[] interceptorResults = new Boolean[noOfInterceptors];
+                if (interceptStream) {
+                    int index = 0;
+                    for (StreamInterceptor interceptor : streamInterceptors) {
+                        interceptorResults[index] = interceptor.interceptTargetRequest(
+                                (MessageContext) conn.getContext()
+                                        .getAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT));
+                        if (!interceptionEnabled && interceptorResults[index]) {
+                            interceptionEnabled = true;
+                        }
+                        index++;
+                    }
+                    if (interceptionEnabled) {
+                        ByteBuffer bytesSentDuplicate = request.copyAndWrite(conn, encoder);
+                        if (bytesSentDuplicate != null) {
+                            bytesWritten = bytesSentDuplicate.position();
+                            index = 0;
+                            for (StreamInterceptor interceptor : streamInterceptors) {
+                                if (interceptorResults[index]) {
+                                    interceptor.targetRequest(bytesSentDuplicate.duplicate(),
+                                                              (MessageContext) conn.getContext().getAttribute(
+                                                                      PassThroughConstants.REQUEST_MESSAGE_CONTEXT));
+                                }
+                                index++;
+                            }
+                        }
+                    } else {
+                        bytesWritten = request.write(conn, encoder);
+                    }
+                } else {
+                    bytesWritten = request.write(conn, encoder);
+                }
                 if (bytesWritten > 0) {
                     if (metrics.getLevel() == MetricsCollector.LEVEL_FULL) {
                         metrics.incrementBytesSent(requestMsgCtx, bytesWritten);
@@ -498,9 +547,51 @@ public class TargetHandler implements NHttpClientEventHandler {
             TargetResponse response = TargetContext.getResponse(conn);
             int statusCode = -1;
 
-			if (response != null) {
+            if (response != null) {
                 statusCode = conn.getHttpResponse().getStatusLine().getStatusCode();
-				int responseRead = response.read(conn, decoder);
+                int responseRead = -1;
+                boolean interceptionEnabled = false;
+                Boolean[] interceptorResults = new Boolean[noOfInterceptors];
+                if (interceptStream) {
+                    int index = 0;
+                    for (StreamInterceptor interceptor : streamInterceptors) {
+                        interceptorResults[index] = interceptor.interceptTargetResponse(
+                                (MessageContext) conn.getContext()
+                                        .getAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT));
+                        if (!interceptionEnabled && interceptorResults[index]) {
+                            interceptionEnabled = true;
+                        }
+                        index++;
+                    }
+                    if (interceptionEnabled) {
+                        ByteBuffer bytesSentDuplicate = response.copyAndRead(conn, decoder);
+                        if (bytesSentDuplicate != null) {
+                            responseRead = bytesSentDuplicate.position();
+                            boolean proceed;
+                            index = 0;
+                            for (StreamInterceptor interceptor : streamInterceptors) {
+                                if (interceptorResults[index]) {
+                                    proceed = interceptor.targetResponse(bytesSentDuplicate.duplicate(),
+                                                                         (MessageContext) conn.getContext()
+                                                                                 .getAttribute(
+                                                                                         PassThroughConstants.RESPONSE_MESSAGE_CONTEXT));
+                                    if (!proceed) {
+                                        log.info("Dropping target connection since request is blocked by : "
+                                                         + interceptor.getName());
+                                        dropTargetConnection(conn);
+                                        response.getPipe().forceProducerComplete(decoder);
+                                        break;
+                                    }
+                                }
+                                index++;
+                            }
+                        }
+                    } else {
+                        responseRead = response.read(conn, decoder);
+                    }
+                } else {
+                    responseRead = response.read(conn, decoder);
+                }
           if (isMessageSizeValidationEnabled) {
               HttpContext httpContext = conn.getContext();
               //this is introduced as some transports which extends passthrough target handler which have overloaded

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
@@ -152,6 +152,8 @@ public class HostConnections {
         ctx.removeAttribute(ExecutionContext.HTTP_RESPONSE);
         ctx.setAttribute(PassThroughConstants.CONNECTION_EXPIRY_TIME, getExpiryTime(conn));
         ctx.removeAttribute(SynapseHTTPRequestFactory.ENDPOINT_URL);
+        ctx.removeAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT);
+        ctx.removeAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT);
         lock.lock();
         try {
             if (busyConnections.remove(conn)) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/SourceConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/SourceConnections.java
@@ -18,6 +18,8 @@ package org.apache.synapse.transport.passthru.connections;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.nio.NHttpServerConnection;
+import org.apache.http.protocol.HttpContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.SourceContext;
 
 import java.io.IOException;
@@ -87,6 +89,8 @@ public class SourceConnections {
      * @param conn the connection being used
      */
     public void releaseConnection(NHttpServerConnection conn) {
+
+        removeAttributes(conn);
         lock.lock();
         try {
             SourceContext.get(conn).reset();
@@ -102,6 +106,18 @@ public class SourceConnections {
         } finally {
             lock.unlock();
         }
+    }
+
+    /**
+     * Removes the attributes from the http context of the connection
+     *
+     * @param connection connection object
+     */
+    private void removeAttributes(NHttpServerConnection connection) {
+
+        HttpContext ctx = connection.getContext();
+        ctx.removeAttribute(PassThroughConstants.REQUEST_MESSAGE_CONTEXT);
+        ctx.removeAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT);
     }
 
 	/**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayConstants.java
@@ -46,4 +46,9 @@ public final class RelayConstants {
             new QName("http://ws.apache.org/commons/ns/payload", "binary");
 
     public static final String FORCE_RESPONSE_EARLY_BUILD = "FORCE_RESPONSE_EARLY_BUILD";
+
+    /**
+     * The name of the stream interceptor file
+     */
+    public static final String STREAM_INTERCEPTOR_FILE = "stream-interceptors.xml";
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -507,16 +507,6 @@ public class RelayUtils {
         }
     }
 
-    public static ByteBuffer cloneBuffer(ByteBuffer original) {
-
-        ByteBuffer clone = ByteBuffer.allocate(original.capacity());
-        original.rewind(); //copy from the beginning
-        clone.put(original);
-        original.rewind();
-        clone.flip();
-        return clone;
-    }
-
     /**
      * Consumes the data in pipe completely in the request message context and discard it
      *

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -36,7 +36,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
@@ -44,15 +43,16 @@ import org.apache.synapse.transport.passthru.ServerWorker;
 import org.apache.synapse.transport.passthru.TargetRequest;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 
-import javax.xml.stream.XMLStreamException;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import javax.xml.stream.XMLStreamException;
 
 public class RelayUtils {
 
@@ -505,6 +505,16 @@ public class RelayUtils {
                 handleException("Error when consuming the input stream to discard", exception);
             }
         }
+    }
+
+    public static ByteBuffer cloneBuffer(ByteBuffer original) {
+
+        ByteBuffer clone = ByteBuffer.allocate(original.capacity());
+        original.rewind(); //copy from the beginning
+        clone.put(original);
+        original.rewind();
+        clone.flip();
+        return clone;
     }
 
     /**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/StreamInterceptorsLoader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/StreamInterceptorsLoader.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.passthru.util;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.apache.synapse.commons.util.PropertyHelper;
+import org.apache.synapse.transport.passthru.StreamInterceptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.xml.namespace.QName;
+
+public class StreamInterceptorsLoader {
+
+    StreamInterceptorsLoader() {
+    }
+
+    private static Log log = LogFactory.getLog(StreamInterceptorsLoader.class);
+
+    private static final QName ROOT_Q = new QName("interceptors");
+    private static final QName INTERCEPTOR_Q = new QName("interceptor");
+    private static final QName CLASS_Q = new QName("class");
+    private static final QName NAME_ATT = new QName("name");
+    private static final QName PARAM_Q = new QName("parameter");
+    private static final QName VALUE_ATT = new QName("value");
+
+    private static List<StreamInterceptor> interceptors = new ArrayList<>();
+
+    private static boolean isLoadedAlready = false;
+
+    /**
+     * Load and get all synapse interceptors
+     *
+     * @return List of loaded synapse interceptors
+     */
+    public static List<StreamInterceptor> getInterceptors() {
+
+        if (!isLoadedAlready) {
+            loadInterceptors();
+            isLoadedAlready = true;
+        }
+        return Collections.unmodifiableList(interceptors);
+    }
+
+    private static void loadInterceptors() {
+
+        OMElement interceptorsConfig = MiscellaneousUtil.loadXMLConfig(RelayConstants.STREAM_INTERCEPTOR_FILE);
+        if (interceptorsConfig != null) {
+
+            if (!ROOT_Q.equals(interceptorsConfig.getQName())) {
+                handleException("Invalid interceptor configuration file");
+            }
+
+            Iterator iterator = interceptorsConfig.getChildrenWithName(INTERCEPTOR_Q);
+            while (iterator.hasNext()) {
+                OMElement interceptorElem = (OMElement) iterator.next();
+
+                String name = null;
+                if (interceptorElem.getAttribute(NAME_ATT) != null) {
+                    name = interceptorElem.getAttributeValue(NAME_ATT);
+                } else {
+                    handleException("Name not defined in one or more interceptor");
+                }
+
+                if (interceptorElem.getAttribute(CLASS_Q) != null) {
+                    String className = interceptorElem.getAttributeValue(CLASS_Q);
+                    if (!"".equals(className)) {
+                        StreamInterceptor interceptor = createInterceptor(className);
+                        interceptors.add(interceptor);
+                        interceptor.setName(name);
+                        populateParameters(interceptorElem, interceptor);
+                    } else {
+                        handleException("Class name is null for interceptor name : " + name);
+                    }
+                } else {
+                    handleException("Class name not defined for interceptor named : " + name);
+                }
+
+            }
+        }
+    }
+
+    private static StreamInterceptor createInterceptor(String classFQName) {
+
+        Object obj = null;
+        try {
+            obj = Class.forName(classFQName).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            handleException("Error creating Interceptor for class name : " + classFQName, e);
+        }
+        if (obj instanceof StreamInterceptor) {
+            return (StreamInterceptor) obj;
+        } else {
+            handleException(
+                    "Error creating StreamInterceptor. The Interceptor should be of type org.apache.synapse.transport.passthru.StreamInterceptor");
+        }
+        return null;
+    }
+
+    private static void populateParameters(OMElement handlerElem, StreamInterceptor interceptor) {
+
+        for (Iterator it = handlerElem.getChildrenWithName(PARAM_Q); it.hasNext(); ) {
+            OMElement child = (OMElement) it.next();
+
+            String propName = child.getAttribute(NAME_ATT).getAttributeValue();
+            if (propName == null) {
+                handleException("StreamInterceptor parameter must contain the name attribute");
+            } else {
+                if (child.getAttribute(VALUE_ATT) != null) {
+                    String value = child.getAttribute(VALUE_ATT).getAttributeValue();
+                    interceptor.addProperty(propName, value);
+                    PropertyHelper.setInstanceProperty(propName, value, interceptor);
+                } else {
+                    OMNode omElt = child.getFirstElement();
+                    if (omElt != null) {
+                        interceptor.addProperty(propName, omElt);
+                        PropertyHelper.setInstanceProperty(propName, omElt, interceptor);
+                    } else {
+                        handleException(
+                                "StreamInterceptor parameter must contain name and value attributes, or a name and a child XML fragment");
+                    }
+                }
+            }
+        }
+    }
+
+    private static void handleException(String msg) {
+        log.error(msg);
+        throw new RuntimeException(msg);
+    }
+
+    private static void handleException(String msg, Exception ex) {
+        log.error(msg, ex);
+        throw new RuntimeException(msg, ex);
+    }
+}

--- a/modules/transports/core/nhttp/src/main/resources/stream-interceptors.xml
+++ b/modules/transports/core/nhttp/src/main/resources/stream-interceptors.xml
@@ -17,7 +17,7 @@
   -->
 <!--resides in conf folder-->
 <interceptors>
-    <interceptor name="SampleStreamInterceptor" class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
+    <interceptor class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
         <parameter name="charset" value="ISO-8859-1"/>
         <parameter name="enableInterception" value="true"/>
     </interceptor>

--- a/modules/transports/core/nhttp/src/main/resources/stream-interceptors.xml
+++ b/modules/transports/core/nhttp/src/main/resources/stream-interceptors.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<!--resides in conf folder-->
+<interceptors>
+    <interceptor name="SampleStreamInterceptor" class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
+        <parameter name="charset" value="ISO-8859-1"/>
+        <parameter name="enableInterception" value="true"/>
+    </interceptor>
+</interceptors>


### PR DESCRIPTION
## Purpose
> Introduce synapse interceptors to intercept message at stream level rather than waiting for complete message to enter into the engine

## Approach
> Introduce global stream interceptors which will be called in all four flows of the request. 
 1. whenever the request data stream enters the engine from the client
 2. whenever the request data stream is written to the client
 3. whenever the response data stream enters from back to the engine
 4. whenever the response data stream is written to the client

These will be engaged via stream-interceptors.xml file found in conf directory.

```xml
  <interceptors xmlns:svns="http://org.wso2.securevault/configuration">
      <interceptor class="org.apache.synapse.transport.passthru.SampleStreamInterceptor">
          <parameter name="charset" value="ISO-8859-1"/>
          <parameter name="enableInterception" value="true"/>
      </interceptor>
  </interceptors>
```

In addition to the above for methods, the interceptors will have additional 4 methods to enable engagement of the corresponding methods.