### PR TITLE
set DoingRest property when endpoint format is not defined.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
@@ -173,6 +173,8 @@ public class BlockingMsgSenderUtils {
                 }
                 axisOutMsgCtx.setDoingREST(true);
             }
+        } else {
+            axisOutMsgCtx.setDoingREST(axisInMsgCtx.isDoingREST());
         }
 
         // MTOM/SWA


### PR DESCRIPTION
- For instances where the endpoint format is not defined (i.e: anonymous endpoints), we need to set a default isDoingRest property.
- Default value will be the based on the incoming request.
- Fixes: https://github.com/wso2/product-ei/issues/5400