### PR TITLE
Add support to get properties from file.properties through PropertyMediator

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/util/FilePropertyLoader.java
@@ -36,12 +36,12 @@ public class FilePropertyLoader {
     private static final String CONF_LOCATION = "conf.location";
     public static final String FILE_PROPERTY_PATH = "properties.file.path";
     private static final String DEFAULT_PROPERTY_FILE = "file.properties";
-    private Map propertyMap;
+    private static Map propertyMap;
 
     private static FilePropertyLoader fileLoaderInstance;
 
     public static FilePropertyLoader getInstance() {
-        if ( null == fileLoaderInstance) {
+        if (null == fileLoaderInstance) {
             fileLoaderInstance = new FilePropertyLoader();
             fileLoaderInstance.loadPropertiesFile();
         }
@@ -56,8 +56,12 @@ public class FilePropertyLoader {
 
         String filePath = System.getProperty(FILE_PROPERTY_PATH);
 
-        if ( null == filePath || filePath.isEmpty()) {
-            throw new SynapseCommonsException(FILE_PROPERTY_PATH + " is empty or null");
+        if (null == filePath || filePath.isEmpty()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(FILE_PROPERTY_PATH + " is empty or null");
+            }
+            propertyMap = new HashMap();
+            return;
         }
         if (("default").equals(filePath)) {
             filePath = System.getProperty(CONF_LOCATION) + File.separator + DEFAULT_PROPERTY_FILE;
@@ -84,5 +88,12 @@ public class FilePropertyLoader {
         } else {
             throw new SynapseCommonsException("File cannot found in " + filePath);
         }
+    }
+
+    public static Map getPropertyMap() {
+        if (propertyMap == null) {
+            FilePropertyLoader.getInstance();
+        }
+        return propertyMap;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/XMLConfigConstants.java
@@ -53,6 +53,8 @@ public class XMLConfigConstants {
     public static final String SCOPE_SYSTEM = "system";
     /** The scope name for environment variables */
     public static final String SCOPE_ENVIRONMENT = "env";
+    /** The scope name for properties defined in a file*/
+    public static final String SCOPE_FILE = "file";
     /** The scope name for properties used for tracing */
     public static final String SCOPE_TRACE = "trace";
     public static final String KEY = "key";

--- a/modules/core/src/main/java/org/apache/synapse/mediators/GetPropertyFunction.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/GetPropertyFunction.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.util.FilePropertyLoader;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -54,6 +55,8 @@ public class GetPropertyFunction implements Function , XPathFunction {
     private static final Log trace = LogFactory.getLog(SynapseConstants.TRACE_LOGGER);
 
     public static final String NULL_STRING = "";
+
+    public static Map filePropertyMap = FilePropertyLoader.getPropertyMap();
 
     /** Synapse Message context*/
     private final MessageContext synCtx;
@@ -109,7 +112,8 @@ public class GetPropertyFunction implements Function , XPathFunction {
                             !XMLConfigConstants.SCOPE_REGISTRY.equals(argOne) &&
                             !XMLConfigConstants.SCOPE_FUNC.equals(argOne) &&
                             !XMLConfigConstants.SCOPE_SYSTEM.equals(argOne) &&
-                            !XMLConfigConstants.SCOPE_ENVIRONMENT.equals(argOne)) {
+                            !XMLConfigConstants.SCOPE_ENVIRONMENT.equals(argOne) &&
+                            !XMLConfigConstants.SCOPE_FILE.equals(argOne)) {
                         return evaluate(XMLConfigConstants.SCOPE_DEFAULT, args.get(0),
                             args.get(1), context.getNavigator());
                     } else {
@@ -357,6 +361,17 @@ public class GetPropertyFunction implements Function , XPathFunction {
             } else {
                 if (traceOrDebugOn) {
                     traceOrDebug(traceOn, "Environment property " + key + " not found");
+                }
+                return NULL_STRING;
+            }
+
+        } else if (XMLConfigConstants.SCOPE_FILE.equals(scope)) {
+            Object propVal = filePropertyMap.get(key);
+            if (propVal != null) {
+                return (String) propVal;
+            } else {
+                if (traceOrDebugOn) {
+                    traceOrDebug(traceOn, "Property " + key + " not found in properties file");
                 }
                 return NULL_STRING;
             }

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
@@ -181,7 +181,8 @@ public class SynapseXPath extends SynapsePath {
 	 if (XMLConfigConstants.SCOPE_REGISTRY.equals(propertyScope)
 			|| XMLConfigConstants.SCOPE_SYSTEM.equals(propertyScope)
              || XMLConfigConstants.SCOPE_TRANSPORT.equals(propertyScope)
-             || XMLConfigConstants.SCOPE_SYSTEM.equals(propertyScope)) {
+             || XMLConfigConstants.SCOPE_ENVIRONMENT.equals(propertyScope)
+             || XMLConfigConstants.SCOPE_FILE.equals(propertyScope)) {
          contentAware = false;
          return;
 	 }


### PR DESCRIPTION
This PR adds support to get properties defined in file.properties configuration file through Property Mediator.
Example:
<property expression="get-property('file', 'host')" name="PropertiesFile" scope="default" type="STRING"/>

Fixes https://github.com/wso2/micro-integrator/issues/2132