### PR TITLE
Fix template building issue due to #ftl directive

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -32,6 +32,7 @@ import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
@@ -121,11 +122,16 @@ public class PayloadFactoryMediator extends AbstractMediator {
         StringBuilder result = new StringBuilder();
         transform(result, synCtx, format);
         String out = result.toString().trim();
+        String updatedFormat = templateProcessor.getFormat();
         if (log.isDebugEnabled()) {
             log.debug("#mediate. Transformed payload format>>> " + out);
         }
         if (mediaType.equals(XML_TYPE)) {
             try {
+                if (templateType.equals(FREEMARKER_TEMPLATE_TYPE)
+                        && StringUtils.isNotEmpty(updatedFormat) && updatedFormat.startsWith("<#ftl")) {
+                    out = "<pfPadding>" + out + "</pfPadding>";
+                }
                 JsonUtil.removeJsonPayload(axis2MessageContext);
                 OMElement omXML = convertStringToOM(out);
                 if (!checkAndReplaceEnvelope(omXML, synCtx)) { // check if the target of the PF 'format' is the entire SOAP envelop, not just the body.

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -32,6 +32,7 @@ import freemarker.template.TemplateExceptionHandler;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMText;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.text.StringEscapeUtils;
@@ -148,7 +149,8 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private void compileFreeMarkerTemplate(String templateString, String mediaType) {
 
         try {
-            if (XML_TYPE.equals(mediaType)) {
+            if (XML_TYPE.equals(mediaType) &&
+                    StringUtils.isNotEmpty(templateString) && !templateString.startsWith("<#ftl")) {
                 templateString = "<pfPadding>" + templateString + "</pfPadding>";
             }
 


### PR DESCRIPTION
I

## Purpose
If FTL  directive, if present, must be the very first thing in the template

https://freemarker.apache.org/docs/ref_directive_ftl.html#ref.directive.ftl
So avoid using <pfPadding> tag prior to conversion and use it in the
end of conversion to avoid missing elements due to getFirstElement stratergy.

Fixes: https://github.com/wso2/micro-integrator/issues/2655