### PR TITLE
Fix template building issue due to #ftl directive

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -32,6 +32,7 @@ import freemarker.template.TemplateExceptionHandler;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMText;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.text.StringEscapeUtils;
@@ -145,7 +146,8 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private void compileFreeMarkerTemplate(String templateString, String mediaType) {
 
         try {
-            if (XML_TYPE.equals(mediaType)) {
+            if (XML_TYPE.equals(mediaType) &&
+                    StringUtils.isNotEmpty(templateString) && !templateString.startsWith("<#ftl")) {
                 templateString = "<pfPadding>" + templateString + "</pfPadding>";
             }
 


### PR DESCRIPTION


## Purpose
If FTL  directive, if present, must be the very first thing in the template

https://freemarker.apache.org/docs/ref_directive_ftl.html#ref.directive.ftl

## Goals
Fixes: https://github.com/wso2/micro-integrator/issues/2655

## Approach
So avoid using <pfPadding> tag prior to conversion and use it in the
end of conversion to avoid missing elements due to getFirstElement stratergy.


