### PR TITLE
Fix the server startup issue when open tracing is enabled

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/JaegerTracingManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/JaegerTracingManager.java
@@ -34,7 +34,7 @@ public class JaegerTracingManager implements OpenTracingManager {
 
     //private static final String SERVICE_NAME will read from ENV variable;
     private static final String SERVICE_NAME =
-            USER_DEFINED_NAME != null & !USER_DEFINED_NAME.isEmpty() ? USER_DEFINED_NAME : "WSO2-SYNAPSE";
+            USER_DEFINED_NAME != null && !USER_DEFINED_NAME.isEmpty() ? USER_DEFINED_NAME : "WSO2-SYNAPSE";
 
     /**
      * The common tracer object.


### PR DESCRIPTION
This PR fixes the NullPointerException, when the "SERVICE_NAME" system variable is not defined (for opentracing).

Fixes https://github.com/wso2/micro-integrator/issues/2215
