### PR TITLE
Fix java.lang.IllegalArgumentException when $ is present

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -170,6 +170,7 @@ public abstract class TemplateProcessor {
             //If media type is xml and replacement value is literal escape xml special characters prior to replacement
             if (mediaType.equals(XML_TYPE) && inferReplacementType(replacementEntry).equals(STRING_TYPE)) {
                 replacementValue = escapeSpecialCharactersOfXml(replacementValue);
+                replacementValue = Matcher.quoteReplacement(replacementValue);
             } else if (mediaType.equals(JSON_TYPE) &&
                     inferReplacementType(replacementEntry).equals(JSON_TYPE) &&
                     isEscapeXmlChars()) {


### PR DESCRIPTION


## Purpose

Fixes: https://github.com/wso2/micro-integrator/issues/2543

## Approach
Fix java.lang.IllegalArgumentException when $ is present by
escaping \" and \$ with Matcher.quoteReplacement()

