### PR TITLE
Avoid mixing up tracingScope of different threads

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -334,7 +334,9 @@ public abstract class RuntimeStatisticCollector {
         if (eventHolder.countHolder.decrementAndGetStatCount() <= 0 &&
                 eventHolder.countHolder.getCallBackCount() <= 0 && !continueStatisticFlow(messageContext)) {
             eventHolder.setEvenCollectionFinished(true);
-            messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            if (isMediationFlowStatisticsEnabled) {
+                messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            }
         }
     }
 
@@ -397,7 +399,9 @@ public abstract class RuntimeStatisticCollector {
 
         if (eventHolder.countHolder.decrementAndGetCallbackCount() <= 0 && eventHolder.countHolder.getStatCount() <= 0) {
             eventHolder.setEvenCollectionFinished(true);
-            messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            if (isMediationFlowStatisticsEnabled) {
+                messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            }
         }
     }
 
@@ -445,7 +449,9 @@ public abstract class RuntimeStatisticCollector {
 
             eventHolder.setEvenCollectionFinished(true);
             eventHolder.setMessageFlowError(true);
-            messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            if (isMediationFlowStatisticsEnabled) {
+                messageContext.getEnvironment().getMessageDataStore().enqueue(eventHolder);
+            }
         }
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScope.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScope.java
@@ -57,10 +57,9 @@ public class TracingScope {
      */
     private Integer pendingCallbacksCount;
 
-    public TracingScope(TracingScope parentScope, String tracingScopeId) {
+    public TracingScope(String tracingScopeId) {
         this.tracingScopeId = tracingScopeId;
         this.spanStore = new SpanStore();
-        this.parentScope = parentScope;
         this.pendingCallbacksCount = 0;
     }
 
@@ -73,11 +72,6 @@ public class TracingScope {
      */
     public void addCallback() {
         this.incrementPendingCallbacksCount();
-        TracingScope parent = this.parentScope;
-        while (parent != null) {
-            parent.incrementPendingCallbacksCount();
-            parent = parent.parentScope;
-        }
     }
 
     /**
@@ -85,11 +79,6 @@ public class TracingScope {
      */
     public void removeCallback() {
         this.decrementPendingCallbacksCount();
-        TracingScope parent = this.parentScope;
-        while (parent != null) {
-            parent.decrementPendingCallbacksCount();
-            parent = parent.parentScope;
-        }
     }
 
     private synchronized void incrementPendingCallbacksCount() {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScopeManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScopeManager.java
@@ -52,9 +52,7 @@ public class TracingScopeManager {
                 // Already existing scope. Return its reference
                 return tracingScopes.get(tracingScopeId);
             } else {
-                // Create scope and return its reference
-                TracingScope parent = getLatestTracingScope();
-                TracingScope tracingScope = new TracingScope(parent, tracingScopeId);
+                TracingScope tracingScope = new TracingScope(null, tracingScopeId);
                 tracingScopes.put(tracingScopeId, tracingScope);
                 return tracingScope;
             }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScopeManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/scoping/TracingScopeManager.java
@@ -52,7 +52,7 @@ public class TracingScopeManager {
                 // Already existing scope. Return its reference
                 return tracingScopes.get(tracingScopeId);
             } else {
-                TracingScope tracingScope = new TracingScope(null, tracingScopeId);
+                TracingScope tracingScope = new TracingScope(tracingScopeId);
                 tracingScopes.put(tracingScopeId, tracingScope);
                 return tracingScope;
             }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves https://github.com/wso2/micro-integrator/issues/2403

- We represent a mediation flow within an API, via a TracingScope. When an API is called, when the flow starts, a tracingScope is created and put into the tracingScopes map. When the flow ends, we remove that entry from the map. In the cases of non blocking calls, the callback finish event will remove this entry, if the pendingCallbacksCount is 0 (This is to make sure that the last callback finish event does this removal). (This pendingCallbacksCount is increased when the call is sent).

- Scope Parenting: When we call an API within a Proxy Service, we create two separate tracingScope_s for the Proxy Service, and the API. In this case, the Proxy's _tracingScope is the parentScope of the API's tracingScope. To get the parent scope, we were getting the tracingScope that was added recently to the tracingScopes map.
When pendingCallbacksCount increases for a child tracingScope, callback counts in all its parentScopes are increased (similarly, it's decreased as well).

- When a thread is waiting for a callback finish, its pendingCallbacksCount will be 1. While waiting for the callback finish, if a second thread calls the API, it will create its tracingScope, and resolves the first thread's tracingScope as its parentScope. The second thread's pendingCallbacksCount will be 0. Then when the second thread sends out the callback (the callback finish event has not yet been received in the first thread), second thread's pendingCallbacksCount will be 1. Due to scope parenting, the first thread's pendingCallbacksCount will now become 2. 

- When the first thread's callback finish is received, its pendingCallbacksCount will be decreased, and becomes 1. This will prevent removing the tracingScope from the tracingScopes map, since the pendingCallbacksCount is not 0. In this case, we fail to remove the first thread's tracingScope.

- This has caused an ever-growing number of tracingScope objects in the tracingScopes map.
As a fix, we are returning null in removed resolving the parent scope. This will make sure that thread A's tracingScope will not become thread B's parentScope, as described above. This will avoid a situation which leads to OOM sitatuation.
