### PR TITLE
Update the URL pattern regex to correctly mask the SMB2 passwords

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -577,7 +577,7 @@ public final class SynapseConstants {
     public enum ENDPOINT_TIMEOUT_TYPE { ENDPOINT_TIMEOUT, GLOBAL_TIMEOUT, HTTP_CONNECTION_TIMEOUT};
 
     // URL pattern
-    public static final Pattern URL_PATTERN = Pattern.compile("[a-z]+://.*");
+    public static final Pattern URL_PATTERN = Pattern.compile("[a-zA-Z0-9]+://.*");
 
     // Password pattern
     public static final Pattern PASSWORD_PATTERN = Pattern.compile(":(?:[^/]+)@");

--- a/modules/core/src/main/java/org/apache/synapse/util/MessageHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/MessageHelper.java
@@ -904,7 +904,7 @@ public class MessageHelper {
         String maskUrl;
         if (urlMatcher.find()) {
             final Matcher pwdMatcher = PASSWORD_PATTERN.matcher(url);
-            maskUrl = pwdMatcher.replaceFirst("\":***@\"");
+            maskUrl = pwdMatcher.replaceFirst(":***@");
             return maskUrl;
         }
         return url;


### PR DESCRIPTION
## Purpose
Since the existing URL pattern regex does not capture the numeric characters, it fails to match the smb2 URL that has a numeric character in it. This PR updates the URL pattern regex used in the EndpointContext.

Fixes wso2/product-ei#5535