### PR TITLE
Make ssl port param optional

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ServerConnFactoryBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ServerConnFactoryBuilder.java
@@ -400,11 +400,13 @@ public class ServerConnFactoryBuilder {
     }
 
     public ServerConnFactory build(final HttpParams params) throws AxisFault {
-
-        int port = ParamUtils.getRequiredParamInt(transportIn, "port");
-
         if (ssl != null || sslByIPMap != null) {
-            return new ServerConnFactory(ssl, sslByIPMap, params, port);
+            String port = ParamUtils.getOptionalParam(transportIn, "port");
+            if (port != null) {
+                return new ServerConnFactory(ssl, sslByIPMap, params, Integer.parseInt(port));
+            } else {
+                return new ServerConnFactory(ssl, sslByIPMap, params);
+            }
         } else {
             return new ServerConnFactory(params);
         }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Make ssl port param optional. Else this will complain when starting Internal APIs