### PR TITLE
Upgrading the jaeger-client to v1.8.0

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/handling/span/JaegerSpanHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/opentracing/management/handling/span/JaegerSpanHandler.java
@@ -23,8 +23,7 @@ import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapExtractAdapter;
-import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.propagation.TextMapAdapter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.ContinuationState;
@@ -155,7 +154,7 @@ public class JaegerSpanHandler implements OpenTracingSpanHandler {
         // We only need to extract span context from headers when there are trp headers available
         if (isOuterLevelSpan(statisticDataUnit, spanStore) && headersMap != null) {
             // Extract span context from headers
-            spanContext = tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(headersMap));
+            spanContext = tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(headersMap));
             span = tracer.buildSpan(statisticDataUnit.getComponentName()).asChildOf(spanContext).start();
         } else {
             span = tracer.buildSpan(statisticDataUnit.getComponentName()).asChildOf(parentSpan).start();
@@ -164,7 +163,7 @@ public class JaegerSpanHandler implements OpenTracingSpanHandler {
         //Fix null pointer issue occurs when spanContext become null
         if (spanContext != null) {
             // Set tracing headers
-            tracer.inject(spanContext, Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(tracerSpecificCarrier));
+            tracer.inject(spanContext, Format.Builtin.HTTP_HEADERS, new TextMapAdapter(tracerSpecificCarrier));
             synCtx.setProperty(SynapseConstants.JAEGER_TRACE_ID, ((JaegerSpanContext) spanContext).getTraceId());
             synCtx.setProperty(SynapseConstants.JAEGER_SPAN_ID, Long.toHexString(((JaegerSpanContext) spanContext).getSpanId()));
             if (logger.isDebugEnabled()) {

--- a/pom.xml
+++ b/pom.xml
@@ -1547,7 +1547,7 @@
        <transport.http.netty.version>6.3.35</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <jaeger-client.version>0.32.0.wso2v4</jaeger-client.version>
+       <jaeger-client.version>1.8.0.wso2v1</jaeger-client.version>
        <zipkin-client.version>2.23.1</zipkin-client.version>
        <zipkin-reporter.version>2.16.2</zipkin-reporter.version>
        <zipkin-urlconnection.version>2.16.2</zipkin-urlconnection.version>


### PR DESCRIPTION
## Purpose
Upgrading the jaeger client version to 1.8.0 which contains libthrift 0.16.0.

## Goals
Upgrading libthrift version to 0.16.0.

## Approach
- After bumping the jaeger client version, there were some interface changes related to TextMapAdapter. Those changes had to be properly modified in the code.
- Updated the pom with the correct versions.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.3 LTS