### PR TITLE
Mark pipe as discardable when it does not produce

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java
@@ -278,6 +278,7 @@ public class SynapseCallbackReceiver extends CallbackReceiver {
                         getAxis2MessageContext().getProperty("pass-through.Source-Connection");
                 Pipe newPipe = new Pipe(conn, sourceConfiguration.getBufferFactory().getBuffer(), "source",
                         sourceConfiguration);
+                newPipe.setDiscardable(true);
                 ((Axis2MessageContext) synapseOutMsgCtx).getAxis2MessageContext()
                         .setProperty(PassThroughConstants.PASS_THROUGH_PIPE, newPipe);
             }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -73,6 +73,9 @@ public class Pipe {
 
     private boolean producerError = false;
 
+    /** Flag to indicate that the Pipe will not produce anything */
+    private boolean discardable = false;
+
     /**
      * Socket Time out value specified in the nttp properties file.
      */
@@ -478,6 +481,14 @@ public class Pipe {
         } finally {
             lock.unlock();
         }
+    }
+
+    public boolean isDiscardable() {
+        return discardable ;
+    }
+
+    public void setDiscardable(boolean discardable) {
+        this.discardable  = discardable ;
     }
 
     /**

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -497,7 +497,7 @@ public class RelayUtils {
             try {
                 while (!pipe.isProducerCompleted() || pipe.isConsumeRequired()) {
                     consume(pipe);
-                    if (pipe.isProducerError()) {
+                    if (pipe.isProducerError() || pipe.isDiscardable()) {
                         break;
                     }
                 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves wso2/product-ei#5371

When we are sure that the Pipe will not produce any more data, we can mark the pipe as discardable so that services won't wait to consume data from the pipe.

