### PR TITLE
Revert "Fix synapse unit test failures"

### DIFF
--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/clients/StockQuoteSampleClient.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/clients/StockQuoteSampleClient.java
@@ -161,10 +161,8 @@ public class StockQuoteSampleClient {
                     symbol, 1);
             serviceClient.getOptions().setAction("urn:getQuote");
             OMElement resultElement = serviceClient.sendReceive(payload);
-            if (resultElement != null) {
-                String parsedResponse = StockQuoteHandler.parseStandardQuoteResponse(resultElement);
-                log.info("Standard :: Stock price = $" + parsedResponse);
-            }
+            log.info("Standard :: Stock price = $" +
+                    StockQuoteHandler.parseStandardQuoteResponse(resultElement));
             clientResult.incrementResponseCount();
         } catch (Exception e) {
             log.error("Error invoking service", e);

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample4.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample4.java
@@ -19,6 +19,7 @@
 
 package org.apache.synapse.samples.framework.tests.message;
 
+import org.apache.axis2.AxisFault;
 import org.apache.synapse.samples.framework.SampleClientResult;
 import org.apache.synapse.samples.framework.SynapseTestCase;
 import org.apache.synapse.samples.framework.clients.StockQuoteSampleClient;
@@ -41,11 +42,18 @@ public class Sample4 extends SynapseTestCase {
         assertResponseReceived(result);
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "MSFT" ,null);
-        assertTrue("Did not get a response", result.responseReceived());
+        assertFalse("Must not get a response", result.responseReceived());
+        Exception resultEx = result.getException();
+        assertNotNull("Did not receive expected error" , resultEx);
+        log.info("Got an error as expected: " + resultEx.getMessage());
+        assertTrue("Did not receive expected error", resultEx instanceof AxisFault);
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "SUN" ,null);
-        assertTrue("Did not get a response", result.responseReceived());
-
+        assertFalse("Must not get a response", result.responseReceived());
+        Exception resultEx2 = result.getException();
+        assertNotNull("Did not receive expected error" , resultEx);
+        log.info("Got an error as expected: " + resultEx.getMessage());
+        assertTrue("Did not receive expected error", resultEx2 instanceof AxisFault);
     }
 
 }

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample5.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/message/Sample5.java
@@ -59,8 +59,11 @@ public class Sample5 extends SynapseTestCase {
                    resultEx.getMessage().contains(expectedError_SUN));
 
         result = client.requestStandardQuote(addUrl, trpUrl, null, "IBM" ,null);
-        assertTrue("Did not get a response", result.responseReceived());
-
+        assertFalse("Must not get a response", result.responseReceived());
+        resultEx = result.getException();
+        assertNotNull("Did not receive expected error", resultEx);
+        log.info("Got an error as expected: " + resultEx.getMessage());
+        assertTrue("Did not receive expected error", resultEx instanceof AxisFault);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1398,8 +1398,8 @@
       <mina.version>1.1.0</mina.version>
       <jms-1.1-spec.version>1.1</jms-1.1-spec.version>
       <!-- Axis2 and its dependencies -->
-      <axis2.version>1.6.1-wso2v63</axis2.version>
-      <axis2.transport.version>2.0.0-wso2v60</axis2.transport.version>
+      <axis2.version>1.6.1-wso2v64</axis2.version>
+      <axis2.transport.version>2.0.0-wso2v62</axis2.transport.version>
       <axiom.version>1.2.11-wso2v16</axiom.version>
       <xml_schema.version>1.4.7</xml_schema.version>
       <xml_apis.version>1.3.04</xml_apis.version>


### PR DESCRIPTION
Reverts wso2/wso2-synapse#1775
Revering the PR, since the related axis2 fix is modified and this test case fix is not needed anymore.

**Note:** Merge this PR after merging https://github.com/wso2/wso2-axis2/pull/228 and updating the axis2 version