### PR TITLE
Add eviction policies for statistic collection queue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
@@ -208,4 +208,13 @@ public class StatisticsConstants {
 
     public static final String CONTINUE_STATISTICS_FLOW = "CONTINUE_STATISTICS_FLOW";
 
+	public static final long MAX_STATISTIC_REPORTING_QUEUE_SIZE = 10000;
+
+	public static final String STATISTIC_REPORTING_QUEUE_EVICTION_POLICY = "statistics.queue.eviction.policy";
+
+	public static final String STATISTIC_REPORTING_QUEUE_SIZE = "statistics.queue.eviction.size";
+
+	public static final String QUEUE_EVICTION_POLICY_OLD_MESSAGES = "old-messages-first";
+
+	public static final String QUEUE_EVICTION_POLICY_NEW_MESSAGES = "new-messages-first";
 }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -103,7 +103,7 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     private SynapseDebugManager synapseDebugManager;
 
     /** The MessageDataStore object*/
-    private MessageDataStore messageDataStore = new MessageDataStore();
+    private MessageDataStore messageDataStore;
 
     private ServerContextInformation contextInformation;
 
@@ -151,6 +151,7 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     public static final String JSON_TYPE = "application/json";
 
     public Axis2SynapseEnvironment(SynapseConfiguration synCfg) {
+        messageDataStore = new MessageDataStore(synCfg);
 
         int coreThreads = SynapseThreadPool.SYNAPSE_CORE_THREADS;
         int maxThreads  = SynapseThreadPool.SYNAPSE_MAX_THREADS;


### PR DESCRIPTION
Currently, Synapse keeps on collecting statistics and storing them in a queue. If the queue is blocked due to some reason, then the queue is keep on getting increasing and might cause OOM. This fix adds a max limit to the queue and drop messages based on two policies.
- `old-messages-first`: If this policy is selected, older statistic data would be lost and new data will be enqueued.
- `new-messages-first`: If this policy is selected, then new statistic messages would be dropeed

You can specify policies in the synapse.properties file with `statistics.queue.eviction.policy` key. Value can be either of the above.
You can also specify the maximum queue size with the `statistics.queue.eviction.size` property in the synapse.properties file.
Fix https://github.com/wso2/product-ei/issues/5567