### PR TITLE
fix PassThrough MBeans are not populated with thread pool data

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -47,6 +47,8 @@ import org.apache.axis2.engine.AxisObserver;
 import org.apache.axis2.transport.TransportListener;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.BaseUtils;
+import org.apache.axis2.transport.base.ManagementSupport;
+import org.apache.axis2.transport.base.TransportMBeanSupport;
 import org.apache.axis2.transport.base.threads.NativeThreadFactory;
 import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.axis2.transport.base.tracker.AxisServiceFilter;
@@ -172,11 +174,6 @@ public class PassThroughHttpListener implements TransportListener {
         PassThroughTransportMetricsCollector metrics = new PassThroughTransportMetricsCollector(
                 true, scheme.getName());
 
-        TransportView view = new TransportView(this, null, metrics, null);
-        MBeanRegistrar.getInstance().registerMBean(
-                view, "Transport",
-                "passthru-" + namePrefix.toLowerCase() + "-receiver");
-
         sourceConfiguration = new SourceConfiguration(cfgCtx, transportInDescription, scheme, workerPool, metrics);
         sourceConfiguration.build();
 
@@ -234,6 +231,10 @@ public class PassThroughHttpListener implements TransportListener {
                     }
                 });
 
+        TransportView view = new TransportView(this, null, metrics, sourceConfiguration.getWorkerPool());
+        MBeanRegistrar.getInstance().registerMBean(
+                view, "Transport",
+                "passthru-" + namePrefix.toLowerCase() + "-receiver");
     }
 
     public void start() throws AxisFault {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -148,9 +148,6 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
 
         PassThroughTransportMetricsCollector metrics = new PassThroughTransportMetricsCollector(
             false, scheme.getName());
-        TransportView view = new TransportView(null, this, metrics, null);
-        MBeanRegistrar.getInstance().registerMBean(view, "Transport",
-                 "passthru-" + namePrefix.toLowerCase() + "-sender");
         
         proxyConfig = new ProxyConfigBuilder().build(transportOutDescription);
         if (log.isDebugEnabled()) {
@@ -202,6 +199,10 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
 
         targetConnections = new TargetConnections(ioReactor, targetConfiguration, connectCallback);
         targetConfiguration.setConnections(targetConnections);
+
+        TransportView view = new TransportView(null, this, metrics, targetConfiguration.getWorkerPool());
+        MBeanRegistrar.getInstance().registerMBean(view, "Transport",
+                "passthru-" + namePrefix.toLowerCase() + "-sender");
 
         // create the delivery agent to hand over messages
         deliveryAgent = new DeliveryAgent(targetConfiguration, targetConnections, proxyConfig);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/TransportView.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/jmx/TransportView.java
@@ -20,6 +20,7 @@
 package org.apache.synapse.transport.passthru.jmx;
 
 import org.apache.axis2.AxisFault;
+import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.synapse.transport.passthru.PassThroughHttpListener;
 import org.apache.synapse.transport.passthru.PassThroughHttpSender;
 
@@ -34,12 +35,12 @@ public class TransportView implements TransportViewMBean {
 
     private PassThroughTransportMetricsCollector metrics = null;
 
-    private ThreadPoolExecutor threadPool = null;
+    private WorkerPool threadPool = null;
 
     public TransportView(PassThroughHttpListener listener,
                          PassThroughHttpSender sender,
                          PassThroughTransportMetricsCollector metrics,
-                         ThreadPoolExecutor threadPool) throws AxisFault {
+                         WorkerPool threadPool) throws AxisFault {
         this.listener = listener;
         this.metrics = metrics;
         this.threadPool = threadPool;
@@ -78,8 +79,8 @@ public class TransportView implements TransportViewMBean {
     }
 
     public int getQueueSize() {
-        if (threadPool != null && threadPool.getQueue() != null) {
-            return threadPool.getQueue().size();
+        if (threadPool != null) {
+            return threadPool.getQueueSize();
         }
         return 0;
     }


### PR DESCRIPTION
## Purpose
JMX PassThrough MBeans are not populated with workerpool data.

## Goals
fix the issue

## Approach
fix the bug by replacing the the last parameter of TransportView instantation from null to workerpool

## User stories
NA

## Release note
fix JMX PassThroughMBeans not populated with workerpool data.

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA
## Migrations (if applicable)
NA

## Test environment
APIM 4.0.0
 
## Learning
NA