### PR TITLE
Update wirelogs code to match upgraded httpcore methods

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
@@ -180,13 +180,14 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
                             this.response.setEntity(entity);
                             this.connMetrics.incrementResponseCount();
                         }
+                        this.hasBufferedInput = this.inbuf.hasData();
                         onResponseReceived(this.response);
                         handler.responseReceived(this);
                         if (this.contentDecoder == null) {
                             resetInput();
                         }
                     }
-                    if (bytesRead == -1) {
+                    if (bytesRead == -1 && !this.inbuf.hasData()) {
                         handler.endOfInput(this);
                     }
                 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
@@ -175,6 +175,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                             ((HttpEntityEnclosingRequest) this.request).setEntity(entity);
                         }
                         this.connMetrics.incrementRequestCount();
+                        this.hasBufferedInput = this.inbuf.hasData();
                         onRequestReceived(this.request);
                         handler.requestReceived(this);
                         if (this.contentDecoder == null) {
@@ -183,7 +184,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                             resetInput();
                         }
                     }
-                    if (bytesRead == -1) {
+                    if (bytesRead == -1 && !this.inbuf.hasData()) {
                         handler.endOfInput(this);
                     }
                 }
@@ -202,7 +203,6 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                     }
                 }
             } catch (final HttpException ex) {
-                resetInput();
                 handler.exception(this, ex);
             } catch (final Exception ex) {
                 handler.exception(this, ex);
@@ -242,7 +242,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
 
             try {
                 if (this.status == ACTIVE) {
-                    if (this.contentEncoder == null) {
+                    if (this.contentEncoder == null && !this.outbuf.hasData()) {
                         handler.responseReady(this);
                     }
                     if (this.contentEncoder != null) {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

For the purpose of printing wire logs, we override the consumeInput and produceOutput methods in DefaultConnection class in httpcore-nio. Since httpcore-nio was upgraded to 4.4.13, we need to introduce the changes in synapse methods too. This PR will add the changes introduced by the following commits.

- https://github.com/apache/httpcomponents-core/commit/f75d0de151f6a58e398cac930d2498b796a13e7d
- https://github.com/apache/httpcomponents-core/commit/e8958470322a313d7ced7923b38edcc35075c64f
- https://github.com/apache/httpcomponents-core/commit/8236168a2369f01486f2e751ed24345720b0887b