### PR TITLE
Upgrade HTTPComponents

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
@@ -29,10 +29,10 @@ import org.apache.axis2.context.ServiceContext;
 import org.apache.axis2.description.InOutAxisOperation;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.http.HttpResponse;
-import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.annotation.Contract;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -494,7 +494,7 @@ public class TestCasesMediator {
         return textElement;
     }
 
-    @NotThreadSafe
+    @Contract(threading = ThreadingBehavior.UNSAFE)
     static class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
         static final String METHOD_NAME = "DELETE";
 

--- a/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
+++ b/modules/features/org.apache.synapse.transport.nhttp.feature/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.httpcomponents</groupId>
+            <groupId>org.apache.httpcomponents.wso2</groupId>
             <artifactId>httpcore-nio</artifactId>
         </dependency>
         <dependency>
@@ -78,7 +78,7 @@
                                 <bundleDef>org.apache.synapse:synapse-commons</bundleDef>
                                 <bundleDef>org.apache.synapse:synapse-nhttp-transport</bundleDef>
                                 <bundleDef>org.apache.httpcomponents.wso2:httpcore</bundleDef>
-                                <bundleDef>org.wso2.orbit.httpcomponents:httpcore-nio</bundleDef>
+                                <bundleDef>org.apache.httpcomponents.wso2:httpcore-nio</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.httpcomponents:httpclient</bundleDef>
                             </bundles>
                         </configuration>

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -174,7 +174,7 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.httpcomponents</groupId>
+            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
         </dependency>
         <dependency>

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
@@ -132,6 +132,9 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
         if (!SynapseDebugInfoHolder.getInstance().isDebuggerEnabled()) {
             //Debugger not enabled, hence going through normal flow
             super.produceOutput(handler);
+            if (!this.outbuf.hasData() && this.contentEncoder == null && this.status != CLOSED) {
+                this.session.clearEvent(EventMask.WRITE);
+            }
         } else {
             produceOutputWire(handler);
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
@@ -125,6 +125,9 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
         if (!SynapseDebugInfoHolder.getInstance().isDebuggerEnabled()) {
             //Debugger not enabled, hence going through normal flow
             super.produceOutput(handler);
+            if (!this.outbuf.hasData() && this.contentEncoder == null && this.status != CLOSED) {
+                this.session.clearEvent(EventMask.WRITE);
+            }
         } else {
             produceOutputWire(handler);
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpSharedOutputBuffer.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpSharedOutputBuffer.java
@@ -18,7 +18,8 @@
  */
 package org.apache.synapse.transport.nhttp;
 
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.annotation.Contract;
 import org.apache.http.nio.ContentEncoder;
 import org.apache.http.nio.IOControl;
 import org.apache.http.nio.util.ByteBufferAllocator;
@@ -52,7 +53,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * NhttpSharedOutputBuffer from httpcore-nio in order to fix
  * https://github.com/wso2/product-ei/issues/1367, without having to do an API change in httpcore-nio component.
  */
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE_CONDITIONAL)
 public class NhttpSharedOutputBuffer extends ExpandableBuffer implements ContentOutputBuffer {
 
     private final ReentrantLock lock;

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/TargetResponseTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/TargetResponseTest.java
@@ -24,8 +24,10 @@ import org.apache.axis2.transport.base.threads.NativeWorkerPool;
 import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
+import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.nio.ContentDecoder;
 import org.apache.http.nio.NHttpClientConnection;
 import org.apache.http.protocol.HttpContext;
@@ -50,7 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
  */
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
-@PrepareForTest({ TargetContext.class, TargetResponse.class })
+@PrepareForTest({ TargetContext.class, TargetResponse.class, HttpRequest.class })
 public class TargetResponseTest extends TestCase {
     private static Log logger = LogFactory.getLog(TargetResponseTest.class.getName());
 
@@ -73,6 +75,9 @@ public class TargetResponseTest extends TestCase {
         targetConfiguration.setConnections(connections);
 
         PowerMockito.mockStatic(TargetContext.class);
+        PowerMockito.mockStatic(HttpRequest.class);
+        HttpRequest httpRequest = new BasicHttpRequest("GET", "test.com");
+        PowerMockito.when(conn.getContext().getAttribute("http.request")).thenReturn(httpRequest);
 
         TargetResponse targetResponse = new TargetResponse(targetConfiguration, response, conn, false, false);
 
@@ -136,6 +141,9 @@ public class TargetResponseTest extends TestCase {
         targetConfiguration.setConnections(connections);
 
         PowerMockito.mockStatic(TargetContext.class);
+        PowerMockito.mockStatic(HttpRequest.class);
+        HttpRequest httpRequest = new BasicHttpRequest("GET", "test.com");
+        PowerMockito.when(conn.getContext().getAttribute("http.request")).thenReturn(httpRequest);
 
         TargetContext cntxt = new TargetContext(targetConfiguration);
         PowerMockito.when(TargetContext.get(any(NHttpClientConnection.class))).thenReturn(cntxt);

--- a/pom.xml
+++ b/pom.xml
@@ -597,9 +597,9 @@
              <version>${hc.httpcore.version}</version>
          </dependency>
          <dependency>
-             <groupId>org.wso2.httpcomponents</groupId>
+             <groupId>org.apache.httpcomponents</groupId>
              <artifactId>httpcore-nio</artifactId>
-             <version>${httpcore-nio.wso2.version}</version>
+             <version>${httpcore-nio.version}</version>
          </dependency>
          <dependency>
              <groupId>org.apache.httpcomponents</groupId>
@@ -610,11 +610,10 @@
              <groupId>org.apache.httpcomponents.wso2</groupId>
              <artifactId>httpcore</artifactId>
              <version>${httpcore.wso2.version}</version>
-         </dependency>
-         <dependency>
-             <groupId>org.wso2.orbit.httpcomponents</groupId>
+         </dependency><dependency>
+             <groupId>org.apache.httpcomponents.wso2</groupId>
              <artifactId>httpcore-nio</artifactId>
-             <version>${httpcore-nio.version}</version>
+             <version>${httpcore-nio.wso2.version}</version>
          </dependency>
          <dependency>
              <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
@@ -1271,12 +1270,12 @@
       <quickfixj.wso2.version>${qfj.version}.wso2v1</quickfixj.wso2.version>
       <org.bouncycastle.version>1.60.0.wso2v1</org.bouncycastle.version>
       <imp.pkg.version.wso2.bouncycastle>[1.52.0,2.0.0)</imp.pkg.version.wso2.bouncycastle>
-      <hc.httpcore.version>4.3.3</hc.httpcore.version>
+      <hc.httpcore.version>4.4.14</hc.httpcore.version>
       <httpcore.wso2.version>${hc.httpcore.version}.wso2v1</httpcore.wso2.version>
-      <httpcore-nio.wso2.version>4.3.3-wso2v4</httpcore-nio.wso2.version>
-      <httpcore-nio.version>4.3.3.wso2v4</httpcore-nio.version>
-      <hc.httpclient.version>4.3.6</hc.httpclient.version>
-      <httpclient.wso2.version>${hc.httpclient.version}.wso2v2</httpclient.wso2.version>
+      <httpcore-nio.version>4.4.14</httpcore-nio.version>
+      <httpcore-nio.wso2.version>${httpcore-nio.version}.wso2v1</httpcore-nio.wso2.version>
+      <hc.httpclient.version>4.5.13</hc.httpclient.version>
+      <httpclient.wso2.version>${hc.httpclient.version}.wso2v1</httpclient.wso2.version>
       <aspectj.version>1.8.5</aspectj.version>
       <spring.version>1.2.8</spring.version>
       <commons-codec.version>1.12</commons-codec.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR upgrades the HTTP components to the latest version.
Httpcore/Httpcore-nio : 4.4.14
Httpclient : 4.5.13

Other modifications: 
- Annotations have been modified according to https://github.com/apache/httpcomponents-core/commit/9e065bad07c9ca771c42e5b4f1dc12118c5e75c9
- Two test cases have been slightly modified to mock HttpRequest
- Clearing write events after output is produced. (Earlier httpcore-nio did this. Now they are supporting pipelining. Hence we have to do it in synapse side)