### PR TITLE
Consider the requests consumed by the processor as separate requests when generating Statistics Reporting

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -331,10 +331,23 @@ public abstract class RuntimeStatisticCollector {
         }
         eventHolder.addEvent(event);
 
-        if (eventHolder.countHolder.decrementAndGetStatCount() <= 0 && eventHolder.countHolder.getCallBackCount() <= 0) {
+        if (eventHolder.countHolder.decrementAndGetStatCount() <= 0 &&
+                eventHolder.countHolder.getCallBackCount() <= 0 && !continueStatisticFlow(messageContext)) {
             eventHolder.setEvenCollectionFinished(true);
             messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
         }
+    }
+
+    /**
+     * Helper method to check whether we need to continue the current statistic flow
+     *
+     * @param messageContext
+     * @return true if we need to continue the current statistic flow
+     */
+    private static boolean continueStatisticFlow(MessageContext messageContext) {
+
+        Object continueStatisticFlow = messageContext.getProperty(StatisticsConstants.CONTINUE_STATISTICS_FLOW);
+        return continueStatisticFlow != null && (Boolean) continueStatisticFlow;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
@@ -201,4 +201,6 @@ public class StatisticsConstants {
 
     public static final String STAT_COLLECTOR_PROPERTY = "STATISTIC_COLLECTOR";
 
+    public static final String CONTINUE_STATISTICS_FLOW = "CONTINUE_STATISTICS_FLOW";
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessorUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessorUtils.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.message.processor;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
+
+import java.util.Set;
+
+public class MessageProcessorUtils {
+
+    /**
+     * Since the request stored in the store and consumed by the processor are considered as separate requests
+     * we need to remove the existing StatisticsReportingEventHolder object
+     *
+     * @param messageContext
+     */
+    public static void removeStatisticsReportingEventHolder(MessageContext messageContext) {
+
+        if (messageContext != null) {
+            Set pros = messageContext.getPropertyKeySet();
+            if (pros != null) {
+                pros.remove(StatisticsConstants.FLOW_STATISTICS_ID);
+                pros.remove(StatisticsConstants.MEDIATION_FLOW_STATISTICS_PARENT_INDEX);
+                pros.remove(StatisticsConstants.STAT_COLLECTOR_PROPERTY);
+                pros.remove(StatisticsConstants.MEDIATION_FLOW_STATISTICS_INDEXING_OBJECT);
+            }
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverForwardingService.java
@@ -38,6 +38,7 @@ import org.apache.synapse.message.MessageProducer;
 import org.apache.synapse.message.StoreForwardException;
 import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.processor.MessageProcessorConstants;
+import org.apache.synapse.message.processor.MessageProcessorUtils;
 import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.task.Task;
 import org.apache.synapse.util.MessageHelper;
@@ -316,7 +317,9 @@ public class FailoverForwardingService implements Task, ManagedLifecycle {
      * store.
      */
     public MessageContext fetch(MessageConsumer msgConsumer) throws StoreForwardException {
-        return messageConsumer.receive();
+        MessageContext messageContext = messageConsumer.receive();
+        MessageProcessorUtils.removeStatisticsReportingEventHolder(messageContext);
+        return messageContext;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
@@ -43,6 +43,7 @@ import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.message.MessageConsumer;
 import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.processor.MessageProcessorConstants;
+import org.apache.synapse.message.processor.MessageProcessorUtils;
 import org.apache.synapse.task.Task;
 
 /**
@@ -248,6 +249,7 @@ public class SamplingService implements Task, ManagedLifecycle {
 				}
 			}
 		}
+		MessageProcessorUtils.removeStatisticsReportingEventHolder(newMsg);
 		return newMsg;
 	}
 


### PR DESCRIPTION
## Purpose
In message store and message processor scenarios, the request consumed by the message processor was not considered when generating Statistics Reporting. Because of this, a WARN log was observed as mentioned in the following issue. With this fix we consider request stored in the store and consumed by the message processor as separate requests when generating Statistics Reporting.

Fixes wso2/product-ei#5408

