### PR TITLE
Remove redundant dependencies

### DIFF
--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -87,6 +87,32 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion> 
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId> 
+                    <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@wso2-jenkins-bot  Hi, I am a user of project **_org.apache.synapse:synapse-patches:2.1.7-wso2v221-SNAPSHOT_**. I found that its pom file introduced **_34_** dependencies. However, among them, **_6_** libraries (**_17%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.apache.synapse:synapse-patches:2.1.7-wso2v221-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
javax.servlet:servlet-api:jar:2.3:compile
javax.ws.rs:jsr311-api:jar:1.0:compile
org.apache.geronimo.specs:geronimo-activation_1.1_spec:jar:1.1:compile
org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1:compile
org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec:jar:1.1.2:compile
</code></pre>