### PR TITLE
Add method to checks if the task location linked to a MP is known

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
@@ -456,6 +456,10 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
                taskManager.isTaskBlocked(TASK_PREFIX + name + SYMBOL_UNDERSCORE + DEFAULT_TASK_SUFFIX);
 	}
 
+	public boolean isTaskLocationKnown() {
+		return taskManager.isTaskExist(TASK_PREFIX + name + DEFAULT_TASK_SUFFIX);
+	}
+
     @Override
     public boolean isPaused() {
 		return taskManager.isTaskDeactivated(TASK_PREFIX + name + SYMBOL_UNDERSCORE + DEFAULT_TASK_SUFFIX);

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverMessageForwardingProcessorView.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverMessageForwardingProcessorView.java
@@ -68,4 +68,9 @@ public class FailoverMessageForwardingProcessorView implements
         assert processor != null;
         processor.deactivate();
     }
+
+    public boolean isTaskLocationKnown() {
+        assert processor != null;
+        return processor.isTaskLocationKnown();
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverMessageForwardingProcessorViewMBean.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverMessageForwardingProcessorViewMBean.java
@@ -86,4 +86,10 @@ public interface FailoverMessageForwardingProcessorViewMBean {
      * This will stop the processing of Messages.
      */
     public void deactivate();
+
+    /**
+     * Checks if the task location linked to this Message Processor is known
+     * @return true if the task location linked to this Message Processor is known
+     */
+    public boolean isTaskLocationKnown();
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/MessageForwardingProcessorView.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/MessageForwardingProcessorView.java
@@ -67,4 +67,9 @@ public class MessageForwardingProcessorView implements MessageForwardingProcesso
         assert processor != null;
         processor.deactivate();
     }
+
+    public boolean isTaskLocationKnown() {
+        assert processor != null;
+        return processor.isTaskLocationKnown();
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/MessageForwardingProcessorViewMBean.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/MessageForwardingProcessorViewMBean.java
@@ -86,4 +86,10 @@ public interface MessageForwardingProcessorViewMBean {
      * This will stop the processing of Messages.
      */
     public void deactivate();
+
+    /**
+     * Checks if the task location linked to this Message Processor is known
+     * @return true if the task location linked to this Message Processor is known
+     */
+    public boolean isTaskLocationKnown();
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingProcessorView.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingProcessorView.java
@@ -38,4 +38,9 @@ public class SamplingProcessorView implements SamplingProcessorViewMBean {
         assert processor != null;
         return processor.isActive();
     }
+
+    public boolean isTaskLocationKnown() {
+        assert processor != null;
+        return processor.isTaskLocationKnown();
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingProcessorViewMBean.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingProcessorViewMBean.java
@@ -38,4 +38,9 @@ public interface SamplingProcessorViewMBean {
      */
     public boolean isActive();
 
+    /**
+     * Checks if the task location linked to this Message Processor is known
+     * @return true if the task location linked to this Message Processor is known
+     */
+    public boolean isTaskLocationKnown();
 }


### PR DESCRIPTION
## Purpose
When blocking the hazelcast clustering communication ports using iptable rules, nodes leave from the cluster and the Management Console shows the MP as deactivated. Instead, we need to show a proper error message mentioning that the processor may be running in other nodes. This PR adds a method to checks if the task location linked to an MP is known.

## Related Issue

wso2/product-ei#5393