### PR TITLE
Fix for appending forward slash to endpoint URL when running unit tests

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/TestCasesMediator.java
@@ -187,7 +187,9 @@ public class TestCasesMediator {
 
         String url;
         if (currentTestCase.getRequestPath() != null) {
-            if (currentTestCase.getRequestPath().startsWith("/")) {
+            if (currentTestCase.getRequestPath().equals("/")) {
+                url = urlPrefix + context;
+            } else if (currentTestCase.getRequestPath().startsWith("/")) {
                 url = urlPrefix + context + currentTestCase.getRequestPath();
             } else {
                 url = urlPrefix + context + "/" + currentTestCase.getRequestPath();


### PR DESCRIPTION
Fixes https://github.com/wso2/integration-studio/issues/1106