### PR TITLE
Add Password grant type to OAuth HTTP endpoints

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointSerializer.java
@@ -19,7 +19,6 @@
 
 package org.apache.synapse.config.xml.endpoints;
 
-
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.SynapseConstants;
@@ -27,12 +26,7 @@ import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.endpoints.HTTPEndpoint;
 import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
-import org.apache.synapse.endpoints.oauth.AuthorizationCodeHandler;
-import org.apache.synapse.endpoints.oauth.ClientCredentialsHandler;
 import org.apache.synapse.endpoints.oauth.OAuthConstants;
-import org.apache.synapse.endpoints.oauth.PasswordCredentialsHandler;
-
-import java.util.Map;
 
 public class HTTPEndpointSerializer extends DefaultEndpointSerializer {
     @Override
@@ -89,7 +83,7 @@ public class HTTPEndpointSerializer extends DefaultEndpointSerializer {
     }
 
     /**
-     * This method returns an OMElement containing the OAuth configuration
+     * This method returns an OMElement containing the OAuth configuration.
      *
      * @param oAuthConfiguredHTTPEndpoint OAuth Configured HTTP Endpoint
      * @return OMElement containing the OAuth configuration
@@ -105,142 +99,7 @@ public class HTTPEndpointSerializer extends DefaultEndpointSerializer {
                 SynapseConstants.SYNAPSE_OMNAMESPACE);
         authentication.addChild(oauth);
 
-        if (oAuthConfiguredHTTPEndpoint.getOauthHandler() instanceof AuthorizationCodeHandler) {
-            oauth.addChild(serializeAuthorizationCodeConfigurationElements(
-                    (AuthorizationCodeHandler) oAuthConfiguredHTTPEndpoint.getOauthHandler()));
-        }
-
-        if (oAuthConfiguredHTTPEndpoint.getOauthHandler() instanceof ClientCredentialsHandler) {
-            oauth.addChild(serializeClientCredentialsConfigurationElements(
-                    (ClientCredentialsHandler) oAuthConfiguredHTTPEndpoint.getOauthHandler()));
-        }
-
-        if (oAuthConfiguredHTTPEndpoint.getOauthHandler() instanceof PasswordCredentialsHandler) {
-            oauth.addChild(serializePasswordCredentialsConfigurationElements(
-                    (PasswordCredentialsHandler) oAuthConfiguredHTTPEndpoint.getOauthHandler()));
-        }
-
+        oauth.addChild(oAuthConfiguredHTTPEndpoint.getOauthHandler().serializeOAuthConfiguration(fac));
         return authentication;
-    }
-
-    /**
-     * This method returns an OMElement containing the Client Credentials configuration
-     *
-     * @param clientCredentialsHandler ClientCredentialsHandler of the OAuth Configured HTTP Endpoint
-     * @return OMElement containing the Client Credentials configuration
-     */
-    private OMElement serializeClientCredentialsConfigurationElements(
-            ClientCredentialsHandler clientCredentialsHandler) {
-
-        OMElement clientCredentials = fac.createOMElement(
-                OAuthConstants.CLIENT_CREDENTIALS,
-                SynapseConstants.SYNAPSE_OMNAMESPACE);
-
-        clientCredentials.addChild(
-                createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_ID, clientCredentialsHandler.getClientId()));
-        clientCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_SECRET,
-                clientCredentialsHandler.getClientSecret()));
-        clientCredentials
-                .addChild(
-                        createOMElementWithValue(OAuthConstants.TOKEN_API_URL, clientCredentialsHandler.getTokenUrl()));
-        if (clientCredentialsHandler.getRequestParametersMap() != null &&
-                clientCredentialsHandler.getRequestParametersMap().size() > 0) {
-            OMElement requestParameters = createOMRequestParams(clientCredentialsHandler.getRequestParametersMap());
-            clientCredentials.addChild(requestParameters);
-        }
-        return clientCredentials;
-    }
-
-    /**
-     * Create an OMElement for request parameter map.
-     *
-     * @param requestParametersMap input parameter map.
-     * @return OMElement of parameter map.
-     */
-    private OMElement createOMRequestParams(Map<String, String> requestParametersMap) {
-        OMElement requestParameters =
-                fac.createOMElement("requestParameters", SynapseConstants.SYNAPSE_OMNAMESPACE);
-        for (Map.Entry<String, String> entry : requestParametersMap.entrySet()) {
-            OMElement parameter = fac.createOMElement("parameter", SynapseConstants.SYNAPSE_OMNAMESPACE);
-            parameter.addAttribute("name", entry.getKey(), null);
-            parameter.setText(entry.getValue());
-            requestParameters.addChild(parameter);
-        }
-        return requestParameters;
-    }
-
-    /**
-     * This method returns an OMElement containing the Authorization Code configuration
-     *
-     * @param authorizationCodeHandler AuthorizationCodeHandler of the OAuth Configured HTTP Endpoint
-     * @return OMElement containing the Authorization Code configuration
-     */
-    private OMElement serializeAuthorizationCodeConfigurationElements(
-            AuthorizationCodeHandler authorizationCodeHandler) {
-
-        OMElement clientCredentials = fac.createOMElement(
-                OAuthConstants.AUTHORIZATION_CODE,
-                SynapseConstants.SYNAPSE_OMNAMESPACE);
-
-        clientCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_ID,
-                authorizationCodeHandler.getClientId()));
-        clientCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_SECRET,
-                authorizationCodeHandler.getClientSecret()));
-        clientCredentials.addChild(
-                createOMElementWithValue(OAuthConstants.OAUTH_REFRESH_TOKEN, authorizationCodeHandler.getRefreshToken()));
-        clientCredentials
-                .addChild(
-                        createOMElementWithValue(OAuthConstants.TOKEN_API_URL, authorizationCodeHandler.getTokenUrl()));
-        if (authorizationCodeHandler.getRequestParametersMap() != null &&
-                authorizationCodeHandler.getRequestParametersMap().size() > 0) {
-            OMElement requestParameters = createOMRequestParams(authorizationCodeHandler.getRequestParametersMap());
-            clientCredentials.addChild(requestParameters);
-        }
-        return clientCredentials;
-    }
-
-    /**
-     * This method returns an OMElement containing the Password Credentials configuration
-     *
-     * @param passwordCredentialsHandler PasswordCredentialsHandler of the OAuth Configured HTTP Endpoint
-     * @return OMElement containing the Password Credentials configuration
-     */
-    private OMElement serializePasswordCredentialsConfigurationElements(
-            PasswordCredentialsHandler passwordCredentialsHandler) {
-
-        OMElement passwordCredentials = fac.createOMElement(
-                OAuthConstants.PASSWORD_CREDENTIALS,
-                SynapseConstants.SYNAPSE_OMNAMESPACE);
-
-        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_ID,
-                passwordCredentialsHandler.getClientId()));
-        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_SECRET,
-                passwordCredentialsHandler.getClientSecret()));
-        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_USERNAME,
-                passwordCredentialsHandler.getUsername()));
-        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_PASSWORD,
-                passwordCredentialsHandler.getPassword()));
-        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.TOKEN_API_URL,
-                passwordCredentialsHandler.getTokenUrl()));
-        if (passwordCredentialsHandler.getRequestParametersMap() != null &&
-                passwordCredentialsHandler.getRequestParametersMap().size() > 0) {
-            OMElement requestParameters = createOMRequestParams(passwordCredentialsHandler.getRequestParametersMap());
-            passwordCredentials.addChild(requestParameters);
-        }
-        return passwordCredentials;
-    }
-
-    /**
-     * This method returns an OMElement containing the elementValue encapsulated by the elementName
-     *
-     * @param elementName  Name of the OMElement
-     * @param elementValue Value of the OMElement
-     * @return OMElement containing the value encapsulated by the elementName
-     */
-    private OMElement createOMElementWithValue(String elementName, String elementValue) {
-
-        OMElement element = fac.createOMElement(elementName, SynapseConstants.SYNAPSE_OMNAMESPACE);
-        element.setText(elementValue);
-        return element;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/HTTPEndpointSerializer.java
@@ -30,6 +30,7 @@ import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
 import org.apache.synapse.endpoints.oauth.AuthorizationCodeHandler;
 import org.apache.synapse.endpoints.oauth.ClientCredentialsHandler;
 import org.apache.synapse.endpoints.oauth.OAuthConstants;
+import org.apache.synapse.endpoints.oauth.PasswordCredentialsHandler;
 
 import java.util.Map;
 
@@ -114,6 +115,11 @@ public class HTTPEndpointSerializer extends DefaultEndpointSerializer {
                     (ClientCredentialsHandler) oAuthConfiguredHTTPEndpoint.getOauthHandler()));
         }
 
