### PR TITLE
Fix MI-2189: Clone mediator when an error occurred the subsequent targets are executed in sequential mode

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPConstants.java
@@ -40,4 +40,6 @@ public final class EIPConstants {
 
     /** Constant for the Aggregate Element Type: child */
     public static final String AGGREGATE_ELEMENT_TYPE_CHILD = "child";
+
+    public static final String ERROR_ON_TARGET_EXECUTION = "ERROR_ON_TARGET_EXECUTION";
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/Target.java
@@ -255,6 +255,7 @@ public class Target {
         try {
             return sequenceMediator.mediate(synCtx);
         } catch (SynapseException syne) {
+            synCtx.setProperty(EIPConstants.ERROR_ON_TARGET_EXECUTION, true);
             if (!synCtx.getFaultStack().isEmpty()) {
                 log.warn(LoggingUtils.getFormattedLog(synCtx, "Executing fault handler due to exception encountered"),
                          syne);
@@ -265,6 +266,7 @@ public class Target {
                                                               + "dropped"));
             }
         } catch (Exception e) {
+            synCtx.setProperty(EIPConstants.ERROR_ON_TARGET_EXECUTION, true);
             String msg = "Unexpected error occurred executing the Target";
             log.error(LoggingUtils.getFormattedLog(synCtx, msg), e);
             if (synCtx.getServiceLog() != null) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/splitter/CloneMediator.java
@@ -133,8 +133,10 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
                 MessageContext clonedMsgCtx = getClonedMessageContext(synCtx, i++, targets.size());
                 ContinuationStackManager.addReliantContinuationState(clonedMsgCtx, i - 1,
                         getMediatorPosition());
-                boolean isSuccess = iter.next().mediate(clonedMsgCtx);
-                if (!isSuccess && sequential && isStopFlowOnFailure) {
+                iter.next().mediate(clonedMsgCtx);
+                boolean isFailure = "true".equalsIgnoreCase((String)clonedMsgCtx.
+                        getProperty(EIPConstants.ERROR_ON_TARGET_EXECUTION));
+                if (isFailure && sequential && isStopFlowOnFailure) {
                     break;
                 }
             }
@@ -170,8 +172,10 @@ public class CloneMediator extends AbstractMediator implements ManagedLifecycle,
             synCtx.setProperty(ITERATION_INDEX_PROPERTY_NAME, i + 1);
             MessageContext clonedMsgCtx = getClonedMessageContext(synCtx, i, noOfIterations);
             ContinuationStackManager.addReliantContinuationState(clonedMsgCtx, i - 1, getMediatorPosition());
-            boolean isSuccess = target.mediate(clonedMsgCtx);
-            if (!isSuccess && sequential && isStopFlowOnFailure) {
+            target.mediate(clonedMsgCtx);
+            boolean isFailure = "true".equalsIgnoreCase((String)clonedMsgCtx.
+                    getProperty(EIPConstants.ERROR_ON_TARGET_EXECUTION));
+            if (isFailure && sequential && isStopFlowOnFailure) {
                 break;
             }
         }


### PR DESCRIPTION


## Purpose

When an error occurs while executing the target in sequencial mode if the STOP_TARGET_EXECUTION_ON_FAILURE property is set the clone mediator will stop its execution

This is to fix https://github.com/wso2/micro-integrator/issues/2189