### PR TITLE
Fix PassThroughMessageProcessor thread hanging issue

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -652,6 +652,10 @@ public class Pipe {
                         writeCondition.signalAll();
                         buffer.clear();
                         return;
+                    } else if (isProducerError()) {
+                        writeCondition.signalAll();
+                        buffer.clear();
+                        return;
                     }
                 } else if (consumerIoControl instanceof NHttpClientConnection) {
                     if (((NHttpClientConnection) consumerIoControl).isStale()) {


### PR DESCRIPTION
## Purpose
This PR fixes an issue where PassThroughMessageProcessor thread hanging after a producer error occurs.

Related issue: https://github.com/wso2/product-apim/issues/12654