### PR TITLE
Fixes the NPE in JMS message processor

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
@@ -149,7 +149,6 @@ public class JmsConsumer implements MessageConsumer {
     }
 
     public boolean cleanup() throws SynapseException {
-        isAlive = false;
         if (logger.isDebugEnabled()) {
             logger.debug(getId() + " cleaning up...");
         }


### PR DESCRIPTION
- If OUT_ONLY has not been specified with an empty reply sequence, the message consumer throws a NPE. 
- Fixes the issue of inability of reactivate a jms message consumer
- Fixes: https://github.com/wso2/micro-integrator/issues/2265
- Related to: https://github.com/wso2/micro-integrator/issues/1807

