### PR TITLE
Fix synapse unit test failures

### DIFF
--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/clients/StockQuoteSampleClient.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/clients/StockQuoteSampleClient.java
@@ -161,8 +161,10 @@ public class StockQuoteSampleClient {
                     symbol, 1);
             serviceClient.getOptions().setAction("urn:getQuote");
             OMElement resultElement = serviceClient.sendReceive(payload);
-            log.info("Standard :: Stock price = $" +
-                    StockQuoteHandler.parseStandardQuoteResponse(resultElement));
+            if (resultElement != null) {
+                String parsedResponse = StockQuoteHandler.parseStandardQuoteResponse(resultElement);
+                log.info("Standard :: Stock price = $" + parsedResponse);
+            }
             clientResult.incrementResponseCount();
         } catch (Exception e) {
             log.error("Error invoking service", e);

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample4.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample4.java
@@ -19,7 +19,6 @@
 
 package org.apache.synapse.samples.framework.tests.message;
 
-import org.apache.axis2.AxisFault;
 import org.apache.synapse.samples.framework.SampleClientResult;
 import org.apache.synapse.samples.framework.SynapseTestCase;
 import org.apache.synapse.samples.framework.clients.StockQuoteSampleClient;
@@ -42,18 +41,11 @@ public class Sample4 extends SynapseTestCase {
         assertResponseReceived(result);
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "MSFT" ,null);
-        assertFalse("Must not get a response", result.responseReceived());
-        Exception resultEx = result.getException();
-        assertNotNull("Did not receive expected error" , resultEx);
-        log.info("Got an error as expected: " + resultEx.getMessage());
-        assertTrue("Did not receive expected error", resultEx instanceof AxisFault);
+        assertTrue("Did not get a response", result.responseReceived());
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "SUN" ,null);
-        assertFalse("Must not get a response", result.responseReceived());
-        Exception resultEx2 = result.getException();
-        assertNotNull("Did not receive expected error" , resultEx);
-        log.info("Got an error as expected: " + resultEx.getMessage());
-        assertTrue("Did not receive expected error", resultEx2 instanceof AxisFault);
+        assertTrue("Did not get a response", result.responseReceived());
+
     }
 
 }

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample5.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample5.java
@@ -59,11 +59,8 @@ public class Sample5 extends SynapseTestCase {
                    resultEx.getMessage().contains(expectedError_SUN));
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "IBM" ,null);
-        assertFalse("Must not get a response", result.responseReceived());
-        resultEx = result.getException();
-        assertNotNull("Did not receive expected error", resultEx);
-        log.info("Got an error as expected: " + resultEx.getMessage());
-        assertTrue("Did not receive expected error", resultEx instanceof AxisFault);
+        assertTrue("Did not get a response", result.responseReceived());
+
     }
 
 }


### PR DESCRIPTION
## Purpose
After the fix https://github.com/wso2/wso2-axis2/pull/215, we successfully get a response, when an empty payload is returned with HTTP status codes 201 or 202.

The tests **testErrorHandling(org.apache.synapse.samples.framework.tests.message.Sample4)** and
  **testCreateFaultAndChangeDirection(org.apache.synapse.samples.framework.tests.message.Sample5)**  were failing after the fix. Because earlier when a response with empty body is received from the canResponseHaveBody() method [1] true is returned. Then while creating a SOAPMessage with empty payload, an AxisFault is thrown [2].

After the above fix, we get a response for an empty payload with HTTP status codes 201, 202. This PR fixes the tests accordingly.

[1] https://github.com/wso2/wso2-axis2/blob/master/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java#L601
[2] https://github.com/wso2/wso2-axis2/blob/master/modules/kernel/src/org/apache/axis2/transport/TransportUtils.java#L93

**Note:** Merge this PR after merging https://github.com/wso2/wso2-axis2/pull/225/files