### PR TITLE
Make passthrough pipe isStale to false before throwing the exception so that a response can be sent

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -643,6 +643,7 @@ public class Pipe {
                 // ex: when client connection is closed while writing back the response
                 if (consumerError || isStale) {
                     buffer.clear();
+                    isStale = false;
                     throw new IOException("Consumer error or stale connection has occurred.");
                 }
                 if (consumerIoControl instanceof NHttpServerConnection) {


### PR DESCRIPTION
When a stale connection occurs (between the server and backend) there is no point in trying to write. In that scenario, we clear the buffer and throw an exception. When we try to send the response back to the client (from server to client), as the pipe state isStale is true again the exception is thrown and no response is submitted.

This PR sets isStale state to false before throwing the exception so that a response can be sent to the client (through the fault handler).

Fixes wso2/product-ei#5394
