### PR TITLE
Adding implementation for Inbound APIs

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -169,6 +169,7 @@
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
 						<Export-Package>
 							org.apache.synapse,
+							org.apache.synapse.api.*,
 							org.apache.synapse.aspects.*,
 							org.apache.synapse.deployers.*,
 							org.apache.synapse.executors.*,

--- a/modules/core/src/main/java/org/apache/synapse/api/AbstractApiHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/AbstractApiHandler.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.api;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.aspects.ComponentType;
+import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
+import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
+import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.api.version.ContextVersionStrategy;
+import org.apache.synapse.api.version.DefaultStrategy;
+import org.apache.synapse.api.version.URLBasedVersionStrategy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Represents an abstract API handler, which can process messages via APIs.
+ */
+public abstract class AbstractApiHandler {
+    private static final Log log = LogFactory.getLog(AbstractApiHandler.class);
+
+    public abstract boolean process(MessageContext synCtx);
+
+    protected abstract boolean dispatchToAPI(MessageContext synCtx);
+
+    protected boolean dispatchToAPI(Collection<API> apiSet, MessageContext synCtx) {
+        //Since swapping elements are not possible with sets, Collection is converted to a List
+        List<API> defaultStrategyApiSet = new ArrayList<API>(apiSet);
+        API defaultAPI = null;
+
+        Object apiObject = synCtx.getProperty(RESTConstants.PROCESSED_API);
+        if (apiObject != null) {
+            if (identifyAPI((API) apiObject, synCtx, defaultStrategyApiSet)) {
+                return true;
+            }
+        } else {
+            for (API api : apiSet) {
+                if (identifyAPI(api, synCtx, defaultStrategyApiSet)) {
+                    return true;
+                }
+            }
+        }
+
+        for (API api : defaultStrategyApiSet) {
+            api.setLogSetterValue();
+            if (api.canProcess(synCtx)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Located specific API: " + api.getName() + " for processing message");
+                }
+                apiProcess(synCtx, api);
+                return true;
+            }
+        }
+
+        if (defaultAPI != null && defaultAPI.canProcess(synCtx)) {
+            defaultAPI.setLogSetterValue();
+            apiProcess(synCtx, defaultAPI);
+            return true;
+        }
+
+        return false;
+    }
+
+    protected void apiProcess(MessageContext synCtx, API api) {
+        Integer statisticReportingIndex = 0;
+        if (RuntimeStatisticCollector.isStatisticsEnabled()) {
+            statisticReportingIndex = OpenEventCollector
+                    .reportEntryEvent(synCtx, api.getAPIName(), api.getAspectConfiguration(), ComponentType.API);
+            api.process(synCtx);
+            CloseEventCollector.tryEndFlow(synCtx, api.getAPIName(), ComponentType.API, statisticReportingIndex, true);
+        } else {
+            api.process(synCtx);
+        }
+    }
+
+    //Process APIs which have context or url strategy
+    protected void apiProcessNonDefaultStrategy(MessageContext synCtx, API api) {
+        Integer statisticReportingIndex = 0;
+        if (RuntimeStatisticCollector.isStatisticsEnabled()) {
+            statisticReportingIndex = OpenEventCollector
+                    .reportEntryEvent(synCtx, api.getAPIName() + "_" + api.getVersion(), api.getAspectConfiguration(),
+                            ComponentType.API);
+            api.process(synCtx);
+            CloseEventCollector.tryEndFlow(synCtx, api.getAPIName(), ComponentType.API, statisticReportingIndex, true);
+        } else {
+            api.process(synCtx);
+        }
+    }
+
+    protected boolean identifyAPI(API api, MessageContext synCtx, List defaultStrategyApiSet) {
+        API defaultAPI = null;
+        api.setLogSetterValue();
+        if ("/".equals(api.getContext())) {
+            defaultAPI = api;
+        } else if (api.getVersionStrategy().getClass().getName().equals(DefaultStrategy.class.getName())) {
+            //APIs whose VersionStrategy is bound to an instance of DefaultStrategy, should be skipped and processed at
+            // last.Otherwise they will be always chosen to process the request without matching the version.
+            defaultStrategyApiSet.add(api);
+        } else if (api.getVersionStrategy().getClass().getName().equals(ContextVersionStrategy.class.getName())
+                || api.getVersionStrategy().getClass().getName().equals(URLBasedVersionStrategy.class.getName())) {
+            api.setLogSetterValue();
+            if (api.canProcess(synCtx)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Located specific API: " + api.getName() + " for processing message");
+                }
+                apiProcessNonDefaultStrategy(synCtx, api);
+                return true;
+            }
+        } else if (api.canProcess(synCtx)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Located specific API: " + api.getName() + " for processing message");
+            }
+            api.process(synCtx);
+            return true;
+        }
+        return false;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/api/AbstractRequestProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/AbstractRequestProcessor.java
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-package org.apache.synapse.rest;
+package org.apache.synapse.api;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,13 +28,13 @@ import org.apache.synapse.SynapseException;
  * first invoke the canProcess method of the processor to validate whether this processor
  * can process the given request or not.
  */
