### PR TITLE
Add support to read Freemarker template from registry resource

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -97,7 +97,10 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     @Override
     public void init() {
 
-        compileFreeMarkerTemplate(getFormat(), getMediaType());
+        String format = getFormat();
+        if (format != null) {
+            compileFreeMarkerTemplate(format, getMediaType());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
This PR adds support to read freemarker template from registry resource.
```
<payloadFactory media-type="text" template-type="freemarker">
     <format key="conf:myresources/resource.ftl"/><args/>
</payloadFactory>
```