### PR TITLE
Allow responding in non HTTP transports

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -104,15 +104,7 @@ public class Axis2Sender {
         }
 
         MessageContext messageContext = ((Axis2MessageContext) smc).getAxis2MessageContext();
-
-        // if this is a dummy 202 Accepted message meant only for the http/s transports
-        // prevent it from going into any other transport sender
-        if (messageContext.isPropertyTrue(NhttpConstants.SC_ACCEPTED) &&
-                messageContext.getTransportOut() != null &&
-                !messageContext.getTransportOut().getName().startsWith(Constants.TRANSPORT_HTTP)) {
-            return;
-        }
-
+        
         // fault processing code
         if (messageContext.isDoingREST() && messageContext.isFault() &&
             isMessagePayloadHasASOAPFault(messageContext)) {


### PR DESCRIPTION
## Purpose
We have prevented successful responses(with status code 202) being sent back in non-http transports. This causes issues when trying to respond back via the SapTransportSender when the backend has responded as such.