-public abstract class AbstractRESTProcessor {
+public abstract class AbstractRequestProcessor {
 
     protected Log log = LogFactory.getLog(getClass());
 
     protected String name;
 
-    public AbstractRESTProcessor(String name) {
+    public AbstractRequestProcessor(String name) {
         this.name = name;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiConstants.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.api;
+
+public class ApiConstants {
+
+    private ApiConstants() {
+        // Prevents Instantiation
+    }
+
+    public static String WS_PROTOCOL = "ws";
+    public static String WSS_PROTOCOL = "wss";
+    public static String HTTP_PROTOCOL = "http";
+    public static String HTTPS_PROTOCOL = "https";
+    public static String API_CALLER = "api.caller";
+
+    /* Constants for inbound APIs */
+    public static String BINDS_TO = "binds-to";
+    public static String DEFAULT_BINDING_ENDPOINT_NAME = "default";
+}

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.api;
+
+import org.apache.axis2.Constants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.api.dispatch.DefaultDispatcher;
+import org.apache.synapse.api.dispatch.RESTDispatcher;
+import org.apache.synapse.api.dispatch.URITemplateBasedDispatcher;
+import org.apache.synapse.api.dispatch.URLMappingBasedDispatcher;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApiUtils {
+
+    private static final Log log = LogFactory.getLog(ApiUtils.class);
+
+    private static final List<RESTDispatcher> dispatchers = new ArrayList<RESTDispatcher>();
+
+    static {
+        dispatchers.add(new URLMappingBasedDispatcher());
+        dispatchers.add(new URITemplateBasedDispatcher());
+        dispatchers.add(new DefaultDispatcher());
+    }
+
+    public static String trimSlashes(String url) {
+        if (url.startsWith("/")) {
+            url = url.substring(1);
+        }
+        if (url.startsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    public static String trimTrailingSlashes(String url) {
+        while (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    public static String getFullRequestPath(MessageContext synCtx) {
+        Object obj = synCtx.getProperty(RESTConstants.REST_FULL_REQUEST_PATH);
+        if (obj != null) {
+            return (String) obj;
+        }
+        org.apache.axis2.context.MessageContext msgCtx = ((Axis2MessageContext) synCtx).
+                getAxis2MessageContext();
+        String url = (String) msgCtx.getProperty(Constants.Configuration.TRANSPORT_IN_URL);
+        if (url == null) {
+            url = (String) synCtx.getProperty(NhttpConstants.SERVICE_PREFIX);
+        }
+
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            try {
+                url = new URL(url).getFile();
+            } catch (MalformedURLException e) {
+                handleException("Request URL: " + url + " is malformed", e);
+            }
+        } else if (url.startsWith("ws://") || url.startsWith("wss://")) {
+            try {
+                URI uri = new URI(url);
+                String query = uri.getQuery();
+                if (query == null) {
+                    url = uri.getPath();
+                } else {
+                    url = uri.getPath() + "?" + query;
+                }
+            } catch (URISyntaxException e) {
+                handleException("Request URL: " + url + " is malformed", e);
+            }
+        }
+        synCtx.setProperty(RESTConstants.REST_FULL_REQUEST_PATH, url);
+        return url;
+    }
+
+    /**
+     * Populate Message context properties for the query parameters extracted from the url
+     *
+     * @param synCtx MessageContext of the request
+     */
+    public static void populateQueryParamsToMessageContext(MessageContext synCtx) {
+
+        String path = getFullRequestPath(synCtx);
+        String method = (String) synCtx.getProperty(RESTConstants.REST_METHOD);
+
+        int queryIndex = path.indexOf('?');
+        if (queryIndex != -1) {
+            String query = path.substring(queryIndex + 1);
+            String[] entries = query.split(RESTConstants.QUERY_PARAM_DELIMITER);
+            String name = null;
+            String value;
+            for (String entry : entries) {
+                int index = entry.indexOf('=');
+                if (index != -1) {
+                    try {
+                        name = entry.substring(0, index);
+                        value = URLDecoder.decode(entry.substring(index + 1),
+                                RESTConstants.DEFAULT_ENCODING);
+                        synCtx.setProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name, value);
+                    } catch (UnsupportedEncodingException uee) {
+                        handleException("Error processing " + method + " request for : " + path, uee);
+                    } catch (IllegalArgumentException e) {
+                        String errorMessage = "Error processing " + method + " request for : " + path
+                                + " due to an error in the request sent by the client";
+                        synCtx.setProperty(SynapseConstants.ERROR_CODE, HttpStatus.SC_BAD_REQUEST);
+                        synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, errorMessage);
+                        org.apache.axis2.context.MessageContext inAxisMsgCtx =
+                                ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+                        inAxisMsgCtx.setProperty(SynapseConstants.HTTP_SC, HttpStatus.SC_BAD_REQUEST);
+                        handleException(errorMessage, e);
+                    }
+                } else {
+                    // If '=' sign isn't present in the entry means that the '&' character is part of
+                    // the query parameter value. If so query parameter value should be updated appending
+                    // the remaining characters.
+                    String existingValue = (String) synCtx.getProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name);
+                    value = RESTConstants.QUERY_PARAM_DELIMITER + entry;
+                    synCtx.setProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name, existingValue + value);
+                }
+            }
+        }
+    }
+
+    public static String getSubRequestPath(MessageContext synCtx) {
+        return (String) synCtx.getProperty(RESTConstants.REST_SUB_REQUEST_PATH);
+    }
+
+    public static List<RESTDispatcher> getDispatchers() {
+        return dispatchers;
+    }
+
+    private static void handleException(String msg, Throwable t) {
+        log.error(msg, t);
+        throw new SynapseException(msg, t);
+    }
+
+    /**
+     * Identify the API by matching the context of the invoking api
+     * with the path of each api in the api list.
+     *
+     * @param path    request path
+     * @param context API context
+     * @return true if the invoking api context matches with the path
+     * and false if the two values don't match
+     */
+    public static boolean matchApiPath(String path, String context) {
+        if (!path.startsWith(context + "/") && !path.startsWith(context + "?") &&
+                !context.equals(path) && !"/".equals(context)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/api/Resource.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/Resource.java
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-package org.apache.synapse.rest;
+package org.apache.synapse.api;
 
 import org.apache.axiom.util.UIDGenerator;
 import org.apache.axis2.Constants;
@@ -39,16 +39,17 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2Sender;
 import org.apache.synapse.mediators.MediatorFaultHandler;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.cors.SynapseCORSConfiguration;
-import org.apache.synapse.rest.cors.CORSHelper;
-import org.apache.synapse.rest.dispatch.DispatcherHelper;
+import org.apache.synapse.api.cors.SynapseCORSConfiguration;
+import org.apache.synapse.api.cors.CORSHelper;
+import org.apache.synapse.api.dispatch.DispatcherHelper;
+import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class Resource extends AbstractRESTProcessor implements ManagedLifecycle, AspectConfigurable {
+public class Resource extends AbstractRequestProcessor implements ManagedLifecycle, AspectConfigurable {
 
     /**
      * List of HTTP methods applicable on this method. Empty list means all methods
@@ -63,6 +64,8 @@ public class Resource extends AbstractRESTProcessor implements ManagedLifecycle,
     private int protocol = RESTConstants.PROTOCOL_HTTP_AND_HTTPS;
 
     AspectConfiguration aspectConfiguration;
+
+    private Set<String> bindsTo = new HashSet<>();
 
     /**
      * In-lined sequence to be executed upon receiving messages
@@ -92,7 +95,7 @@ public class Resource extends AbstractRESTProcessor implements ManagedLifecycle,
         super(UIDGenerator.generateUID());
     }
 
-    protected String getName() {
+    public String getName() {
         return name;
     }
 
@@ -213,6 +216,14 @@ public class Resource extends AbstractRESTProcessor implements ManagedLifecycle,
         this.protocol = protocol;
     }
 
+    public Set<String> getBindsTo() {
+        return bindsTo;
+    }
+
+    public void addAllBindsTo(Set<String> inboundEndpointBindings) {
+        this.bindsTo.addAll(inboundEndpointBindings);
+    }
+
     @Override
     boolean canProcess(MessageContext synCtx) {
         if (synCtx.isResponse()) {
@@ -319,7 +330,7 @@ public class Resource extends AbstractRESTProcessor implements ManagedLifecycle,
             }
 
             synCtx.setProperty(RESTConstants.SYNAPSE_RESOURCE, name);
-            RESTUtils.populateQueryParamsToMessageContext(synCtx);
+            ApiUtils.populateQueryParamsToMessageContext(synCtx);
         } else {
             // Add CORS headers for response message
             CORSHelper.handleCORSHeadersForResponse(SynapseCORSConfiguration.getInstance(), synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/api/cors/CORSConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/cors/CORSConfiguration.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.apache.synapse.rest.cors;
+package org.apache.synapse.api.cors;
 
 import java.util.Set;
 

--- a/modules/core/src/main/java/org/apache/synapse/api/cors/CORSHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/cors/CORSHelper.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.apache.synapse.rest.cors;
+package org.apache.synapse.api.cors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/modules/core/src/main/java/org/apache/synapse/api/cors/SynapseCORSConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/cors/SynapseCORSConfiguration.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.apache.synapse.rest.cors;
+package org.apache.synapse.api.cors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/DefaultDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/DefaultDispatcher.java
@@ -15,17 +15,22 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.apache.synapse.rest.version;
 
-public interface VersionStrategy {
+package org.apache.synapse.api.dispatch;
 
-    public boolean isMatchingVersion(Object versionInfoObj);
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.Resource;
 
-    public String getVersion();
+import java.util.Collection;
 
-    public String getVersionType();
+public class DefaultDispatcher implements RESTDispatcher {
 
-    public String getVersionParam();
-
-
+    public Resource findResource(MessageContext synCtx, Collection<Resource> resources) {
+        for (Resource resource : resources) {
+            if (resource.getDispatcherHelper() == null) {
+                return resource;
+            }
+        }
+        return null;
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/DispatcherHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/DispatcherHelper.java
@@ -16,22 +16,10 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
-import org.apache.synapse.MessageContext;
-import org.apache.synapse.rest.dispatch.RESTDispatcher;
-import org.apache.synapse.rest.Resource;
+public interface DispatcherHelper {
 
-import java.util.Collection;
+    public String getString();
 
-public class DefaultDispatcher implements RESTDispatcher {
-
-    public Resource findResource(MessageContext synCtx, Collection<Resource> resources) {
-        for (Resource resource : resources) {
-            if (resource.getDispatcherHelper() == null) {
-                return resource;
-            }
-        }
-        return null;
-    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/RESTDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/RESTDispatcher.java
@@ -16,10 +16,10 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.rest.Resource;
+import org.apache.synapse.api.Resource;
 
 import java.util.Collection;
 

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateBasedDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateBasedDispatcher.java
@@ -16,9 +16,11 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
+import org.apache.synapse.api.Resource;
 import org.apache.synapse.rest.*;
 
 import java.util.Collection;
@@ -28,7 +30,7 @@ import java.util.Map;
 public class URITemplateBasedDispatcher implements RESTDispatcher {
 
     public Resource findResource(MessageContext synCtx, Collection<Resource> resources) {
-        String url = RESTUtils.getSubRequestPath(synCtx);
+        String url = ApiUtils.getSubRequestPath(synCtx);
         for (Resource r : resources) {
             DispatcherHelper helper = r.getDispatcherHelper();
             if (helper instanceof URITemplateHelper) {

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateHelper.java
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.commons.templates.uri.URITemplate;

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingBasedDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingBasedDispatcher.java
@@ -16,14 +16,17 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.rest.*;
+import org.apache.synapse.api.ApiUtils;
+import org.apache.synapse.api.Resource;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class URLMappingBasedDispatcher implements RESTDispatcher {
 
@@ -46,7 +49,7 @@ public class URLMappingBasedDispatcher implements RESTDispatcher {
             return null;
         }
 
-        String url = RESTUtils.getSubRequestPath(synCtx);
+        String url = ApiUtils.getSubRequestPath(synCtx);
         for (int i = 0; i < count; i++) {
             if (mappings.get(i).isExactMatch(url)) {
                 if (log.isDebugEnabled()) {

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingHelper.java
@@ -16,9 +16,9 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.dispatch;
+package org.apache.synapse.api.dispatch;
 
-import org.apache.synapse.rest.RESTUtils;
+import org.apache.synapse.api.ApiUtils;
 
 public class URLMappingHelper implements DispatcherHelper {
 
@@ -45,7 +45,7 @@ public class URLMappingHelper implements DispatcherHelper {
 
     public boolean isExactMatch(String url) {
         if (!"/".equals(url)) {
-            url = RESTUtils.trimTrailingSlashes(url);
+            url = ApiUtils.trimTrailingSlashes(url);
         }
         int index = url.indexOf('?');
         if (index > 0) {
@@ -70,7 +70,7 @@ public class URLMappingHelper implements DispatcherHelper {
                 return 1;
             }
 
-            url = RESTUtils.trimSlashes(url);
+            url = ApiUtils.trimSlashes(url);
             int index = url.indexOf('?');
             if (index != -1) {
                 url = url.substring(0, index);

--- a/modules/core/src/main/java/org/apache/synapse/api/inbound/InboundApiHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/inbound/InboundApiHandler.java
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.synapse.api.inbound;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.AbstractApiHandler;
+import org.apache.synapse.api.ApiConstants;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.api.API;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * This class is responsible for receiving requests from inbound endpoints and dispatching
+ * them to a suitable inbound API for further processing.
+ */
+public class InboundApiHandler extends AbstractApiHandler {
+
+    private static final Log log = LogFactory.getLog(InboundApiHandler.class);
+
+    /**
+     * Attempt to process the given message through one of the available inbound APIs. This method
+     * will first try to locate a suitable API for the given message by running it through
+     * the API validation routines available. If a matching API is found it will dispatch
+     * the message to the located API. If a matching API cannot be found, message will be
+     * left intact so any other handlers (eg: main sequence) can pick it up later.
+     *
+     * @param synCtx MessageContext of the request to be processed
+     * @return true if the message was dispatched to an API and false otherwise
+     */
+    public boolean process(MessageContext synCtx) {
+        if (synCtx.isResponse()) {
+            return dispatchToAPI(synCtx);
+        }
+        org.apache.axis2.context.MessageContext msgCtx = ((Axis2MessageContext) synCtx).
+                getAxis2MessageContext();
+        String protocol = msgCtx.getIncomingTransportName();
+        if (!Arrays.asList(ApiConstants.WS_PROTOCOL, ApiConstants.WSS_PROTOCOL,
+                ApiConstants.HTTP_PROTOCOL, ApiConstants.HTTPS_PROTOCOL).contains(protocol)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Invalid protocol for Inbound API mediation: " + protocol);
+            }
+            return false;
+        }
+        return dispatchToAPI(synCtx);
+    }
+
+    @Override
+    protected boolean dispatchToAPI(MessageContext synCtx) {
+        Object apiCaller = synCtx.getProperty(ApiConstants.API_CALLER);
+        if (apiCaller != null) {
+            Map<String, API> apis = synCtx.getEnvironment().getSynapseConfiguration()
+                    .getApiTableWithBindsTo().get(apiCaller.toString());
+            if (apis != null) {
+                return dispatchToAPI(apis.values(), synCtx);
+            }
+        }
+        return false;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/api/inbound/InboundApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/inbound/InboundApiUtils.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.api.inbound;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.ApiConstants;
+import org.apache.synapse.api.Resource;
+
+import javax.xml.namespace.QName;
+import java.util.HashSet;
+import java.util.Set;
+
+public class InboundApiUtils {
+
+    private static final Log log = LogFactory.getLog(InboundApiUtils.class);
+
+    private InboundApiUtils() {
+        // Prevents Instantiation
+    }
+
+    public static void addBindsTo(API api, OMElement omElement) {
+        api.addAllBindsTo(extractBindsTo(omElement));
+    }
+
+    public static void addBindsTo(Resource resource, OMElement omElement) {
+        resource.addAllBindsTo(extractBindsTo(omElement));
+    }
+
+    private static Set<String> extractBindsTo(OMElement omElement) {
+        OMAttribute bindsToAttribute = omElement.getAttribute(new QName(ApiConstants.BINDS_TO));
+        Set<String> bindsTo = new HashSet<>();
+        if (bindsToAttribute != null) {
+            String[] inboundEndpointNames = bindsToAttribute.getAttributeValue().split(",");
+            for (String inboundEndpointName : inboundEndpointNames) {
+                String trimmedInboundEndpointName = inboundEndpointName.trim();
+                if (!trimmedInboundEndpointName.isEmpty()) {
+                    bindsTo.add(trimmedInboundEndpointName);
+                }
+            }
+        }
+        return bindsTo;
+    }
+
+    private static void validateBindsTo(API api, Resource resource) {
+        if (!api.getBindsTo().containsAll(resource.getBindsTo())) {
+            handleException("A resource definition's 'binds-to' must be a subset of its API definition's 'binds-to'");
+        }
+    }
+
+    public static void populateBindsTo(API api) {
+        if (api.getBindsTo().isEmpty()) {
+            api.addBindsTo(ApiConstants.DEFAULT_BINDING_ENDPOINT_NAME);
+        }
+        for (Resource resource : api.getResources()) {
+            if (resource.getBindsTo().isEmpty()) {
+                // Resource has no inbound endpoint bindings specified. Inherit 'binds-to' from the API.
+                resource.addAllBindsTo(api.getBindsTo());
+            } else {
+                validateBindsTo(api, resource);
+            }
+        }
+    }
+
+    private static void handleException(String msg) {
+        log.error(msg);
+        throw new SynapseException(msg);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/api/rest/RestRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/rest/RestRequestHandler.java
@@ -1,5 +1,5 @@
 /*
-*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 *  WSO2 Inc. licenses this file to you under the Apache License,
 *  Version 2.0 (the "License"); you may not use this file except
@@ -16,29 +16,27 @@
 * under the License.
 */
 
-package org.apache.synapse.rest;
+package org.apache.synapse.api.rest;
 
+import org.apache.axis2.Constants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.api.rest.RestRequestHandler;
-import org.apache.synapse.api.version.ContextVersionStrategy;
-import org.apache.synapse.api.version.DefaultStrategy;
-import org.apache.synapse.api.version.URLBasedVersionStrategy;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.AbstractApiHandler;
+import org.apache.synapse.api.ApiConstants;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+
+import java.util.Map;
 
 /**
  * This class is responsible for receiving requests from various sources and dispatching
  * them to a suitable REST API for further processing. This is the main entry point for
  * mediating messages through APIs and Resources.
- *
- * @deprecated  Replaced by {@link RestRequestHandler}
  */
-@Deprecated
-public class RESTRequestHandler {
+public class RestRequestHandler extends AbstractApiHandler {
 
-    private RestRequestHandler restRequestHandler = new RestRequestHandler();
-
-    private static final Log log = LogFactory.getLog(RESTRequestHandler.class);
+    private static final Log log = LogFactory.getLog(RestRequestHandler.class);
 
     /**
      * Attempt to process the given message through one of the available APIs. This method
@@ -51,6 +49,31 @@ public class RESTRequestHandler {
      * @return true if the message was dispatched to an API and false otherwise
      */
     public boolean process(MessageContext synCtx) {
-        return restRequestHandler.process(synCtx);
+
+        if (synCtx.isResponse()) {
+            return dispatchToAPI(synCtx);
+        }
+
+        org.apache.axis2.context.MessageContext msgCtx = ((Axis2MessageContext) synCtx).
+                getAxis2MessageContext();
+        String protocol = msgCtx.getIncomingTransportName();
+        if (!Constants.TRANSPORT_HTTP.equals(protocol) && !Constants.TRANSPORT_HTTPS.equals(protocol)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Invalid protocol for REST API mediation: " + protocol);
+            }
+            return false;
+        }
+
+        return dispatchToAPI(synCtx);
+    }
+
+    @Override
+    protected boolean dispatchToAPI(MessageContext synCtx) {
+        Map<String, API> apis = synCtx.getEnvironment().getSynapseConfiguration()
+                .getApiTableWithBindsTo().get(ApiConstants.DEFAULT_BINDING_ENDPOINT_NAME);
+        if (apis != null) {
+            return dispatchToAPI(apis.values(), synCtx);
+        }
+        return false;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/api/version/AbstractVersionStrategy.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/version/AbstractVersionStrategy.java
@@ -15,9 +15,9 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.apache.synapse.rest.version;
+package org.apache.synapse.api.version;
 
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 public abstract class AbstractVersionStrategy implements VersionStrategy {
     protected API api;

--- a/modules/core/src/main/java/org/apache/synapse/api/version/ContextVersionStrategy.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/version/ContextVersionStrategy.java
@@ -16,13 +16,13 @@
 * under the License.
 */
 
-package org.apache.synapse.rest.version;
+package org.apache.synapse.api.version;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.RESTUtils;
 
 public class ContextVersionStrategy extends AbstractVersionStrategy {
     String versionParam;
@@ -51,7 +51,7 @@ public class ContextVersionStrategy extends AbstractVersionStrategy {
     public boolean isMatchingVersion(Object versionInfoObj) {
         MessageContext msgContext = (MessageContext) versionInfoObj;
 
-        String path = RESTUtils.getFullRequestPath(msgContext);
+        String path = ApiUtils.getFullRequestPath(msgContext);
         String context = getAPI().getContext();
 
         return path.startsWith(context);

--- a/modules/core/src/main/java/org/apache/synapse/api/version/DefaultStrategy.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/version/DefaultStrategy.java
@@ -15,11 +15,24 @@
 * specific language governing permissions and limitations
 * under the License.
 */
+package org.apache.synapse.api.version;
 
-package org.apache.synapse.rest.dispatch;
+import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
+import org.apache.synapse.api.API;
 
-public interface DispatcherHelper {
+public class DefaultStrategy extends  AbstractVersionStrategy{
 
-    public String getString();
+    public DefaultStrategy(API api) {
+        super(api, "", VersionStrategyFactory.TYPE_NULL);
+    }
+
+    public boolean isMatchingVersion(Object versionInfoObj) {
+        return true;
+    }
+
+    public String getVersionParam() {
+        return "";
+    }
+
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/api/version/URLBasedVersionStrategy.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/version/URLBasedVersionStrategy.java
@@ -15,12 +15,12 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.apache.synapse.rest.version;
+package org.apache.synapse.api.version;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
-import org.apache.synapse.rest.API;
-import org.apache.synapse.rest.RESTUtils;
+import org.apache.synapse.api.API;
 
 public class URLBasedVersionStrategy extends AbstractVersionStrategy {
     String versionParam;
@@ -32,7 +32,7 @@ public class URLBasedVersionStrategy extends AbstractVersionStrategy {
 
     public boolean isMatchingVersion(Object versionInfoObj) {
         MessageContext msgContext = (MessageContext) versionInfoObj;
-        String path = RESTUtils.getFullRequestPath(msgContext);
+        String path = ApiUtils.getFullRequestPath(msgContext);
 
         String context = getAPI().getContext();
         String pathStringAfterContext = path.substring(context.length());

--- a/modules/core/src/main/java/org/apache/synapse/api/version/VersionStrategy.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/version/VersionStrategy.java
@@ -15,24 +15,17 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.apache.synapse.rest.version;
+package org.apache.synapse.api.version;
 
-import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
-import org.apache.synapse.rest.API;
+public interface VersionStrategy {
 
-public class DefaultStrategy extends  AbstractVersionStrategy{
+    public boolean isMatchingVersion(Object versionInfoObj);
 
-    public DefaultStrategy(API api) {
-        super(api, "", VersionStrategyFactory.TYPE_NULL);
-    }
+    public String getVersion();
 
-    public boolean isMatchingVersion(Object versionInfoObj) {
-        return true;
-    }
+    public String getVersionType();
 
-    public String getVersionParam() {
-        return "";
-    }
+    public String getVersionParam();
 
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/StatisticSynapseConfigurationObserver.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/StatisticSynapseConfigurationObserver.java
@@ -32,7 +32,7 @@ import org.apache.synapse.eventing.SynapseEventSource;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.libraries.model.Library;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 public class StatisticSynapseConfigurationObserver implements SynapseObserver{
 	@Override

--- a/modules/core/src/main/java/org/apache/synapse/config/AbstractSynapseObserver.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/AbstractSynapseObserver.java
@@ -31,7 +31,7 @@ import org.apache.synapse.endpoints.Endpoint;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.mediators.template.TemplateMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 public abstract class AbstractSynapseObserver implements SynapseObserver {
 

--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseObserver.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseObserver.java
@@ -27,7 +27,7 @@ import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.libraries.model.Library;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 /**
  * An implementation of this interface can be registered with the SynapseConfiguration to receive

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MultiXMLConfigurationBuilder.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MultiXMLConfigurationBuilder.java
@@ -42,7 +42,7 @@ import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.eventing.SynapseEventSource;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MultiXMLConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MultiXMLConfigurationSerializer.java
@@ -38,7 +38,7 @@ import org.apache.synapse.eventing.SynapseEventSource;
 import org.apache.synapse.Startup;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.message.store.MessageStore;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.startup.AbstractStartup;
 import org.apache.synapse.commons.executors.PriorityExecutor;
 import org.apache.synapse.commons.executors.config.PriorityExecutorSerializer;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseImportSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseImportSerializer.java
@@ -26,7 +26,6 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.libraries.imports.SynapseImport;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.rest.API;
 
 /**
  * This will serialize the SynapseImport to the xml configuration as specified bellow

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationFactory.java
@@ -21,8 +21,6 @@ package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMComment;
 import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.OMText;
-import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.axis2.AxisFault;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,14 +50,12 @@ import org.apache.synapse.mediators.template.TemplateMediator;
 import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.registry.Registry;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.task.TaskManager;
 import org.apache.synapse.unittest.UnitTestMockRegistry;
 
 import javax.xml.namespace.QName;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Properties;
 
 public class SynapseXMLConfigurationFactory implements ConfigurationFactory {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapseXMLConfigurationSerializer.java
@@ -44,7 +44,7 @@ import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.eventing.SynapseEventSource;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 import javax.xml.namespace.QName;
 import java.util.*;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APIFactory.java
@@ -26,13 +26,15 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.api.inbound.InboundApiUtils;
 import org.apache.synapse.aspects.AspectConfiguration;
 import org.apache.synapse.commons.util.PropertyHelper;
 import org.apache.synapse.config.xml.XMLConfigConstants;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.rest.Handler;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.version.VersionStrategy;
+import org.apache.synapse.api.Resource;
+import org.apache.synapse.api.version.VersionStrategy;
 import org.apache.synapse.util.CommentListUtil;
 
 import javax.xml.namespace.QName;
@@ -85,6 +87,8 @@ public class APIFactory {
         if (publishSwagger != null) {
             api.setSwaggerResourcePath(publishSwagger.getAttributeValue());
         }
+
+        InboundApiUtils.addBindsTo(api, apiElt);
 
         Iterator resources = apiElt.getChildrenWithName(new QName(
                 XMLConfigConstants.SYNAPSE_NAMESPACE, "resource"));

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APISerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/APISerializer.java
@@ -21,12 +21,13 @@ package org.apache.synapse.config.xml.rest;
 import org.apache.axiom.om.*;
 import org.apache.axis2.Constants;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.ApiConstants;
 import org.apache.synapse.aspects.statistics.StatisticsConfigurable;
 import org.apache.synapse.config.xml.XMLConfigConstants;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.rest.Handler;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.Resource;
+import org.apache.synapse.api.Resource;
 import org.apache.synapse.util.CommentListUtil;
 
 import java.util.Iterator;
@@ -54,6 +55,10 @@ public class APISerializer {
 
         if (api.getSwaggerResourcePath() != null) {
             apiElt.addAttribute("publishSwagger", api.getSwaggerResourcePath(), null);
+        }
+
+        if (api.getBindsTo() != null) {
+            apiElt.addAttribute(ApiConstants.BINDS_TO, String.join(",", api.getBindsTo()), null);
         }
 
         StatisticsConfigurable statisticsConfigurable = api.getAspectConfiguration();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/ResourceFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/ResourceFactory.java
@@ -25,13 +25,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SequenceType;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.api.inbound.InboundApiUtils;
 import org.apache.synapse.config.xml.SequenceMediatorFactory;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.Resource;
-import org.apache.synapse.rest.dispatch.URITemplateHelper;
-import org.apache.synapse.rest.dispatch.URLMappingHelper;
+import org.apache.synapse.api.Resource;
+import org.apache.synapse.api.dispatch.URITemplateHelper;
+import org.apache.synapse.api.dispatch.URLMappingHelper;
 
 import javax.xml.namespace.QName;
 import java.util.Properties;
@@ -49,6 +50,7 @@ public class ResourceFactory {
         configureURLMappings(resource, resourceElt);
         configureSequences(resource, resourceElt, properties);
         configureFilters(resource, resourceElt);
+        InboundApiUtils.addBindsTo(resource, resourceElt);
         return resource;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/ResourceSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/ResourceSerializer.java
@@ -22,12 +22,13 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.ApiConstants;
 import org.apache.synapse.config.xml.SequenceMediatorSerializer;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.Resource;
-import org.apache.synapse.rest.dispatch.DispatcherHelper;
-import org.apache.synapse.rest.dispatch.URITemplateHelper;
-import org.apache.synapse.rest.dispatch.URLMappingHelper;
+import org.apache.synapse.api.Resource;
+import org.apache.synapse.api.dispatch.DispatcherHelper;
+import org.apache.synapse.api.dispatch.URITemplateHelper;
+import org.apache.synapse.api.dispatch.URLMappingHelper;
 
 public class ResourceSerializer {
 
@@ -42,6 +43,10 @@ public class ResourceSerializer {
                 value += method + " ";
             }
             resourceElt.addAttribute("methods", value.trim(), null);
+        }
+
+        if (resource.getBindsTo() != null) {
+            resourceElt.addAttribute(ApiConstants.BINDS_TO, String.join(",", resource.getBindsTo()), null);
         }
 
         if (resource.getContentType() != null) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/VersionStrategyFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/VersionStrategyFactory.java
@@ -22,11 +22,11 @@ import org.apache.axiom.om.OMElement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
-import org.apache.synapse.rest.API;
-import org.apache.synapse.rest.version.ContextVersionStrategy;
-import org.apache.synapse.rest.version.DefaultStrategy;
-import org.apache.synapse.rest.version.URLBasedVersionStrategy;
-import org.apache.synapse.rest.version.VersionStrategy;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.version.ContextVersionStrategy;
+import org.apache.synapse.api.version.DefaultStrategy;
+import org.apache.synapse.api.version.URLBasedVersionStrategy;
+import org.apache.synapse.api.version.VersionStrategy;
 
 import javax.xml.namespace.QName;
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/rest/VersionStrategySerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/rest/VersionStrategySerializer.java
@@ -17,19 +17,12 @@
 */
 package org.apache.synapse.config.xml.rest;
 
-import org.apache.axiom.om.OMAbstractFactory;
-import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.OMFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.SynapseException;
-import org.apache.synapse.rest.API;
-import org.apache.synapse.rest.version.DefaultStrategy;
-import org.apache.synapse.rest.version.URLBasedVersionStrategy;
-import org.apache.synapse.rest.version.VersionStrategy;
-
-import javax.xml.namespace.QName;
+import org.apache.synapse.api.version.DefaultStrategy;
+import org.apache.synapse.api.version.URLBasedVersionStrategy;
+import org.apache.synapse.api.version.VersionStrategy;
 
 public class VersionStrategySerializer {
     private static final Log log = LogFactory.getLog(VersionStrategySerializer.class);

--- a/modules/core/src/main/java/org/apache/synapse/continuation/ContinuationStackManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/continuation/ContinuationStackManager.java
@@ -33,9 +33,9 @@ import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.mediators.MediatorFaultHandler;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.rest.RESTConstants;
-import org.apache.synapse.rest.Resource;
+import org.apache.synapse.api.Resource;
 
 import java.util.Set;
 import java.util.Stack;

--- a/modules/core/src/main/java/org/apache/synapse/debug/utils/APIDebugUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/debug/utils/APIDebugUtil.java
@@ -27,8 +27,8 @@ import org.apache.synapse.debug.constructs.SynapseMediationFlowPoint;
 import org.apache.synapse.debug.constructs.SynapseSequenceType;
 import org.apache.synapse.debug.constructs.APIMediationFlowPoint;
 import org.apache.synapse.mediators.AbstractMediator;
-import org.apache.synapse.rest.API;
-import org.apache.synapse.rest.Resource;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.Resource;
 
 /**
  * Utility class that handle persisting API related breakpoint/skip information at mediator level as

--- a/modules/core/src/main/java/org/apache/synapse/deployers/APIDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/APIDeployer.java
@@ -26,7 +26,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.MultiXMLConfigurationBuilder;
 import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.config.xml.rest.APISerializer;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 
 import java.io.File;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/RespondMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/RespondMediator.java
@@ -7,8 +7,8 @@ import org.apache.synapse.SynapseLog;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2Sender;
 import org.apache.synapse.mediators.AbstractMediator;
-import org.apache.synapse.rest.cors.SynapseCORSConfiguration;
-import org.apache.synapse.rest.cors.CORSHelper;
+import org.apache.synapse.api.cors.SynapseCORSConfiguration;
+import org.apache.synapse.api.cors.CORSHelper;
 
 public class RespondMediator extends AbstractMediator{
 

--- a/modules/core/src/main/java/org/apache/synapse/rest/RESTUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/rest/RESTUtils.java
@@ -18,139 +18,68 @@
 
 package org.apache.synapse.rest;
 
-import org.apache.axis2.Constants;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpStatus;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.SynapseException;
-import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.apache.synapse.rest.dispatch.RESTDispatcher;
-import org.apache.synapse.rest.dispatch.DefaultDispatcher;
-import org.apache.synapse.rest.dispatch.URLMappingBasedDispatcher;
-import org.apache.synapse.rest.dispatch.URITemplateBasedDispatcher;
-import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.apache.synapse.api.ApiUtils;
+import org.apache.synapse.api.dispatch.RESTDispatcher;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated Replaced by {@link ApiUtils}
+ */
+@Deprecated
 public class RESTUtils {
 
-    private static final Log log = LogFactory.getLog(RESTUtils.class);
-
-    private static final List<RESTDispatcher> dispatchers = new ArrayList<RESTDispatcher>();
-
-    static {
-        dispatchers.add(new URLMappingBasedDispatcher());
-        dispatchers.add(new URITemplateBasedDispatcher());
-        dispatchers.add(new DefaultDispatcher());
-    }
-
+    /**
+     * @deprecated  Replaced by {@link ApiUtils#trimSlashes(String)}
+     */
+    @Deprecated
     public static String trimSlashes(String url) {
-        if (url.startsWith("/")) {
-            url = url.substring(1);
-        }
-        if (url.startsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-        return url;
+        return ApiUtils.trimSlashes(url);
     }
 
+    /**
+     * @deprecated  Replaced by {@link ApiUtils#trimTrailingSlashes(String)}
+     */
+    @Deprecated
     public static String trimTrailingSlashes(String url) {
-        while (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-        return url;
+        return ApiUtils.trimTrailingSlashes(url);
     }
 
+    /**
+     * @deprecated  Replaced by {@link ApiUtils#getFullRequestPath(MessageContext)}
+     */
+    @Deprecated
     public static String getFullRequestPath(MessageContext synCtx) {
-        Object obj = synCtx.getProperty(RESTConstants.REST_FULL_REQUEST_PATH);
-        if (obj != null) {
-            return (String) obj;
-        }
-
-        org.apache.axis2.context.MessageContext msgCtx = ((Axis2MessageContext) synCtx).
-                getAxis2MessageContext();
-        String url = (String) msgCtx.getProperty(Constants.Configuration.TRANSPORT_IN_URL);
-        if (url == null) {
-            url = (String) synCtx.getProperty(NhttpConstants.SERVICE_PREFIX);
-        }
-
-        if (url.startsWith("http://") || url.startsWith("https://")) {
-            try {
-                url = new URL(url).getFile();
-            } catch (MalformedURLException e) {
-                handleException("Request URL: " + url + " is malformed", e);
-            }
-        }
-        synCtx.setProperty(RESTConstants.REST_FULL_REQUEST_PATH, url);
-        return url;
+        return ApiUtils.getFullRequestPath(synCtx);
     }
 
     /**
      * Populate Message context properties for the query parameters extracted from the url
      *
      * @param synCtx MessageContext of the request
+     *
+     * @deprecated  Replaced by {@link ApiUtils#populateQueryParamsToMessageContext(MessageContext)}
      */
+    @Deprecated
     public static void populateQueryParamsToMessageContext(MessageContext synCtx) {
-
-        String path = getFullRequestPath(synCtx);
-        String method = (String) synCtx.getProperty(RESTConstants.REST_METHOD);
-
-        int queryIndex = path.indexOf('?');
-        if (queryIndex != -1) {
-            String query = path.substring(queryIndex + 1);
-            String[] entries = query.split(RESTConstants.QUERY_PARAM_DELIMITER);
-            String name = null;
-            String value;
-            for (String entry : entries) {
-                int index = entry.indexOf('=');
-                if (index != -1) {
-                    try {
-                        name = entry.substring(0, index);
-                        value = URLDecoder.decode(entry.substring(index + 1),
-                                RESTConstants.DEFAULT_ENCODING);
-                        synCtx.setProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name, value);
-                    } catch (UnsupportedEncodingException uee) {
-                        handleException("Error processing " + method + " request for : " + path, uee);
-                    } catch (IllegalArgumentException e) {
-                        String errorMessage = "Error processing " + method + " request for : " + path
-                                + " due to an error in the request sent by the client";
-                        synCtx.setProperty(SynapseConstants.ERROR_CODE, HttpStatus.SC_BAD_REQUEST);
-                        synCtx.setProperty(SynapseConstants.ERROR_MESSAGE, errorMessage);
-                        org.apache.axis2.context.MessageContext inAxisMsgCtx =
-                                ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-                        inAxisMsgCtx.setProperty(SynapseConstants.HTTP_SC, HttpStatus.SC_BAD_REQUEST);
-                        handleException(errorMessage, e);
-                    }
-                } else {
-                    // If '=' sign isn't present in the entry means that the '&' character is part of
-                    // the query parameter value. If so query parameter value should be updated appending
-                    // the remaining characters.
-                    String existingValue = (String) synCtx.getProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name);
-                    value = RESTConstants.QUERY_PARAM_DELIMITER + entry;
-                    synCtx.setProperty(RESTConstants.REST_QUERY_PARAM_PREFIX + name, existingValue + value);
-                }
-            }
-        }
+        ApiUtils.populateQueryParamsToMessageContext(synCtx);
     }
 
+    /**
+     * @deprecated  Replaced by {@link ApiUtils#getSubRequestPath(MessageContext)}
+     */
+    @Deprecated
     public static String getSubRequestPath(MessageContext synCtx) {
-        return (String) synCtx.getProperty(RESTConstants.REST_SUB_REQUEST_PATH);
+        return ApiUtils.getSubRequestPath(synCtx);
     }
 
+    /**
+     * @deprecated  Replaced by {@link ApiUtils#getDispatchers()}
+     */
+    @Deprecated
     public static List<RESTDispatcher> getDispatchers() {
-        return dispatchers;
-    }
-
-    private static void handleException(String msg, Throwable t) {
-        log.error(msg, t);
-        throw new SynapseException(msg, t);
+        return ApiUtils.getDispatchers();
     }
 
     /**
@@ -161,12 +90,11 @@ public class RESTUtils {
      * @param context API context
      * @return true if the invoking api context matches with the path
      * and false if the two values don't match
+     *
+     * @deprecated  Replaced by {@link ApiUtils#matchApiPath(String, String)}
      */
+    @Deprecated
     public static boolean matchApiPath(String path, String context) {
-        if (!path.startsWith(context + "/") && !path.startsWith(context + "?") &&
-                !context.equals(path) && !"/".equals(context)) {
-            return false;
-        }
-        return true;
+        return ApiUtils.matchApiPath(path, context);
     }
 }

--- a/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/StatisticSynapseConfigurationObserverTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/StatisticSynapseConfigurationObserverTest.java
@@ -19,10 +19,9 @@ package org.apache.synapse.aspects.flow.statistics;
 
 import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.endpoints.DefaultEndpoint;
-import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/modules/core/src/test/java/org/apache/synapse/config/SynapseConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/SynapseConfigurationTest.java
@@ -19,7 +19,7 @@ package org.apache.synapse.config;
 
 import java.util.Collection;
 
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 import junit.framework.TestCase;
 

--- a/modules/core/src/test/java/org/apache/synapse/config/SynapseObserverTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/SynapseObserverTest.java
@@ -29,7 +29,7 @@ import org.apache.synapse.Startup;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.libraries.model.Library;
 import org.apache.synapse.mediators.template.TemplateMediator;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.startup.quartz.StartUpController;
 import org.apache.synapse.commons.executors.PriorityExecutor;
 import org.apache.synapse.mediators.base.SequenceMediator;

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseXMLConfigurationSerializerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/SynapseXMLConfigurationSerializerTest.java
@@ -31,7 +31,7 @@ import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.message.store.impl.jms.JmsStore;
 import org.apache.synapse.registry.Registry;
 import org.apache.synapse.registry.SimpleInMemoryRegistry;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 import org.apache.synapse.startup.quartz.QuartzTaskManager;
 import org.apache.synapse.startup.quartz.StartUpController;
 import org.apache.synapse.task.TaskDescription;

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/rest/APISerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/rest/APISerializationTest.java
@@ -21,13 +21,13 @@ package org.apache.synapse.config.xml.rest;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.synapse.config.xml.AbstractTestCase;
-import org.apache.synapse.rest.API;
+import org.apache.synapse.api.API;
 
 public class APISerializationTest extends AbstractTestCase {
 
     public void testAPISerialization1() throws Exception {
-        String xml = "<api name=\"test\" context=\"/dictionary\" transports=\"https\" xmlns=\"http://ws.apache.org/ns/synapse\">" +
-                "<resource url-mapping=\"/admin/view\" inSequence=\"in\" outSequence=\"out\"/></api>";
+        String xml = "<api name=\"test\" context=\"/dictionary\" binds-to=\"\" transports=\"https\" xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<resource binds-to=\"\" url-mapping=\"/admin/view\" inSequence=\"in\" outSequence=\"out\"/></api>";
         OMElement om = AXIOMUtil.stringToOM(xml);
         API api = APIFactory.createAPI(om);
         OMElement out = APISerializer.serializeAPI(api);
@@ -35,8 +35,8 @@ public class APISerializationTest extends AbstractTestCase {
     }
 
     public void testAPISerialization2() throws Exception {
-        String xml = "<api name=\"test\" context=\"/dictionary\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
-                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource url-mapping=\"/admin/view\" " +
+        String xml = "<api name=\"test\" context=\"/dictionary\" binds-to=\"\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
+                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource binds-to=\"\" url-mapping=\"/admin/view\" " +
                 "inSequence=\"in\" outSequence=\"out\"/></api>";
         OMElement om = AXIOMUtil.stringToOM(xml);
         API api = APIFactory.createAPI(om);
@@ -45,8 +45,8 @@ public class APISerializationTest extends AbstractTestCase {
     }
 
     public void testAPISerialization3() throws Exception {
-        String xml = "<api name=\"test\" context=\"/dictionary\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
-                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource url-mapping=\"/admin/view\" " +
+        String xml = "<api name=\"test\" context=\"/dictionary\" binds-to=\"\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
+                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource binds-to=\"\" url-mapping=\"/admin/view\" " +
                 "inSequence=\"in\"><outSequence><log/><send/></outSequence></resource></api>";
         OMElement om = AXIOMUtil.stringToOM(xml);
         API api = APIFactory.createAPI(om);
@@ -55,8 +55,8 @@ public class APISerializationTest extends AbstractTestCase {
     }
 
     public void testAPISerialization4() throws Exception {
-        String xml = "<api name=\"test\" context=\"/dictionary\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
-                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource url-mapping=\"/admin/view\" " +
+        String xml = "<api name=\"test\" context=\"/dictionary\" binds-to=\"\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
+                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource binds-to=\"\" url-mapping=\"/admin/view\" " +
                 "outSequence=\"out\"><inSequence><log/><send/></inSequence></resource></api>";
         OMElement om = AXIOMUtil.stringToOM(xml);
         API api = APIFactory.createAPI(om);
@@ -65,11 +65,12 @@ public class APISerializationTest extends AbstractTestCase {
     }
 
     public void testAPISerialization5() throws Exception {
-        String xml = "<api name=\"test\" context=\"/dictionary\" transports=\"https\" hostname=\"apache.org\" port=\"8243\"" +
-                " xmlns=\"http://ws.apache.org/ns/synapse\"><resource url-mapping=\"/admin/view/*\" " +
+        String xml = "<api xmlns=\"http://ws.apache.org/ns/synapse\" name=\"test\" context=\"/dictionary\" " +
+                "hostname=\"apache.org\" port=\"8243\" binds-to=\"\" transports=\"https\">" +
+                "<resource binds-to=\"\" url-mapping=\"/admin/view/*\" " +
                 "><inSequence><log/><send/></inSequence><outSequence><log/><send/></outSequence></resource>" +
-                "<resource url-mapping=\"/admin/*\"><inSequence><log/><send/></inSequence><outSequence>" +
-                "<log/><send/></outSequence></resource><resource uri-template=\"/{char}/{word}\">" +
+                "<resource binds-to=\"\" url-mapping=\"/admin/*\"><inSequence><log/><send/></inSequence><outSequence>" +
+                "<log/><send/></outSequence></resource><resource binds-to=\"\" uri-template=\"/{char}/{word}\">" +
                 "<inSequence><send/></inSequence><faultSequence><log level=\"full\"/></faultSequence>" +
                 "</resource></api>";
         OMElement om = AXIOMUtil.stringToOM(xml);

--- a/modules/core/src/test/java/org/apache/synapse/rest/APIDispatcherTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/APIDispatcherTest.java
@@ -21,10 +21,11 @@ package org.apache.synapse.rest;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.API;
 import org.apache.synapse.config.SynapseConfiguration;
-import org.apache.synapse.rest.version.ContextVersionStrategy;
-import org.apache.synapse.rest.version.DefaultStrategy;
-import org.apache.synapse.rest.version.URLBasedVersionStrategy;
+import org.apache.synapse.api.version.ContextVersionStrategy;
+import org.apache.synapse.api.version.DefaultStrategy;
+import org.apache.synapse.api.version.URLBasedVersionStrategy;
 
 public class APIDispatcherTest extends RESTMediationTestCase {
 

--- a/modules/core/src/test/java/org/apache/synapse/rest/BasicAPIMediationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/BasicAPIMediationTest.java
@@ -17,9 +17,10 @@
 package org.apache.synapse.rest;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.API;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.apache.synapse.rest.version.URLBasedVersionStrategy;
+import org.apache.synapse.api.version.URLBasedVersionStrategy;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 
 public class BasicAPIMediationTest extends RESTMediationTestCase {

--- a/modules/core/src/test/java/org/apache/synapse/rest/ResourceTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/ResourceTest.java
@@ -19,6 +19,8 @@
 package org.apache.synapse.rest;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.Resource;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
@@ -28,7 +30,7 @@ import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.mediators.builtin.PropertyMediator;
 import org.apache.synapse.mediators.transform.XSLTMediator;
-import org.apache.synapse.rest.dispatch.URITemplateHelper;
+import org.apache.synapse.api.dispatch.URITemplateHelper;
 
 public class ResourceTest extends RESTMediationTestCase {
 

--- a/modules/core/src/test/java/org/apache/synapse/rest/RestUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/RestUtilsTest.java
@@ -18,6 +18,7 @@ package org.apache.synapse.rest;
 
 import junit.framework.Assert;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.config.SynapseConfiguration;
 
 /**
@@ -30,7 +31,7 @@ public class RestUtilsTest extends RESTMediationTestCase {
         MessageContext msgCtx = getMessageContext(synapseConfig, false,
                 "http://localhos:9443/test/admin?PARAM1=1&PARAM2=2", "GET");
 
-        String url = RESTUtils.getFullRequestPath(msgCtx);
+        String url = ApiUtils.getFullRequestPath(msgCtx);
         Assert.assertTrue(url.contains("PARAM1=1&PARAM2=2"));
     }
 

--- a/modules/core/src/test/java/org/apache/synapse/rest/URITemplateBasedDispatcherTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/URITemplateBasedDispatcherTest.java
@@ -19,8 +19,10 @@
 package org.apache.synapse.rest;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.Resource;
 import org.apache.synapse.config.SynapseConfiguration;
-import org.apache.synapse.rest.dispatch.URITemplateHelper;
+import org.apache.synapse.api.dispatch.URITemplateHelper;
 
 public class URITemplateBasedDispatcherTest extends RESTMediationTestCase {
 

--- a/modules/core/src/test/java/org/apache/synapse/rest/URLMappingBasedDispatcherTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/rest/URLMappingBasedDispatcherTest.java
@@ -20,8 +20,10 @@ package org.apache.synapse.rest;
 
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.Resource;
 import org.apache.synapse.config.SynapseConfiguration;
-import org.apache.synapse.rest.dispatch.URLMappingHelper;
+import org.apache.synapse.api.dispatch.URLMappingHelper;
 
 public class URLMappingBasedDispatcherTest extends RESTMediationTestCase {
 

--- a/modules/samples/src/main/java/samples/userguide/SimpleLoggingObserver.java
+++ b/modules/samples/src/main/java/samples/userguide/SimpleLoggingObserver.java
@@ -20,14 +20,6 @@
 package samples.userguide;
 
 import org.apache.synapse.config.AbstractSynapseObserver;
-import org.apache.synapse.config.Entry;
-import org.apache.synapse.Mediator;
-import org.apache.synapse.Startup;
-import org.apache.synapse.eventing.SynapseEventSource;
-import org.apache.synapse.core.axis2.ProxyService;
-import org.apache.synapse.endpoints.Endpoint;
-import org.apache.synapse.inbound.InboundEndpoint;
-import org.apache.synapse.rest.API;
 
 /**
  * This sample observer implementation simply calls the event handlers defined


### PR DESCRIPTION
## Purpose
Introducing Internal APIs to Synapse, and moving classes from `org.apache.synapse.rest` to `org.apache.synapse.api` to support this. (Commit for moving the classes: https://github.com/wso2/wso2-synapse/pull/1691/commits/446daf5879c312a86b3fc974e01e8a24fb6d123d).

### Introducing Internal APIs to Synapse
An Internal API is an API, which can only be invoked through a specified set of inbound endpoints. To define this, an API will have a `binds-to` attribute specified at either API level or Resource level. This attribute denotes that, from which inbound endpoint callers, can the API be invoked. 
- If `binds-to` is not specified at a Resource level, that Resource will inherit `binds-to` from the API level.
- If `binds-to` is specified at Resource level, that will override what has been provided in API level `binds-to`.
- `binds-to` of a Resource must be a subset of `binds-to` of its API.
- If `binds-to` is not present in an API, that API will be bound to `default`. This is then used when dispatching requests from various sources. (`default` can be stated as a binding too)

Refer to the examples below:

**Example 1: `binds-to` specified only at API level**
```xml
<api xmlns="http://ws.apache.org/ns/synapse" 
        name="websocket-api" 
        context="/chats/1.0.0" 
        version="1.0.0" 
        version-type="context"
        binds-to="WebSocketInboundEndpoint, WebSocketInboundEndpoint2"
>
    <resource uri-template="/rooms/{roomID}" faultSequence="fault">
        ...
    </resource>
    <resource uri-template="/lobby" faultSequence="fault">
        ...
    </resource>
</api>
```
* Since both the Resources don't have `binds-to`, each of them will inherit `binds-to` from the API level.
* Therefore, we can invoke `/chats/1.0.0/rooms/{roomID}` and `/chats/1.0.0/lobby` via either `WebSocketInboundEndpoint` or `WebSocketInboundEndpoint2`.

**Example 2: `binds-to` specified at the API level and Resource level**
```xml
<api xmlns="http://ws.apache.org/ns/synapse" 
        name="websocket-api" 
        context="/chats/1.0.0" 
        version="1.0.0" 
        version-type="context"
        binds-to="WebSocketInboundEndpoint, WebSocketInboundEndpoint2"
>
    <resource uri-template="/rooms/{roomID}" faultSequence="fault">
        ...
    </resource>
    <resource uri-template="/lobby" faultSequence="fault" binds-to="WebSocketInboundEndpoint">
        ...
    </resource>
</api>
```
* Since the first Resource doesn't have `binds-to`, it will inherit `binds-to` from the API level. This will behave as same as **Example 1**.
* Second Resource has a defined `binds-to`. Therefore, we can only invoke `/chats/1.0.0/lobby` from `WebSocketInboundEndpoint`.

**Example 3: Default binding**
```xml
<api xmlns="http://ws.apache.org/ns/synapse" 
        name="websocket-api" 
        context="/chats/1.0.0" 
        version="1.0.0" 
        version-type="context"
>
<resource uri-template="/rooms/{roomID}" faultSequence="fault">
        ...
    </resource>
    <resource uri-template="/lobby" faultSequence="fault">
        ...
    </resource>
</api>
```
* This doesn't have any `binds-to` specified, therefore, this will be bound to `default` (Specifying `binds-to="default"` at the API level gives the same results as well).
* Both `chats/1.0.0/rooms/{roomID}` and `chats/1.0.0/lobby`, can be invoked from any inbound endpoint.

### Refactoring: Moving classes from `org.apache.synapse.rest` to `org.apache.synapse.api`
In addition to the existing `RestRequestHandler`, this PR will introduce the `InboundApiHandler` which handles inbound API dispatching.

## Goals
> Limit APIs in such a way that, they can be only called through certain inbound endpoints. 
> Example: Having _topics_ for a WebSocket API. The underlying artifact will be a Synapse `<api>`, but, it can be still called through other sources - not only through a WebSocket endpoint. In this case, we can specify `binds-to="WebSocketEndpoint"` to make it only accessible through `WebSocketEndpoint`.

## Approach
> 1. Store bindings in `API` and `Resource` objects, at the time of creating them.
> 2. Maintain the bindings in `SynapseConfiguration`.
> 3. Get the bindings when dispatching, and dispatch appropriately.

## Related PRs
> https://github.com/wso2/carbon-mediation/pull/1490 - Accommodating Inbound APIs in Carbon-mediation.