### PR TITLE
Use class loader to load pluggable mediator's serializer

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorSerializerFinder.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorSerializerFinder.java
@@ -119,7 +119,8 @@ public class MediatorSerializerFinder {
             log.debug("Registering mediator extensions found in the classpath.. ");
         }
         // register MediatorSerializer extensions
-        Iterator it = java.util.ServiceLoader.load(MediatorSerializer.class).iterator();
+        Iterator it = java.util.ServiceLoader
+                .load(MediatorSerializer.class, MediatorSerializerFinder.class.getClassLoader()).iterator();
         while (it.hasNext()) {
             MediatorSerializer ms = (MediatorSerializer) it.next();
             String name = ms.getMediatorClassName();


### PR DESCRIPTION
- Use class loader to load pluggable mediator's serializer
- Fixed https://github.com/wso2/product-apim/issues/11118