### PR TITLE
Fix Payload Factory mediator evaluates String that starts with '{' as JSON

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -167,10 +167,9 @@ public abstract class TemplateProcessor {
             // No conversion required, as path evaluates to regular String.
             replacementValue = replacementEntry.getKey();
             String trimmedReplacementValue = replacementValue.trim();
-            //If media type is xml and replacement value is json convert it to xml format prior to replacement
-            if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE)
-                    && isJson(trimmedReplacementValue)) {
-                replacementValue = convertJsonStringToXml(replacementValue);
+            //If media type is xml and replacement value is literal escape xml special characters prior to replacement
+            if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE)) {
+                replacementValue = escapeSpecialCharactersOfXml(replacementValue);
             } else if (mediaType.equals(JSON_TYPE) &&
                     inferReplacementType(replacementEntry).equals(JSON_TYPE) &&
                     isEscapeXmlChars()) {

--- a/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessorTest.java
@@ -94,7 +94,7 @@ public class TemplateProcessorTest {
                     getArgumentDetails(JSON_PATH, false, true));
             Map.Entry<String, ArgumentDetails> jsonToXmlWithInferReplacementTypeStringAndSpecialChars =
                     Maps.immutableEntry(
-                            "{\"name\":\"hello\\\\nworld\"}",
+                            "{\"name\":\"hello & world\"}",
                             getArgumentDetails(JSON_PATH, false, true));
 
             // InferReplacementTypeStringAndMediaTypeJson
@@ -140,9 +140,9 @@ public class TemplateProcessorTest {
                     {XML_TYPE, jsonToXml, synCtx, "<name>john smith</name><subject /><isStudent>true</isStudent>"},
                     {XML_TYPE, jsonToXmlArray, synCtx, "<jsonElement>55</jsonElement><jsonElement>76</jsonElement>"},
                     {XML_TYPE, jsonToXmlWithSpecialChars, synCtx, "<name>hello\\\nworld</name>"},
-                    {XML_TYPE, jsonToXmlWithInferReplacementTypeString, synCtx, "<name>john smith</name>"},
+                    {XML_TYPE, jsonToXmlWithInferReplacementTypeString, synCtx, "{\"name\":\"john smith\"}"},
                     {XML_TYPE, jsonToXmlWithInferReplacementTypeStringAndSpecialChars, synCtx,
-                            "<name>hello\\\nworld</name>"},
+                            "{\"name\":\"hello & world\"}"},
                     {JSON_TYPE, inferReplacementTypeStringAndMediaTypeJson, synCtx,
                             "{\\\\\"name\\\\\":\\\\\"hello\\\\\\\\nworld\\\\\"}"},
                     {JSON_TYPE, inferReplacementTypeStringAndMediaTypeJson2, synCtx,


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-ei/issues/5510