+        if (oAuthConfiguredHTTPEndpoint.getOauthHandler() instanceof PasswordCredentialsHandler) {
+            oauth.addChild(serializePasswordCredentialsConfigurationElements(
+                    (PasswordCredentialsHandler) oAuthConfiguredHTTPEndpoint.getOauthHandler()));
+        }
+
         return authentication;
     }
 
@@ -191,6 +197,37 @@ public class HTTPEndpointSerializer extends DefaultEndpointSerializer {
             clientCredentials.addChild(requestParameters);
         }
         return clientCredentials;
+    }
+
+    /**
+     * This method returns an OMElement containing the Password Credentials configuration
+     *
+     * @param passwordCredentialsHandler PasswordCredentialsHandler of the OAuth Configured HTTP Endpoint
+     * @return OMElement containing the Password Credentials configuration
+     */
+    private OMElement serializePasswordCredentialsConfigurationElements(
+            PasswordCredentialsHandler passwordCredentialsHandler) {
+
+        OMElement passwordCredentials = fac.createOMElement(
+                OAuthConstants.PASSWORD_CREDENTIALS,
+                SynapseConstants.SYNAPSE_OMNAMESPACE);
+
+        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_ID,
+                passwordCredentialsHandler.getClientId()));
+        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_CLIENT_SECRET,
+                passwordCredentialsHandler.getClientSecret()));
+        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_USERNAME,
+                passwordCredentialsHandler.getUsername()));
+        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.OAUTH_PASSWORD,
+                passwordCredentialsHandler.getPassword()));
+        passwordCredentials.addChild(createOMElementWithValue(OAuthConstants.TOKEN_API_URL,
+                passwordCredentialsHandler.getTokenUrl()));
+        if (passwordCredentialsHandler.getRequestParametersMap() != null &&
+                passwordCredentialsHandler.getRequestParametersMap().size() > 0) {
+            OMElement requestParameters = createOMRequestParams(passwordCredentialsHandler.getRequestParametersMap());
+            passwordCredentials.addChild(requestParameters);
+        }
+        return passwordCredentials;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
@@ -26,9 +26,9 @@ import org.apache.synapse.MessageContext;
  */
 public class AuthorizationCodeHandler extends OAuthHandler {
 
-    private String clientId;
-    private String clientSecret;
-    private String refreshToken;
+    private final String clientId;
+    private final String clientSecret;
+    private final String refreshToken;
 
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret,
                                     String refreshToken) {
@@ -44,23 +44,22 @@ public class AuthorizationCodeHandler extends OAuthHandler {
 
         StringBuilder payload = new StringBuilder();
 
-        clientId = OAuthUtils.resolveExpression(clientId, messageContext);
-        clientSecret = OAuthUtils.resolveExpression(clientSecret, messageContext);
-        refreshToken = OAuthUtils.resolveExpression(refreshToken, messageContext);
-
         payload.append(OAuthConstants.REFRESH_TOKEN_GRANT_TYPE)
-                .append(OAuthConstants.PARAM_REFRESH_TOKEN).append(refreshToken);
-        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(clientId);
-        payload.append(OAuthConstants.PARAM_CLIENT_SECRET).append(clientSecret);
+                .append(OAuthConstants.PARAM_REFRESH_TOKEN)
+                .append(OAuthUtils.resolveExpression(refreshToken, messageContext));
+        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(OAuthUtils.resolveExpression(clientId, messageContext));
+        payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
+                .append(OAuthUtils.resolveExpression(clientSecret, messageContext));
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();
     }
 
     @Override
-    protected String getEncodedCredentials() {
+    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
 
-        return Base64Utils.encode((clientId + ":" + clientSecret).getBytes());
+        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
+                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
@@ -18,24 +18,22 @@
 
 package org.apache.synapse.endpoints.oauth;
 
-import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 
 /**
- * This class is used to handle Authorization code grant oauth
+ * This class is used to handle Authorization code grant oauth.
  */
 public class AuthorizationCodeHandler extends OAuthHandler {
 
-    private final String clientId;
-    private final String clientSecret;
     private final String refreshToken;
 
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret,
                                     String refreshToken) {
 
-        super(tokenApiUrl);
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
+        super(tokenApiUrl, clientId, clientSecret);
         this.refreshToken = refreshToken;
     }
 
@@ -47,43 +45,29 @@ public class AuthorizationCodeHandler extends OAuthHandler {
         payload.append(OAuthConstants.REFRESH_TOKEN_GRANT_TYPE)
                 .append(OAuthConstants.PARAM_REFRESH_TOKEN)
                 .append(OAuthUtils.resolveExpression(refreshToken, messageContext));
-        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(OAuthUtils.resolveExpression(clientId, messageContext));
+        payload.append(OAuthConstants.PARAM_CLIENT_ID)
+                .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
         payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
-                .append(OAuthUtils.resolveExpression(clientSecret, messageContext));
+                .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();
     }
 
     @Override
-    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
+    protected OMElement serializeSpecificOAuthConfigs(OMFactory omFactory) {
 
-        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
-                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
+        OMElement authCode = omFactory.createOMElement(
+                OAuthConstants.AUTHORIZATION_CODE,
+                SynapseConstants.SYNAPSE_OMNAMESPACE);
+
+        authCode.addChild(
+                OAuthUtils.createOMElementWithValue(omFactory, OAuthConstants.OAUTH_REFRESH_TOKEN, getRefreshToken()));
+        return authCode;
     }
 
     /**
-     * Return the client id relevant to the Authorization Code Handler
-     *
-     * @return String client id
-     */
-    public String getClientId() {
-
-        return clientId;
-    }
-
-    /**
-     * Return the client secret relevant to the Authorization Code Handler
-     *
-     * @return String client secret
-     */
-    public String getClientSecret() {
-
-        return clientSecret;
-    }
-
-    /**
-     * Return the refresh token secret relevant to the Authorization Code Handler
+     * Return the refresh token secret relevant to the Authorization Code Handler.
      *
      * @return String refresh token
      */

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
@@ -18,22 +18,19 @@
 
 package org.apache.synapse.endpoints.oauth;
 
-import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 
 /**
- * This class is used to handle Client Credentials grant oauth
+ * This class is used to handle Client Credentials grant oauth.
  */
 public class ClientCredentialsHandler extends OAuthHandler {
 
-    private final String clientId;
-    private final String clientSecret;
-
     public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret) {
 
-        super(tokenApiUrl);
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
+        super(tokenApiUrl, clientId, clientSecret);
     }
 
     @Override
@@ -42,38 +39,18 @@ public class ClientCredentialsHandler extends OAuthHandler {
         StringBuilder payload = new StringBuilder();
 
         payload.append(OAuthConstants.CLIENT_CRED_GRANT_TYPE);
-        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(OAuthUtils.resolveExpression(clientId, messageContext));
+        payload.append(OAuthConstants.PARAM_CLIENT_ID)
+                .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
         payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
-                .append(OAuthUtils.resolveExpression(clientSecret, messageContext));
+                .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();
     }
 
     @Override
-    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
+    protected OMElement serializeSpecificOAuthConfigs(OMFactory omFactory) {
 
-        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
-                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
-    }
-
-    /**
-     * Return the client id relevant to the Client Credentials Handler
-     *
-     * @return String client id
-     */
-    public String getClientId() {
-
-        return clientId;
-    }
-
-    /**
-     * Return the client secret relevant to the Client Credentials Handler
-     *
-     * @return String client secret
-     */
-    public String getClientSecret() {
-
-        return clientSecret;
+        return omFactory.createOMElement(OAuthConstants.CLIENT_CREDENTIALS, SynapseConstants.SYNAPSE_OMNAMESPACE);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
@@ -26,8 +26,8 @@ import org.apache.synapse.MessageContext;
  */
 public class ClientCredentialsHandler extends OAuthHandler {
 
-    private String clientId;
-    private String clientSecret;
+    private final String clientId;
+    private final String clientSecret;
 
     public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret) {
 
@@ -41,21 +41,20 @@ public class ClientCredentialsHandler extends OAuthHandler {
 
         StringBuilder payload = new StringBuilder();
 
-        clientId = OAuthUtils.resolveExpression(clientId, messageContext);
-        clientSecret = OAuthUtils.resolveExpression(clientSecret, messageContext);
-
         payload.append(OAuthConstants.CLIENT_CRED_GRANT_TYPE);
-        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(clientId);
-        payload.append(OAuthConstants.PARAM_CLIENT_SECRET).append(clientSecret);
+        payload.append(OAuthConstants.PARAM_CLIENT_ID).append(OAuthUtils.resolveExpression(clientId, messageContext));
+        payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
+                .append(OAuthUtils.resolveExpression(clientSecret, messageContext));
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();
     }
 
     @Override
-    protected String getEncodedCredentials() {
+    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
 
-        return Base64Utils.encode((clientId + ":" + clientSecret).getBytes());
+        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
+                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
@@ -27,9 +27,12 @@ public class OAuthConstants {
     public static final String OAUTH = "oauth";
     public static final String CLIENT_CREDENTIALS = "clientCredentials";
     public static final String AUTHORIZATION_CODE = "authorizationCode";
+    public static final String PASSWORD_CREDENTIALS = "passwordCredentials";
     public static final String TOKEN_API_URL = "tokenUrl";
     public static final String OAUTH_CLIENT_ID = "clientId";
     public static final String OAUTH_CLIENT_SECRET = "clientSecret";
+    public static final String OAUTH_USERNAME = "username";
+    public static final String OAUTH_PASSWORD = "password";
     public static final String OAUTH_REFRESH_TOKEN = "refreshToken";
     public static final String REQUEST_PARAMETERS = "requestParameters";
     public static final String REQUEST_PARAMETER = "parameter";
@@ -42,6 +45,7 @@ public class OAuthConstants {
     public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
     public static final String CLIENT_CRED_GRANT_TYPE = "grant_type=client_credentials";
     public static final String REFRESH_TOKEN_GRANT_TYPE = "grant_type=refresh_token";
+    public static final String PASSWORD_CRED_GRANT_TYPE = "grant_type=password";
 
     // elements in the oauth response
     public static final String ACCESS_TOKEN = "access_token";
@@ -51,6 +55,8 @@ public class OAuthConstants {
     public static final String EXPIRES_IN = "expires_in";
 
     // parameters used to build oauth requests
+    public static final String PARAM_USERNAME = "&username=";
+    public static final String PARAM_PASSWORD = "&password=";
     public static final String PARAM_CLIENT_ID = "&client_id=";
     public static final String PARAM_CLIENT_SECRET = "&client_secret=";
     public static final String PARAM_REFRESH_TOKEN = "&refresh_token=";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthHandler.java
@@ -74,7 +74,7 @@ public abstract class OAuthHandler {
                 public String call() throws OAuthException, IOException {
 
                     return OAuthClient.generateToken(tokenApiUrl, buildTokenRequestPayload(messageContext),
-                            getEncodedCredentials());
+                            getEncodedCredentials(messageContext));
                 }
             });
         } catch (ExecutionException e) {
@@ -133,9 +133,11 @@ public abstract class OAuthHandler {
     /**
      * Return the base 64 encoded clientId:clientSecret relevant to the OAuth handler.
      *
+     * @param messageContext Message Context of the request which will be used to resolve dynamic expressions
      * @return String payload
+     * @throws OAuthException In the event of errors when resolving the dynamic expressions
      */
-    protected abstract String getEncodedCredentials();
+    protected abstract String getEncodedCredentials(MessageContext messageContext) throws OAuthException;
 
     /**
      * Return the request parameters as a string

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthUtils.java
@@ -19,6 +19,7 @@
 package org.apache.synapse.endpoints.oauth;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.util.UIDGenerator;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.lang.StringUtils;
@@ -46,7 +47,7 @@ import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
 
 /**
- * Helper class to build OAuth handlers using the synapse configuration of the endpoints
+ * Helper class to build OAuth handlers using the synapse configuration of the endpoints.
  */
 public class OAuthUtils {
 
@@ -54,7 +55,7 @@ public class OAuthUtils {
     private static final Pattern EXPRESSION_PATTERN = Pattern.compile("(\\{[^\"<>}\\]]+})");
 
     /**
-     * This method will return an OAuthHandler instance depending on the oauth configs
+     * This method will return an OAuthHandler instance depending on the oauth configs.
      *
      * @param httpElement Element containing http configs
      * @return OAuthHandler object
@@ -85,7 +86,7 @@ public class OAuthUtils {
     }
 
     /**
-     * This method will return an OAuthHandler instance depending on the oauth configs
+     * This method will return an OAuthHandler instance depending on the oauth configs.
      *
      * @param oauthElement Element containing OAuth configs
      * @return OAuthHandler object
@@ -104,32 +105,25 @@ public class OAuthUtils {
                 SynapseConstants.SYNAPSE_NAMESPACE, OAuthConstants.PASSWORD_CREDENTIALS));
 
         if (hasMultipleOAuthConfigs(authCodeElement, clientCredentialsElement, passwordCredentialsElement)) {
-            if (log.isDebugEnabled()) {
-                log.error("Invalid OAuth configuration: AuthorizationCode and ClientCredentials grants are not " +
-                        "allowed together");
-            }
+            log.error("Invalid OAuth configuration: Multiple OAuth configurations are defined");
             return null;
         }
 
         if (authCodeElement != null) {
             oAuthHandler = getAuthorizationCodeHandler(authCodeElement);
-        }
-
-        if (clientCredentialsElement != null) {
+        } else if (clientCredentialsElement != null) {
             oAuthHandler = getClientCredentialsHandler(clientCredentialsElement);
-        }
-
-        if (passwordCredentialsElement != null) {
+        } else if (passwordCredentialsElement != null) {
             oAuthHandler = getPasswordCredentialsHandler(passwordCredentialsElement);
         }
         return oAuthHandler;
     }
 
     /**
-     * Method to check whether there are multiple OAuth config defined
+     * Method to check whether there are multiple OAuth config defined.
      *
-     * @param authCodeElement OAuth config for authorization code
-     * @param clientCredentialsElement OAuth config for client credentials
+     * @param authCodeElement            OAuth config for authorization code
+     * @param clientCredentialsElement   OAuth config for client credentials
      * @param passwordCredentialsElement OAuth config for password credentials
      * @return true if there are multiple OAuth config defined
      */
@@ -142,7 +136,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to get a AuthorizationCodeHandler
+     * Method to get a AuthorizationCodeHandler.
      *
      * @param authCodeElement Element containing authorization code configs
      * @return AuthorizationCodeHandler object
@@ -155,9 +149,7 @@ public class OAuthUtils {
         String tokenApiUrl = getChildValue(authCodeElement, OAuthConstants.TOKEN_API_URL);
 
         if (clientId == null || clientSecret == null || refreshToken == null || tokenApiUrl == null) {
-            if (log.isDebugEnabled()) {
-                log.error("Invalid AuthorizationCode configuration");
-            }
+            log.error("Invalid AuthorizationCode configuration");
             return null;
         }
         AuthorizationCodeHandler handler = new AuthorizationCodeHandler(tokenApiUrl, clientId, clientSecret,
@@ -173,7 +165,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to get a ClientCredentialsHandler
+     * Method to get a ClientCredentialsHandler.
      *
      * @param clientCredentialsElement Element containing client credentials configs
      * @return ClientCredentialsHandler object
@@ -186,9 +178,7 @@ public class OAuthUtils {
         String tokenApiUrl = getChildValue(clientCredentialsElement, OAuthConstants.TOKEN_API_URL);
 
         if (clientId == null || clientSecret == null || tokenApiUrl == null) {
-            if (log.isDebugEnabled()) {
-                log.error("Invalid ClientCredentials configuration");
-            }
+            log.error("Invalid ClientCredentials configuration");
             return null;
         }
         ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret);
@@ -203,7 +193,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to get a PasswordCredentialsHandler
+     * Method to get a PasswordCredentialsHandler.
      *
      * @param passwordCredentialsElement Element containing password credentials configs
      * @return PasswordCredentialsHandler object
@@ -218,9 +208,7 @@ public class OAuthUtils {
         String tokenApiUrl = getChildValue(passwordCredentialsElement, OAuthConstants.TOKEN_API_URL);
 
         if (username == null || password == null || tokenApiUrl == null || clientId == null || clientSecret == null) {
-            if (log.isDebugEnabled()) {
-                log.error("Invalid PasswordCredentials configuration");
-            }
+            log.error("Invalid PasswordCredentials configuration");
             return null;
         }
         PasswordCredentialsHandler handler = new PasswordCredentialsHandler(tokenApiUrl, clientId, clientSecret,
@@ -236,7 +224,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to return the request parameters as a Map
+     * Method to return the request parameters as a Map.
      *
      * @param oauthElement OAuth config OMElement
      * @return Map<String, String> containing request parameters
@@ -258,9 +246,7 @@ public class OAuthUtils {
             String paramName = parameter.getAttributeValue(new QName(OAuthConstants.NAME));
             String paramValue = parameter.getText().trim();
             if (StringUtils.isBlank(paramName) || StringUtils.isBlank(paramValue)) {
-                if (log.isDebugEnabled()) {
-                    log.error("Invalid Request Parameters in OAuth configuration");
-                }
+                log.error("Invalid Request Parameters in OAuth configuration");
                 return null;
             }
             paramValue = ResolverFactory.getInstance().getResolver(paramValue).resolve();
@@ -270,7 +256,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to check whether there are request parameters are defined in the OAuth config
+     * Method to check whether there are request parameters are defined in the OAuth config.
      *
      * @param oauthElement OAuth config OMElement
      * @return true if there are request parameters in the oauth element
@@ -286,7 +272,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to get the value inside a child element
+     * Method to get the value inside a child element.
      *
      * @param parentElement Parent OMElement
      * @param childName     name of the child
@@ -304,7 +290,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to check whether a non empty value is present inside an OMelement
+     * Method to check whether a non empty value is present inside an OMelement.
      *
      * @param childElement OMElement
      * @return true if there is a non empty value inside the element
@@ -315,7 +301,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to generate a random id for each OAuth handler
+     * Method to generate a random id for each OAuth handler.
      *
      * @return String containing random id
      */
@@ -326,7 +312,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to check whether retry is needed
+     * Method to check whether retry is needed.
      *
      * @param httpEndpoint     OAuth Configured HTTP Endpoint related to the message context
      * @param synapseInMsgCtx  MessageContext that has been received
@@ -362,7 +348,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to check whether parameter value is an expression
+     * Method to check whether parameter value is an expression.
      *
      * @param value String
      * @return true if the value is an expression
@@ -374,7 +360,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to check whether parameter value is a JSON Path
+     * Method to check whether parameter value is a JSON Path.
      *
      * @param value String
      * @return true if the value is a JSON Path
@@ -385,7 +371,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to evaluate the expression
+     * Method to evaluate the expression.
      *
      * @param expressionStr  expression String
      * @param messageContext MessageContext of the request
@@ -408,7 +394,7 @@ public class OAuthUtils {
     }
 
     /**
-     * This method evaluate the value as an expression or return the value
+     * This method evaluate the value as an expression or return the value.
      *
      * @param value          String parameter value
      * @param messageContext MessageContext of the request
@@ -424,7 +410,7 @@ public class OAuthUtils {
     }
 
     /**
-     * Method to append 401 status code to NON_ERROR_HTTP_STATUS_CODES property
+     * Method to append 401 status code to NON_ERROR_HTTP_STATUS_CODES property.
      *
      * @param synCtx MessageContext of the request
      */
@@ -454,5 +440,39 @@ public class OAuthUtils {
             axis2Ctx.setProperty(HTTPConstants.NON_ERROR_HTTP_STATUS_CODES,
                     String.valueOf(OAuthConstants.HTTP_SC_UNAUTHORIZED));
         }
+    }
+
+    /**
+     * This method returns an OMElement containing the elementValue encapsulated by the elementName.
+     *
+     * @param elementName  Name of the OMElement
+     * @param elementValue Value of the OMElement
+     * @return OMElement containing the value encapsulated by the elementName
+     */
+    public static OMElement createOMElementWithValue(OMFactory omFactory, String elementName, String elementValue) {
+
+        OMElement element = omFactory.createOMElement(elementName, SynapseConstants.SYNAPSE_OMNAMESPACE);
+        element.setText(elementValue);
+        return element;
+    }
+
+    /**
+     * Create an OMElement for request parameter map.
+     *
+     * @param requestParametersMap input parameter map.
+     * @return OMElement of parameter map.
+     */
+    public static OMElement createOMRequestParams(OMFactory omFactory, Map<String, String> requestParametersMap) {
+
+        OMElement requestParameters =
+                omFactory.createOMElement(OAuthConstants.REQUEST_PARAMETERS, SynapseConstants.SYNAPSE_OMNAMESPACE);
+        for (Map.Entry<String, String> entry : requestParametersMap.entrySet()) {
+            OMElement parameter =
+                    omFactory.createOMElement(OAuthConstants.REQUEST_PARAMETER, SynapseConstants.SYNAPSE_OMNAMESPACE);
+            parameter.addAttribute(OAuthConstants.NAME, entry.getKey(), null);
+            parameter.setText(entry.getValue());
+            requestParameters.addChild(parameter);
+        }
+        return requestParameters;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.endpoints.oauth;
+
+import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.synapse.MessageContext;
+
+/**
+ * This class is used to handle Password Credentials grant oauth
+ */
+public class PasswordCredentialsHandler extends OAuthHandler {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String username;
+    private final String password;
+
+    protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
+                                         String password) {
+
+        super(tokenApiUrl);
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    protected String buildTokenRequestPayload(MessageContext messageContext) throws OAuthException {
+
+        StringBuilder payload = new StringBuilder();
+
+        payload.append(OAuthConstants.PASSWORD_CRED_GRANT_TYPE);
+        payload.append(OAuthConstants.PARAM_USERNAME).append(OAuthUtils.resolveExpression(username, messageContext));
+        payload.append(OAuthConstants.PARAM_PASSWORD).append(OAuthUtils.resolveExpression(password, messageContext));
+        String requestParams = getRequestParametersAsString(messageContext);
+        payload.append(requestParams);
+
+        return payload.toString();
+    }
+
+    @Override
+    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
+
+        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
+                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
+    }
+
+    public String getClientId() {
+
+        return clientId;
+    }
+
+    public String getClientSecret() {
+
+        return clientSecret;
+    }
+
+    public String getUsername() {
+
+        return username;
+    }
+
+    public String getPassword() {
+
+        return password;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
@@ -18,25 +18,23 @@
 
 package org.apache.synapse.endpoints.oauth;
 
-import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 
 /**
- * This class is used to handle Password Credentials grant oauth
+ * This class is used to handle Password Credentials grant oauth.
  */
 public class PasswordCredentialsHandler extends OAuthHandler {
 
-    private final String clientId;
-    private final String clientSecret;
     private final String username;
     private final String password;
 
     protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
                                          String password) {
 
-        super(tokenApiUrl);
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
+        super(tokenApiUrl, clientId, clientSecret);
         this.username = username;
         this.password = password;
     }
@@ -56,20 +54,17 @@ public class PasswordCredentialsHandler extends OAuthHandler {
     }
 
     @Override
-    protected String getEncodedCredentials(MessageContext messageContext) throws OAuthException {
+    protected OMElement serializeSpecificOAuthConfigs(OMFactory omFactory) {
 
-        return Base64Utils.encode((OAuthUtils.resolveExpression(clientId, messageContext) + ":" +
-                OAuthUtils.resolveExpression(clientSecret, messageContext)).getBytes());
-    }
+        OMElement passwordCredentials = omFactory.createOMElement(
+                OAuthConstants.PASSWORD_CREDENTIALS,
+                SynapseConstants.SYNAPSE_OMNAMESPACE);
 
-    public String getClientId() {
-
-        return clientId;
-    }
-
-    public String getClientSecret() {
-
-        return clientSecret;
+        passwordCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory, OAuthConstants.OAUTH_USERNAME,
+                username));
+        passwordCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory, OAuthConstants.OAUTH_PASSWORD,
+                password));
+        return passwordCredentials;
     }
 
     public String getUsername() {

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
@@ -63,6 +63,8 @@ public class OAuthUtilsTest {
 
     private final static String clientId = "clientId";
     private final static String clientSecret = "clientSecret";
+    private final static String username = "username";
+    private final static String password = "password";
     private final static String refreshToken = "refreshToken";
     private final static String tokenUrl = "tokenUrl";
 
@@ -120,11 +122,34 @@ public class OAuthUtilsTest {
                             "</requestParameters>" +
                             "</clientCredentials></oauth></authentication></http>";
 
+            String passwordCredentialsConfig =
+                    "<http xmlns=\"http://ws.apache.org/ns/synapse\"><authentication><oauth><passwordCredentials>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + clientSecret + ">client_secret</" + clientSecret + ">" +
+                            "<" + username + ">tester123</" + username + ">" +
+                            "<" + password + ">abc@123</" + password + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl +
+                            "></passwordCredentials></oauth></authentication></http>";
+
+            String passwordCredentialsConfigWithRequestParams =
+                    "<http xmlns=\"http://ws.apache.org/ns/synapse\"><authentication><oauth><passwordCredentials>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + clientSecret + ">client_secret</" + clientSecret + ">" +
+                            "<" + username + ">tester123</" + username + ">" +
+                            "<" + password + ">abc@123</" + password + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl + ">" +
+                            "<requestParameters>" +
+                            "   <parameter name=\"account_id\">{$ctx:accountID}</parameter>" +
+                            "</requestParameters>" +
+                            "</passwordCredentials></oauth></authentication></http>";
+
             return Arrays.asList(new Object[][]{
                     {authorizationCodeConfig, AuthorizationCodeHandler.class},
                     {authorizationCodeConfigWithRequestParams, AuthorizationCodeHandler.class},
                     {clientCredentialsConfig, ClientCredentialsHandler.class},
-                    {clientCredentialsConfigWithRequestParams, ClientCredentialsHandler.class}
+                    {clientCredentialsConfigWithRequestParams, ClientCredentialsHandler.class},
+                    {passwordCredentialsConfig, PasswordCredentialsHandler.class},
+                    {passwordCredentialsConfigWithRequestParams, PasswordCredentialsHandler.class}
             });
         }
 
@@ -190,11 +215,48 @@ public class OAuthUtilsTest {
                             "</requestParameters>" +
                             "</clientCredentials></oauth></authentication></http>";
 
+            String passwordCredentialsConfig =
+                    "<http xmlns=\"http://ws.apache.org/ns/synapse\"><authentication><oauth><passwordCredentials>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + password + ">abc@123</" + password + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl +
+                            "></passwordCredentials></oauth></authentication></http>";
+
+            String passwordCredentialsConfigWithInvalidRequestParams =
+                    "<http xmlns=\"http://ws.apache.org/ns/synapse\"><authentication><oauth><passwordCredentials>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + clientSecret + ">client_secret</" + clientSecret + ">" +
+                            "<" + username + ">tester123</" + username + ">" +
+                            "<" + password + ">abc@123</" + password + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl + ">" +
+                            "<requestParameters>" +
+                            "   <parameter>abc@123</parameter>" +
+                            "</requestParameters>" +
+                            "</passwordCredentials></oauth></authentication></http>";
+
+            String multipleOAuthConfig =
+                    "<http xmlns=\"http://ws.apache.org/ns/synapse\"><authentication><oauth><passwordCredentials>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + clientSecret + ">client_secret</" + clientSecret + ">" +
+                            "<" + username + ">tester123</" + username + ">" +
+                            "<" + password + ">abc@123</" + password + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl +
+                            "></passwordCredentials>" +
+                            "<authorizationCode>" +
+                            "<" + clientId + ">client_id</" + clientId + ">" +
+                            "<" + clientSecret + ">client_secret</" + clientSecret + ">" +
+                            "<" + refreshToken + ">refresh_token</" + refreshToken + ">" +
+                            "<" + tokenUrl + ">oauth_server_url</" + tokenUrl + ">" +
+                            "</authorizationCode></oauth></authentication></http>";
+
             return Arrays.asList(new Object[][]{
                     {authorizationCodeConfig},
                     {authorizationCodeConfigWithInvalidRequestParams},
                     {clientCredentialsConfig},
-                    {clientCredentialsConfigWithInvalidRequestParams}
+                    {clientCredentialsConfigWithInvalidRequestParams},
+                    {passwordCredentialsConfig},
+                    {passwordCredentialsConfigWithInvalidRequestParams},
+                    {multipleOAuthConfig}
             });
         }
 

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/endpoint/Sample63.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/endpoint/Sample63.java
@@ -86,4 +86,11 @@ public class Sample63 extends SynapseTestCase {
         HttpResponse response = client.doGet("http://127.0.0.1:8280/foodapi/list/withoutTransportHeaders");
         assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
+
+    public void testOAuthConfiguredEPPasswordGrantType() throws Exception {
+
+        BasicHttpClient client = new BasicHttpClient();
+        HttpResponse response = client.doGet("http://127.0.0.1:8280/foodapi/list/passwordGrant");
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
+    }
 }

--- a/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/Constants.java
+++ b/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/Constants.java
@@ -26,5 +26,7 @@ public class Constants {
     static final String tokenType = "Bearer";
     static final String clientId = "my_client_id";
     static final String clientSecret = "my_client_secret";
-
+    static final String username = "tester123";
+    static final String password = "abc@123";
+    static final String passwordGrant = "password";
 }

--- a/repository/conf/sample/synapse_sample_63.xml
+++ b/repository/conf/sample/synapse_sample_63.xml
@@ -76,6 +76,36 @@
                             </endpoint>
                         </send>
                     </case>
+                    <case regex="passwordGrant">
+                        <property name="clientID" value="my_client_id"/>
+                        <payloadFactory media-type="json">
+                            <format>{"account_id" : "$1"}</format>
+                            <args>
+                                <arg value="1234"/>
+                            </args>
+                        </payloadFactory>
+                        <send>
+                            <endpoint>
+                                <http method="get" uri-template="http://localhost:9000/foodservice/food">
+                                    <authentication>
+                                        <oauth>
+                                            <passwordCredentials>
+                                                <clientId>{$ctx:clientID}</clientId>
+                                                <clientSecret>my_client_secret</clientSecret>
+                                                <username>tester123</username>
+                                                <password>abc@123</password>
+                                                <tokenUrl>http://localhost:9000/foodservice/password-token</tokenUrl>
+                                                <requestParameters>
+                                                    <parameter name="account_id">{json-eval($.account_id)}</parameter>
+                                                    <parameter name="user_role">tester</parameter>
+                                                </requestParameters>
+                                            </passwordCredentials>
+                                        </oauth>
+                                    </authentication>
+                                </http>
+                            </endpoint>
+                        </send>
+                    </case>
                     <case regex="withCustomParams">
                         <property name="clientID" value="my_client_id"/>
                         <payloadFactory media-type="json">


### PR DESCRIPTION
## Purpose

Add Password grant type to OAuth HTTP endpoints.

## User Stories

A sample Password grant type config is shown below,

```xml
<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
    <http method="get" uri-template="http://localhost:9192/service/foodservice">
        <authentication>
            <oauth>
                <passwordCredentials>
                    <clientId>clientId</clientId>
                    <clientSecret>clientSecret</clientSecret>
                    <username>internal-user</username>
                    <password>abc@123</password>
                    <tokenUrl>oauthServerUrl</tokenUrl>
                    <requestParameters>
                        <parameter name="account_id">{json-eval($.account_id)}</parameter>
                        <parameter name="user_role">tester</parameter>
                    </requestParameters>
                </passwordCredentials>
            </oauth>
        </authentication>
    </http>
</endpoint>
```

Fixes https://github.com/wso2/product-ei/issues/5492