### PR TITLE
Introduce authMode parameter to oauth mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/AuthorizationCodeHandler.java
@@ -31,9 +31,9 @@ public class AuthorizationCodeHandler extends OAuthHandler {
     private final String refreshToken;
 
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret,
-                                    String refreshToken) {
+                                    String refreshToken, String authMode) {
 
-        super(tokenApiUrl, clientId, clientSecret);
+        super(tokenApiUrl, clientId, clientSecret, authMode);
         this.refreshToken = refreshToken;
     }
 
@@ -45,10 +45,12 @@ public class AuthorizationCodeHandler extends OAuthHandler {
         payload.append(OAuthConstants.REFRESH_TOKEN_GRANT_TYPE)
                 .append(OAuthConstants.PARAM_REFRESH_TOKEN)
                 .append(OAuthUtils.resolveExpression(refreshToken, messageContext));
-        payload.append(OAuthConstants.PARAM_CLIENT_ID)
-                .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
-        payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
-                .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
+        if ("payload".equalsIgnoreCase(getAuthMode())) {
+            payload.append(OAuthConstants.PARAM_CLIENT_ID)
+                    .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
+            payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
+                    .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
+        }
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/ClientCredentialsHandler.java
@@ -28,9 +28,9 @@ import org.apache.synapse.SynapseConstants;
  */
 public class ClientCredentialsHandler extends OAuthHandler {
 
-    public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret) {
+    public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode) {
 
-        super(tokenApiUrl, clientId, clientSecret);
+        super(tokenApiUrl, clientId, clientSecret, authMode);
     }
 
     @Override
@@ -39,10 +39,12 @@ public class ClientCredentialsHandler extends OAuthHandler {
         StringBuilder payload = new StringBuilder();
 
         payload.append(OAuthConstants.CLIENT_CRED_GRANT_TYPE);
-        payload.append(OAuthConstants.PARAM_CLIENT_ID)
-                .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
-        payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
-                .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
+        if ("payload".equalsIgnoreCase(getAuthMode())) {
+            payload.append(OAuthConstants.PARAM_CLIENT_ID)
+                    .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
+            payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
+                    .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
+        }
         payload.append(getRequestParametersAsString(messageContext));
 
         return payload.toString();

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthClient.java
@@ -68,7 +68,9 @@ public class OAuthClient {
 
         HttpPost httpPost = new HttpPost(tokenApiUrl);
         httpPost.setHeader(OAuthConstants.CONTENT_TYPE_HEADER, OAuthConstants.APPLICATION_X_WWW_FORM_URLENCODED);
-        httpPost.setHeader(OAuthConstants.AUTHORIZATION_HEADER, OAuthConstants.BASIC + credentials);
+        if (credentials != null) {
+            httpPost.setHeader(OAuthConstants.AUTHORIZATION_HEADER, OAuthConstants.BASIC + credentials);
+        }
         httpPost.setEntity(new StringEntity(payload));
 
         try (CloseableHttpResponse response = httpClient.execute(httpPost)) {

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthConstants.java
@@ -31,6 +31,7 @@ public class OAuthConstants {
     public static final String TOKEN_API_URL = "tokenUrl";
     public static final String OAUTH_CLIENT_ID = "clientId";
     public static final String OAUTH_CLIENT_SECRET = "clientSecret";
+    public static final String OAUTH_AUTHENTICATION_MODE = "authMode";
     public static final String OAUTH_USERNAME = "username";
     public static final String OAUTH_PASSWORD = "password";
     public static final String OAUTH_REFRESH_TOKEN = "refreshToken";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/OAuthUtils.java
@@ -147,13 +147,14 @@ public class OAuthUtils {
         String clientSecret = getChildValue(authCodeElement, OAuthConstants.OAUTH_CLIENT_SECRET);
         String refreshToken = getChildValue(authCodeElement, OAuthConstants.OAUTH_REFRESH_TOKEN);
         String tokenApiUrl = getChildValue(authCodeElement, OAuthConstants.TOKEN_API_URL);
+        String authMode = getChildValue(authCodeElement, OAuthConstants.OAUTH_AUTHENTICATION_MODE);
 
         if (clientId == null || clientSecret == null || refreshToken == null || tokenApiUrl == null) {
             log.error("Invalid AuthorizationCode configuration");
             return null;
         }
         AuthorizationCodeHandler handler = new AuthorizationCodeHandler(tokenApiUrl, clientId, clientSecret,
-                refreshToken);
+                refreshToken, authMode);
         if (hasRequestParameters(authCodeElement)) {
             Map<String, String> requestParameters = getRequestParameters(authCodeElement);
             if (requestParameters == null) {
@@ -176,12 +177,13 @@ public class OAuthUtils {
         String clientId = getChildValue(clientCredentialsElement, OAuthConstants.OAUTH_CLIENT_ID);
         String clientSecret = getChildValue(clientCredentialsElement, OAuthConstants.OAUTH_CLIENT_SECRET);
         String tokenApiUrl = getChildValue(clientCredentialsElement, OAuthConstants.TOKEN_API_URL);
+        String authMode = getChildValue(clientCredentialsElement, OAuthConstants.OAUTH_AUTHENTICATION_MODE);
 
         if (clientId == null || clientSecret == null || tokenApiUrl == null) {
             log.error("Invalid ClientCredentials configuration");
             return null;
         }
-        ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret);
+        ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret, authMode);
         if (hasRequestParameters(clientCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(clientCredentialsElement);
             if (requestParameters == null) {
@@ -206,13 +208,14 @@ public class OAuthUtils {
         String username = getChildValue(passwordCredentialsElement, OAuthConstants.OAUTH_USERNAME);
         String password = getChildValue(passwordCredentialsElement, OAuthConstants.OAUTH_PASSWORD);
         String tokenApiUrl = getChildValue(passwordCredentialsElement, OAuthConstants.TOKEN_API_URL);
+        String authMode = getChildValue(passwordCredentialsElement, OAuthConstants.OAUTH_AUTHENTICATION_MODE);
 
         if (username == null || password == null || tokenApiUrl == null || clientId == null || clientSecret == null) {
             log.error("Invalid PasswordCredentials configuration");
             return null;
         }
         PasswordCredentialsHandler handler = new PasswordCredentialsHandler(tokenApiUrl, clientId, clientSecret,
-                username, password);
+                username, password, authMode);
         if (hasRequestParameters(passwordCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(passwordCredentialsElement);
             if (requestParameters == null) {

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/oauth/PasswordCredentialsHandler.java
@@ -32,9 +32,9 @@ public class PasswordCredentialsHandler extends OAuthHandler {
     private final String password;
 
     protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
-                                         String password) {
+                                         String password, String authMode) {
 
-        super(tokenApiUrl, clientId, clientSecret);
+        super(tokenApiUrl, clientId, clientSecret, authMode);
         this.username = username;
         this.password = password;
     }
@@ -47,6 +47,12 @@ public class PasswordCredentialsHandler extends OAuthHandler {
         payload.append(OAuthConstants.PASSWORD_CRED_GRANT_TYPE);
         payload.append(OAuthConstants.PARAM_USERNAME).append(OAuthUtils.resolveExpression(username, messageContext));
         payload.append(OAuthConstants.PARAM_PASSWORD).append(OAuthUtils.resolveExpression(password, messageContext));
+        if ("payload".equalsIgnoreCase(getAuthMode())) {
+            payload.append(OAuthConstants.PARAM_CLIENT_ID)
+                    .append(OAuthUtils.resolveExpression(getClientId(), messageContext));
+            payload.append(OAuthConstants.PARAM_CLIENT_SECRET)
+                    .append(OAuthUtils.resolveExpression(getClientSecret(), messageContext));
+        }
         String requestParams = getRequestParametersAsString(messageContext);
         payload.append(requestParams);
 

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/oauth/OAuthUtilsTest.java
@@ -300,7 +300,7 @@ public class OAuthUtilsTest {
 
             OAuthHandler oAuthHandler =
                     new AuthorizationCodeHandler("oauth_server_url", "client_id", "client_secret",
-                            "refresh_token");
+                            "refresh_token", "header");
 
             OAuthConfiguredHTTPEndpoint httpEndpoint = new OAuthConfiguredHTTPEndpoint(oAuthHandler);
 


### PR DESCRIPTION

## Purpose
This is to fix https://github.com/wso2/product-ei/issues/5512

```
<authentication>
<oauth>
<clientCredentials>
<clientId>8ghGvzmw3itBfNSkicxs2aWQzzoa</clientId>
<clientSecret>XXXXXXXXXXXXXXx</clientSecret>
<tokenUrl>https://localhost:9444/oauth2/token</tokenUrl>
<authMode>payload</authMode>
</clientCredentials>
</oauth>
</authentication>
```