### PR TITLE
Fix issues when response with an unsupported content type received 

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -213,6 +213,7 @@ public class Axis2Sender {
                 AxisEngine.send(messageContext);
             }
         } catch (AxisFault e) {
+            smc.setProperty(SynapseConstants.RESPONSE_STATE, new ResponseState());
             handleException(getResponseMessage(messageContext), e, smc);
         }
     }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -505,6 +505,8 @@ public class RelayUtils {
                 handleException("Error when consuming the input stream to discard", exception);
             }
         }
+        msgContext.removeProperty(org.apache.synapse.commons.json.Constants.
+                ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM);
     }
 
     /**


### PR DESCRIPTION
### Purpose
This PR fixes the issues below.

1. OOM issue occurs when the response is containing an unsupported content type
2. Client does not get any response if there is any exception occurred during the execution of send mediator.

### Issues
Fixes https://github.com/wso2/product-apim/issues/9672