### PR TITLE
Fixing NullPointer issue when invalid XML content generated from the PayloadFactory

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -237,6 +237,11 @@ public class PayloadFactoryMediator extends AbstractMediator {
 
     private boolean checkAndReplaceEnvelope(OMElement resultElement, MessageContext synCtx) {
         OMElement firstChild = resultElement.getFirstElement();
+
+        if (firstChild == null) {
+            handleException("Generated content is not a valid XML payload", synCtx);
+        }
+        
         QName resultQName = firstChild.getQName();
         if (resultQName.getLocalPart().equals("Envelope") && (
                 resultQName.getNamespaceURI().equals(SOAP11Constants.SOAP_ENVELOPE_NAMESPACE_URI) ||


### PR DESCRIPTION
## Purpose
Fixing NullPointer issue occur when an invalid XML content is generated from the PayloadFactory

Fixes https://github.com/wso2/micro-integrator/issues/2123