### PR TITLE
Fix Content-Type wrongly set when using SWA

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetRequest.java
@@ -188,11 +188,11 @@ public class TargetRequest {
 		if (o != null && o instanceof TreeMap) {
 			Map _headers = (Map) o;
 			String trpContentType = (String) _headers.get(HTTP.CONTENT_TYPE);
-			if (trpContentType != null && !trpContentType.equals("")) {
-				if (!TargetRequestFactory.isMultipartContent(trpContentType)) {
-					addHeader(HTTP.CONTENT_TYPE, trpContentType);
-				}
-			}
+            if (trpContentType != null && !trpContentType.equals("")) {
+                if (!TargetRequestFactory.isMultipartContent(trpContentType) && !requestMsgCtx.isDoingSwA()) {
+                    addHeader(HTTP.CONTENT_TYPE, trpContentType);
+                }
+            }
 
 		}
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
@@ -114,6 +114,9 @@ public class TargetRequestFactory {
 			String cType = getContentType(msgContext, configuration.isPreserveHttpHeader(HTTP.CONTENT_TYPE));
 			if (cType != null && !httpMethod.equals(HTTPConstants.HTTP_METHOD_GET)
 					&& RelayUtils.shouldOverwriteContentType(msgContext, request)) {
+                if (msgContext.isDoingSwA()) {
+                    cType = HTTPConstants.MEDIA_TYPE_MULTIPART_RELATED;
+                }
 				String messageType = (String) msgContext.getProperty(NhttpConstants.MESSAGE_TYPE);
 				if (messageType != null) {
 					boolean builderInvoked = false;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/TargetRequestFactory.java
@@ -114,7 +114,7 @@ public class TargetRequestFactory {
 			String cType = getContentType(msgContext, configuration.isPreserveHttpHeader(HTTP.CONTENT_TYPE));
 			if (cType != null && !httpMethod.equals(HTTPConstants.HTTP_METHOD_GET)
 					&& RelayUtils.shouldOverwriteContentType(msgContext, request)) {
-                if (msgContext.isDoingSwA()) {
+                if (!TargetRequestFactory.isMultipartContent(cType) && msgContext.isDoingSwA()) {
                     cType = HTTPConstants.MEDIA_TYPE_MULTIPART_RELATED;
                 }
 				String messageType = (String) msgContext.getProperty(NhttpConstants.MESSAGE_TYPE);


### PR DESCRIPTION
For the SWA, content-type is set to text/xml but this need to be
multipart/related. Fix this by changing targetRequestFactory

Fixes: wso2/product-apim#12104