### PR TITLE
Update OAuth request body param keys in HTTP EP 

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/OAuthConfiguredHTTPEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/OAuthConfiguredHTTPEndpoint.java
@@ -19,10 +19,8 @@
 package org.apache.synapse.endpoints;
 
 import org.apache.axis2.AxisFault;
-import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.endpoints.oauth.MessageCache;
 import org.apache.synapse.endpoints.oauth.OAuthConstants;
 import org.apache.synapse.endpoints.oauth.OAuthException;
@@ -51,10 +49,7 @@ public class OAuthConfiguredHTTPEndpoint extends HTTPEndpoint {
 
             // If this a blocking call, add 401 as a non error http status code
             if (synCtx.getProperty(SynapseConstants.BLOCKING_MSG_SENDER) != null) {
-                org.apache.axis2.context.MessageContext axis2Ctx =
-                        ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-                axis2Ctx.setProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES,
-                        String.valueOf(OAuthConstants.HTTP_SC_UNAUTHORIZED));
+                OAuthUtils.append401HTTPSC(synCtx);
             }
 
             // Clone the original MessageContext and save it to do a retry after a token refresh

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
@@ -48,8 +48,8 @@ public class OAuthConstants {
     public static final String EXPIRES_IN = "expires_in";
 
     // parameters used to build oauth requests
-    public static final String PARAM_CLIENT_ID = "&clientId=";
-    public static final String PARAM_CLIENT_SECRET = "&clientSecret=";
+    public static final String PARAM_CLIENT_ID = "&client_id=";
+    public static final String PARAM_CLIENT_SECRET = "&client_secret=";
     public static final String PARAM_REFRESH_TOKEN = "&refresh_token=";
 
     public static final String RETRIED_ON_OAUTH_FAILURE = "RETRIED_ON_OAUTH_FAILURE";

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
@@ -29,6 +29,7 @@ import org.apache.axis2.context.ServiceContext;
 import org.apache.axis2.description.InOutAxisOperation;
 import org.apache.axis2.description.TransportInDescription;
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for OAuthUtils which contains helper functions used to generate OAuth handlers
@@ -211,6 +213,54 @@ public class OAuthUtilsTest {
             assertEquals(expected,
                     OAuthUtils.retryOnOAuthFailure(httpEndpoint, messageContextIn, messageContextOut));
 
+        }
+    }
+
+    /**
+     * Tests retryOnOauthFailure method
+     */
+    @RunWith(Parameterized.class)
+    public static class Append401HTTPSC {
+
+        private final MessageContext messageContext;
+        private final String expected;
+
+        public Append401HTTPSC(MessageContext messageContext, String expected) {
+
+            this.messageContext = messageContext;
+            this.expected = expected;
+        }
+
+        @Parameterized.Parameters
+        public static Collection provideDataForAppend401HTTPSCTests() throws AxisFault {
+
+            MessageContext messageContext = createMessageContext();
+
+            MessageContext messageContext2 = createMessageContext();
+            org.apache.axis2.context.MessageContext axis2MessageContext =
+                    ((Axis2MessageContext) messageContext2).getAxis2MessageContext();
+            axis2MessageContext.setProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES, "403");
+
+            return Arrays.asList(new Object[][]{
+                    {messageContext, "401"},
+                    {messageContext2, "401, 403"},
+            });
+        }
+
+        @Test
+        public void testAppend401HTTPSC() {
+
+            OAuthUtils.append401HTTPSC(messageContext);
+
+            org.apache.axis2.context.MessageContext axis2MessageContext =
+                    ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+            Object nonErrorCodesInMsgCtx = axis2MessageContext.getProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES);
+
+            assertTrue(nonErrorCodesInMsgCtx instanceof String);
+            String strNonErrorCodes = ((String) nonErrorCodesInMsgCtx).trim();
+            for (String strRetryErrorCode : expected.split(",")) {
+                assertTrue(strNonErrorCodes.contains(strRetryErrorCode.trim()));
+            }
         }
     }
 

--- a/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
+++ b/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
@@ -90,8 +90,8 @@ public class FoodService {
         String clientSecret = decodedCredentials.split(":")[1];
 
         String refreshToken = tokenRequestParams.getFirst("refresh_token");
-        String clientIdInBody = tokenRequestParams.getFirst("clientId");
-        String clientSecretInBody = tokenRequestParams.getFirst("clientSecret");
+        String clientIdInBody = tokenRequestParams.getFirst("client_id");
+        String clientSecretInBody = tokenRequestParams.getFirst("client_secret");
 
         if (refreshToken != null && !refreshToken.equals(Constants.refreshToken)) {
             return false;


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/2218
Fixes https://github.com/wso2/micro-integrator/issues/2219

## Goals
- Rename `clientId` and `clientSecret` param keys to `client_id` and `client_secret`
- Check NON_ERROR_HTTP_STATUS_CODES type and append 401