### PR TITLE
Bump quartz, rhino, Jackson and Gson

### DIFF
--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -296,8 +296,8 @@
   	        <artifactId>commons-vfs2</artifactId>
   	    </dependency>
         <dependency>
-            <groupId>rhino.wso2</groupId>
-            <artifactId>js</artifactId>
+            <groupId>org.wso2.orbit.org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.axis2</groupId>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>synapse-samples</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler.wso2</groupId>
+            <groupId>org.wso2.orbit.org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
         </dependency>
         <dependency>
@@ -141,7 +141,7 @@
                                 <bundleDef>org.apache.synapse:synapse-extensions</bundleDef>
                                 <bundleDef>org.apache.synapse:synapse-tasks</bundleDef>
                                 <bundleDef>net.sf.saxon.wso2:saxon</bundleDef>
-                                <bundleDef>org.quartz-scheduler.wso2:quartz</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.quartz-scheduler:quartz</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${com.google.code.gson.version}</bundleDef>
                                 <bundleDef>org.wso2.caching:wso2caching-core</bundleDef>
                                 <bundleDef>com.damnhandy.wso2:handy-uri-templates</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1420,7 +1420,7 @@
       <maven.artifact.version>2.0.8</maven.artifact.version>
       <maven.archiver.version>2.2</maven.archiver.version>
       <plexus.utils.version>1.5.4</plexus.utils.version>
-      <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
+      <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
       <org.codehaus.jettison.wso2.version>1.1.wso2v1</org.codehaus.jettison.wso2.version>
       <com.damnhandy.version>2.1.6</com.damnhandy.version>
       <damnhandy.version>${com.damnhandy.version}.wso2v2</damnhandy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -348,8 +348,8 @@
              <scope>test</scope>
          </dependency>
          <dependency>
-             <groupId>rhino.wso2</groupId>
-             <artifactId>js</artifactId>
+             <groupId>org.wso2.orbit.org.mozilla</groupId>
+             <artifactId>rhino</artifactId>
              <version>${js.version}</version>
          </dependency>
          <dependency>
@@ -1477,7 +1477,7 @@
       <xmlsec.version>1.4.2</xmlsec.version>
       <xalan.version>2.7.2</xalan.version>
       <xerces.version>2.8.1</xerces.version>
-      <js.version>1.7.0.R4.wso2v1</js.version>
+      <js.version>1.7.14.wso2v1</js.version>
       <!-- startup, quartz -->
       <commons-collections.version>3.2.1</commons-collections.version>
       <quartz.version>2.3.2</quartz.version>
@@ -1534,7 +1534,7 @@
       <powermock.version>1.7.1</powermock.version>
       <dataprovider.version>1.13.1</dataprovider.version>
       <activemq.version>5.2.0</activemq.version>
-      <rhino.version>1.7R4</rhino.version>
+      <rhino.version>1.7.14</rhino.version>
       <jetty.version>7.2.0.v20101020</jetty.version>
        <xml.apis.version>1.4.01</xml.apis.version>
       <!-- The Java version used to execute maven-antrun-plugin in the integration module.

--- a/pom.xml
+++ b/pom.xml
@@ -1524,7 +1524,7 @@
       <javax.servlet.version>3.0.1</javax.servlet.version>
       <powermock.version>1.7.1</powermock.version>
       <fge.json.schema.validator.version>2.2.6.wso2v8</fge.json.schema.validator.version>
-      <fasterxml.jackson.version>2.13.1</fasterxml.jackson.version>
+      <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
       <google.guava.version>31.0.1-jre</google.guava.version>
       <failureaccess.version>1.0.1</failureaccess.version>
       <joda-time.version>2.9.4.wso2v1</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
              <version>${quartz.version}</version>
          </dependency>
          <dependency>
-             <groupId>org.quartz-scheduler.wso2</groupId>
+             <groupId>org.wso2.orbit.org.quartz-scheduler</groupId>
              <artifactId>quartz</artifactId>
              <version>${quartz.wso2.version}</version>
          </dependency>
@@ -1480,7 +1480,7 @@
       <js.version>1.7.0.R4.wso2v1</js.version>
       <!-- startup, quartz -->
       <commons-collections.version>3.2.1</commons-collections.version>
-      <quartz.version>2.1.1</quartz.version>
+      <quartz.version>2.3.2</quartz.version>
       <quartz.wso2.version>${quartz.version}.wso2v1</quartz.wso2.version>
       <geronimo-spec.version>1.1</geronimo-spec.version>
       <!-- xalan xsltc  -->


### PR DESCRIPTION
## Purpose
Upgrade the following dependencies,
- quartz to v2.3.2
- rhino to v1.7.14
- jackson to v2.13.3
- gson to v2.9.0