### PR TITLE
Add HTTPS support for unit tests of APIs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
     static final String TEST_CASES = "test-cases";
     static final String TEST_CASE_REQUEST_PATH = "request-path";
     static final String TEST_CASE_REQUEST_METHOD = "request-method";
+    static final String TEST_CASE_PROTOCOL_TYPE = "request-protocol";
     static final String TEST_CASE_INPUT = "input";
     static final String TEST_CASE_INPUT_PAYLOAD = "payload";
     static final String TEST_CASE_INPUT_PROPERTIES = "properties";

--- a/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/SynapseTestcaseDataReader.java
@@ -100,6 +100,7 @@ import static org.apache.synapse.unittest.Constants.TEST_CASE_INPUT_PROPERTIES;
 import static org.apache.synapse.unittest.Constants.TEST_CASE_INPUT_PROPERTY_NAME;
 import static org.apache.synapse.unittest.Constants.TEST_CASE_INPUT_PROPERTY_SCOPE;
 import static org.apache.synapse.unittest.Constants.TEST_CASE_INPUT_PROPERTY_VALUE;
+import static org.apache.synapse.unittest.Constants.TEST_CASE_PROTOCOL_TYPE;
 import static org.apache.synapse.unittest.Constants.TEST_CASE_REQUEST_METHOD;
 import static org.apache.synapse.unittest.Constants.TEST_CASE_REQUEST_PATH;
 import static org.apache.synapse.unittest.Constants.TYPE_LOCAL_ENTRY;
@@ -385,6 +386,14 @@ class SynapseTestcaseDataReader {
         if (testCaseRequestMethodNode != null) {
             String requestMethod = testCaseRequestMethodNode.getText();
             testCase.setRequestMethod(requestMethod);
+        }        
+        
+        QName qualifiedInputProtocolType = new QName("", TEST_CASE_PROTOCOL_TYPE, "");
+        OMElement testCaseProtocolTypeNode = testCaseInputNode.getFirstChildWithName(qualifiedInputProtocolType);
+
+        if (testCaseProtocolTypeNode != null) {
+            String protocolType = testCaseProtocolTypeNode.getText();
+            testCase.setProtocolType(protocolType);
         }
 
 

--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
@@ -169,20 +169,28 @@ public class TestCasesMediator {
      * @return response received from the API resource
      */
     static Map.Entry<String, HttpResponse> apiResourceExecutor(TestCase currentTestCase, String context,
-                                                               String resourceMethod) throws IOException {
+                                                               String resourceMethod, String protocolType) throws IOException {
+
+        String urlPrefix = "";
+        if (protocolType.equals(HTTP_KEY)) {
+            urlPrefix = HTTP_LOCALHOST_URL + httpPassThruOperatingPort ;
+        } else if (protocolType.equals(HTTPS_KEY)) {
+            urlPrefix = HTTPS_LOCALHOST_URL + httpsPassThruOperatingPort;
+        } else {
+            return new AbstractMap.SimpleEntry<>("'" + urlPrefix + "' transport is not supported", null);
+        }
+
 
         String url;
         if (currentTestCase.getRequestPath() != null) {
             if (currentTestCase.getRequestPath().startsWith("/")) {
-                url = HTTP_LOCALHOST_URL + httpPassThruOperatingPort
-                        + context + currentTestCase.getRequestPath();
+                url = urlPrefix + context + currentTestCase.getRequestPath();
             } else {
-                url = HTTP_LOCALHOST_URL + httpPassThruOperatingPort
-                        + context + "/" + currentTestCase.getRequestPath();
+                url = urlPrefix + context + "/" + currentTestCase.getRequestPath();
             }
 
         } else {
-            url = HTTP_LOCALHOST_URL + httpPassThruOperatingPort + context;
+            url = urlPrefix + context;
         }
 
 

--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestingAgent.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 
 import static org.apache.synapse.unittest.Constants.API_CONTEXT;
+import static org.apache.synapse.unittest.Constants.HTTP_KEY;
 import static org.apache.synapse.unittest.Constants.TYPE_API;
 import static org.apache.synapse.unittest.Constants.TYPE_ENDPOINT;
 import static org.apache.synapse.unittest.Constants.TYPE_LOCAL_ENTRY;
@@ -307,8 +308,12 @@ class TestingAgent {
                     case TYPE_API:
                         String context = artifactNode.getAttributeValue(new QName(API_CONTEXT));
                         String resourceMethod = currentTestCase.getRequestMethod();
+                        String protocolType = currentTestCase.getProtocolType();
+                        if (protocolType == null || protocolType.isEmpty()) {
+                            protocolType = HTTP_KEY;
+                        }
                         Map.Entry<String, HttpResponse> invokedApiResult = TestCasesMediator.apiResourceExecutor
-                                (currentTestCase, context, resourceMethod);
+                                (currentTestCase, context, resourceMethod, protocolType);
 
                         testSuiteSummary.setMediationStatus(Constants.PASSED_KEY);
                         checkAssertionWithAPIMediation(invokedApiResult, currentTestCase, testSummary);

--- a/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/TestCase.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/testcase/data/classes/TestCase.java
@@ -26,6 +26,7 @@ public class TestCase {
     private String testCaseName;
     private String requestPath;
     private String requestMethod;
+    private String protocolType;
     private String inputPayload;
     private List<Map<String, String>> propertyMap = new ArrayList<>();
     private List<AssertEqual> assertEquals = new ArrayList<>();
@@ -92,6 +93,24 @@ public class TestCase {
      */
     public String getRequestMethod() {
         return requestMethod;
+    }
+
+    /**
+     * Get request protocol type of the test case
+     * @return protocol type of the test case
+     */
+    public String getProtocolType() {
+
+        return protocolType;
+    }
+
+    /**
+     * Set protocol type of the test case
+     * @param protocolType Protocol type to set
+     */
+    public void setProtocolType(String protocolType) {
+
+        this.protocolType = protocolType;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Adding HTTPS support for unit tests of APIs in Integration Studio

Related issues: https://github.com/wso2/maven-tools/issues/90