### PR TITLE
Fix '%U' is not working as expected for the PassThrough access-log

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
@@ -459,7 +459,8 @@ public class Access {
         public void addElement(StringBuilder buf, Date date, HttpRequest request,
                                HttpResponse response) {
             if (request != null) {
-                buf.append(request.getRequestLine().getUri());
+                String uri = request.getRequestLine().getUri().split("\\?")[0];
+                buf.append(uri);
             } else {
                 buf.append('-');
             }


### PR DESCRIPTION
## Purpose

- This PR fixes https://github.com/wso2/product-apim/issues/9738
- This PR ports https://github.com/wso2-support/wso2-synapse/pull/1057