### PR TITLE
Improve the Timeout Logs of Gateway

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -32,6 +32,7 @@ import org.apache.synapse.SynapseHandler;
 import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.aspects.ComponentType;
@@ -157,6 +158,7 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
 
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_REST, mc.isDoingREST());
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_SOAP11, mc.isSOAP11());
+        synCtx.setProperty(CorrelationConstants.CORRELATION_ID, mc.getProperty(CorrelationConstants.CORRELATION_ID));
 
         try {
             if(synCtx.getEnvironment().isDebuggerEnabled()) {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseMessageReceiver.java
@@ -28,6 +28,7 @@ import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.util.logging.LoggingUtils;
 
@@ -86,6 +87,7 @@ public class SynapseMessageReceiver implements MessageReceiver {
 
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_REST, mc.isDoingREST());
         synCtx.setProperty(SynapseConstants.IS_CLIENT_DOING_SOAP11, mc.isSOAP11());
+        synCtx.setProperty(CorrelationConstants.CORRELATION_ID, mc.getProperty(CorrelationConstants.CORRELATION_ID));
 
         TenantInfoConfigurator configurator = synCtx.getEnvironment().getTenantInfoConfigurator();
         if (configurator != null) {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
@@ -29,6 +29,7 @@ import org.apache.synapse.ServerContextInformation;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.aspects.flow.statistics.collectors.CallbackStatisticCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.config.SynapseConfigUtils;
 import org.apache.synapse.endpoints.dispatch.SALSessions;
 import org.apache.synapse.commons.logger.ContextAwareLogger;
@@ -145,7 +146,9 @@ public class TimeoutHandler extends TimerTask {
                                             + (callback.getTimeoutDuration() / 1000) + " seconds for "
                                             + getEndpointLogMessage(callback.getSynapseOutMsgCtx(),
                                             callback.getAxis2OutMsgCtx()) + ", "
-                                            + getServiceLogMessage(callback.getSynapseOutMsgCtx()));
+                                            + getServiceLogMessage(callback.getSynapseOutMsgCtx())
+                                            + "Correlation ID : " + callback.getAxis2OutMsgCtx().getProperty(
+                                            CorrelationConstants.CORRELATION_ID));
                         }
 
                         if (callback.getTimeOutAction() != SynapseConstants.NONE) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -93,6 +93,9 @@ public class LogMediator extends AbstractMediator {
             }
         }
 
+        if (getCorrelationId(synCtx) != null) {
+            synCtx.setProperty(PassThroughConstants.CORRELATION_ID, getCorrelationId(synCtx));
+        }
         SynapseLog synLog = getLog(synCtx);
 
         if (synLog.isTraceOrDebugEnabled()) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -93,9 +93,6 @@ public class LogMediator extends AbstractMediator {
             }
         }
 
-        if (getCorrelationId(synCtx) != null) {
-            synCtx.setProperty(PassThroughConstants.CORRELATION_ID, getCorrelationId(synCtx));
-        }
         SynapseLog synLog = getLog(synCtx);
 
         if (synLog.isTraceOrDebugEnabled()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -577,7 +577,9 @@ public class SourceHandler implements NHttpServerEventHandler {
                     .get("direction") + ", "
                     + "CAUSE_OF_ERROR = Connection between the client and the EI timeouts, HTTP_URL = " + logDetails
                     .get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method") + ", SOCKET_TIMEOUT = " + conn
-                    .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
+                    .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn
+                    + " Correlation ID : " + conn.getContext().getAttribute(
+                            CorrelationConstants.CORRELATION_ID).toString());
             if (sourceConfiguration.isCorrelationLoggingEnabled()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }
@@ -590,7 +592,9 @@ public class SourceHandler implements NHttpServerEventHandler {
                     + ", DIRECTION = " + logDetails.get("direction") + ", "
                     + "CAUSE_OF_ERROR = Connection between the client and the EI timeouts, HTTP_URL = " + logDetails
                     .get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method") + ", SOCKET_TIMEOUT = " + conn
-                    .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
+                    .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn
+                    +  " Correlation ID : " + conn.getContext().getAttribute(
+                    CorrelationConstants.CORRELATION_ID).toString());
             if (sourceConfiguration.isCorrelationLoggingEnabled()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }
@@ -605,7 +609,8 @@ public class SourceHandler implements NHttpServerEventHandler {
                             + "CAUSE_OF_ERROR = Connection between the client and the EI timeouts, HTTP_URL = "
                             + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
                             + ", SOCKET_TIMEOUT = " + conn.getSocketTimeout() + ", CLIENT_ADDRESS = "
-                            + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
+                            + getClientConnectionInfo(conn) + ", CONNECTION " + conn + " Correlation ID : "
+                            + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID).toString());
             if (sourceConfiguration.isCorrelationLoggingEnabled()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }


### PR DESCRIPTION
The PR improves the Time out logs by adding Correlation ID to the logs and it adds the capability to print the correlation of a request through custom log mediator. So both of these together provides the capabilty to Trace a particular request which got time out using the introduced correlation Id.

Fix [https://github.com/wso2/product-apim/issues/10135](https://github.com/wso2/product-apim/issues/10135)