### PR TITLE
Remove template mediator destroy logic

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
@@ -349,9 +349,6 @@ public class InvokeMediator extends AbstractMediator implements
     public void destroy() {
         TemplateMediator templateMediator =
                 synapseEnv.getSynapseConfiguration().getSequenceTemplate(targetTemplate);
-        if (templateMediator != null) {
-            templateMediator.destroy();
-        }
         if (templateMediator == null || templateMediator.isDynamic()) {
             synapseEnv.removeUnavailableArtifactRef(targetTemplate);
         }


### PR DESCRIPTION
## Purpose
> Remove template mediator destroy logic since the memory is getting GC'ed eventually.
Fixes wso2/micro-integrator/issues/2632