### PR TITLE
Allow a way to pass axis2 properties from request to response context

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
@@ -45,7 +45,9 @@ import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -63,9 +65,12 @@ public class ClientWorker implements Runnable {
     /** the axis2 message context of the request */
     private MessageContext requestMessageContext;
 
-    public ClientWorker(TargetConfiguration targetConfiguration,
-                        MessageContext outMsgCtx,
-                        TargetResponse response) {
+    public ClientWorker(TargetConfiguration targetConfiguration, MessageContext outMsgCtx, TargetResponse response) {
+        this(targetConfiguration, outMsgCtx, response, Collections.emptyList());
+    }
+
+    public ClientWorker(TargetConfiguration targetConfiguration, MessageContext outMsgCtx, TargetResponse response,
+                        List<String> allowedResponseProperties) {
         this.targetConfiguration = targetConfiguration;
         this.response = response;
         this.expectEntityBody = response.isExpectResponseBody();
@@ -190,6 +195,9 @@ public class ClientWorker implements Runnable {
                 response.getConnection());
         responseMsgCtx.setProperty(CorrelationConstants.CORRELATION_ID,
                 outMsgCtx.getProperty(CorrelationConstants.CORRELATION_ID));
+        for (String property : allowedResponseProperties) {
+            responseMsgCtx.setProperty(property, outMsgCtx.getProperty(property));
+        }
         responseMsgCtx.setProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE,
                                    outMsgCtx.getProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE));
         response.getConnection().getContext().setAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -56,6 +56,8 @@ public class PassThroughConfiguration {
     // URI configurations that determine if it requires custom rest dispatcher
     private static final String REST_URI_API_REGEX = "rest_uri_api_regex";
     private static final String REST_URI_PROXY_REGEX = "rest_uri_proxy_regex";
+    // properties which are allowed to be directly pass through from request context to response context explicitly
+    private static final String ALLOWED_RESPONSE_PROPERTIES = "allowed_response_properties";
 
     /** Reverse proxy mode is enabled or not */
     private Boolean reverseProxyMode = null;
@@ -376,6 +378,10 @@ public class PassThroughConfiguration {
 
     public boolean isListeningIOReactorShared(){
         return getBooleanProperty(PassThroughConfigPNames.HTTP_LISTENING_IO_REACTOR_SHARING_ENABLE, false);
+    }
+
+    public String getAllowedResponseProperties() {
+        return getStringProperty(ALLOWED_RESPONSE_PROPERTIES, null);
     }
 
     /**


### PR DESCRIPTION
When response message context is created from request, the axis2 properties are not copied by default. This adds a config, via which it can be explicitly copied to response context from request.

Config **passthru-http.properties**
```xml
allowed_response_properties={pro1_name},{prop2_name}
```