### PR TITLE
Downgrade jacoco plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1295,7 +1295,7 @@
       <maven.site.plugin.version>2.0-beta-6</maven.site.plugin.version>
       <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>
       <maven.surefire.plugin.version.2.2>2.2</maven.surefire.plugin.version.2.2>
-      <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
+      <maven.jacoco.plugin.version>0.7.4.201502262128</maven.jacoco.plugin.version>
       <maven.assembly.plugin.version>2.2-beta-2</maven.assembly.plugin.version>
       <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
       <maven.dependency.plugin.version>2.0</maven.dependency.plugin.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject, due to a jacoco plugin error in jenkins.
```
ERROR: Step ‘Record JaCoCo coverage report’ aborted due to exception: 
org.jacoco.core.data.IncompatibleExecDataVersionException: Cannot read execution data version 0x1006. This version of JaCoCo uses execution data version 0x1007.
	at org.jacoco.core.data.ExecutionDataReader.readHeader(ExecutionDataReader.java:129)
	at org.jacoco.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:109)
	at org.jacoco.core.data.ExecutionDataReader.read(ExecutionDataReader.java:92)
	at hudson.plugins.jacoco.ExecutionFileLoader.loadExecutionData(ExecutionFileLoader.java:95)
```