### PR TITLE
Set the new JSON Stream to the next mediator placed after aggregate mediator, Fix issue in Enrich Mediator target action 

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/EnrichMediatorFactory.java
@@ -331,7 +331,7 @@ public class EnrichMediatorFactory extends AbstractMediatorFactory {
     private void validateTypeCombination(OMElement sourceElement, OMElement targetElement) {
         int sourceType = -1;
         int targetType = -1;
-        int targetAction = -1;
+        int targetAction = 0;
 
         // source type attribute
         OMAttribute sourceTypeAttr = sourceElement.getAttribute(ATT_TYPE);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
@@ -499,6 +499,15 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
                 try {
                     aggregate.getLastMessage().setEnvelope(
                             MessageHelper.cloneSOAPEnvelope(newSynCtx.getEnvelope()));
+                    // Setting the new JSON stream to the next mediator
+                    if (aggregationExpression instanceof SynapseJsonPath) {
+                        org.apache.axis2.context.MessageContext msgCtx = ((Axis2MessageContext) aggregate.getLastMessage())
+                                .getAxis2MessageContext();
+                        org.apache.axis2.context.MessageContext newAxisMsgCtx = ((Axis2MessageContext) newSynCtx)
+                                .getAxis2MessageContext();
+                        msgCtx.setProperty(Constants.ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM,
+                                newAxisMsgCtx.getProperty(Constants.ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM));
+                    }
                 } catch (AxisFault axisFault) {
                     log.warn("Error occurred while assigning aggregated message" +
                              " back to the last received message context");


### PR DESCRIPTION
## Purpose
This PR sets the new JSON Stream to the next mediator placed after the aggregate mediator (after completing the aggregation).
Fixes wso2/product-ei#5523

Also, when target type is set to 'key' in Enrich mediator, this sets the action 'replace' (default) if no action is specified.
Fixes wso2/micro-integrator#2479
