### PR TITLE
Add ENABLE_REST to allowedProperties wso2/micro-integrator#2520

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSenderUtils.java
@@ -337,6 +337,7 @@ public class BlockingMsgSenderUtils {
                                                  "setCharacterEncoding",
                                                  NhttpConstants.DISTRIBUTED_TRANSACTION,
                                                  NhttpConstants.DISTRIBUTED_TRANSACTION_MANAGER,
+                                                 Constants.Configuration.ENABLE_REST,
                                                  Constants.Configuration.HTTP_METHOD,
                                                  Constants.Configuration.MESSAGE_TYPE,
                                                  Constants.Configuration.CONTENT_TYPE,


### PR DESCRIPTION
## Purpose
> `enableREST` is not listed as an allowed property in axis2 message context. This leads to the issue wso2/micro-integrator#2520, in which when call mediator is used in blocking mode with a scheduled task, the endpoint will be marked as failed if the response's type is `text/xml` instead of `application/xml` even if the `enableREST` property is set.

## Approach
> List `enableREST` as an allowed property under axis2 message context.

## Release note
> Fixed an issue where `enableREST` property is ignored in the axis2 message context which led to suspending HTTP endpoints if they respond with the content type `text/xml` instead of `application/xml`

## Documentation
> TBA

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage