### PR TITLE
Add runtime configurable correlation log support to passthru

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -55,6 +55,7 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.commons.util.ext.TenantInfoInitiator;
 import org.apache.synapse.commons.util.ext.TenantInfoInitiatorProvider;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.apache.synapse.transport.util.PassThroughMessageHandler;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.transport.http.conn.SynapseDebugInfoHolder;
@@ -146,7 +147,7 @@ public class ServerWorker implements Runnable {
             ThreadContext.remove(CorrelationConstants.CORRELATION_MDC_PROPERTY);
             /* Subsequent to removing the correlation id MDC thread local value, a new value is put in case
                there is one */
-            if (sourceConfiguration.isCorrelationLoggingEnabled() && StringUtils.isNotEmpty(correlationId)) {
+            if ( PassThroughCorrelationConfigDataHolder.isEnable() && StringUtils.isNotEmpty(correlationId)) {
                 ThreadContext.put(CorrelationConstants.CORRELATION_MDC_PROPERTY, correlationId);
                 /* Log the time taken to switch from the previous thread to this thread */
                 if (initiationTimestamp != 0) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -147,7 +147,7 @@ public class ServerWorker implements Runnable {
             ThreadContext.remove(CorrelationConstants.CORRELATION_MDC_PROPERTY);
             /* Subsequent to removing the correlation id MDC thread local value, a new value is put in case
                there is one */
-            if ( PassThroughCorrelationConfigDataHolder.isEnable() && StringUtils.isNotEmpty(correlationId)) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable() && StringUtils.isNotEmpty(correlationId)) {
                 ThreadContext.put(CorrelationConstants.CORRELATION_MDC_PROPERTY, correlationId);
                 /* Log the time taken to switch from the previous thread to this thread */
                 if (initiationTimestamp != 0) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
@@ -171,6 +171,10 @@ public class SourceContext {
             }
             if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 long lastStateUpdateTime = sourceContext.getLastStateUpdatedTime();
+                if (PassThroughCorrelationConfigDataHolder.isToggled()) {
+                    lastStateUpdateTime = sourceContext.updateLastStateUpdatedTime();
+                    PassThroughCorrelationConfigDataHolder.resetToggled();
+                }
                 String url = "", method = "";
                 if (sourceContext.getRequest() != null) {
                     url = sourceContext.getRequest().getUri();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpRequest;
 import org.apache.http.nio.NHttpConnection;
 import org.apache.synapse.commons.logger.ContextAwareLogger;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 
@@ -156,7 +157,7 @@ public class SourceContext {
         conn.getContext().setAttribute(CONNECTION_INFORMATION, sourceContext);
         sourceContext.setState(state);
 
-        if (sourceContext.getSourceConfiguration().isCorrelationLoggingEnabled()) {
+        if (PassThroughCorrelationConfigDataHolder.isEnable()) {
             sourceContext.updateLastStateUpdatedTime();
         }
     }
@@ -168,7 +169,7 @@ public class SourceContext {
             if(sourceContext.getState() == state) {
                 return;
             }
-            if (sourceContext.getSourceConfiguration().isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 long lastStateUpdateTime = sourceContext.getLastStateUpdatedTime();
                 String url = "", method = "";
                 if (sourceContext.getRequest() != null) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceContext.java
@@ -171,6 +171,7 @@ public class SourceContext {
             }
             if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 long lastStateUpdateTime = sourceContext.getLastStateUpdatedTime();
+                // If the Correlation Logs are toggled (off -> on) during runtime, we need to reset the last state updated time.
                 if (PassThroughCorrelationConfigDataHolder.isToggled()) {
                     lastStateUpdateTime = sourceContext.updateLastStateUpdatedTime();
                     PassThroughCorrelationConfigDataHolder.resetToggled();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -50,6 +50,7 @@ import org.apache.synapse.transport.http.conn.LoggingNHttpClientConnection;
 import org.apache.synapse.transport.http.conn.LoggingNHttpServerConnection;
 import org.apache.synapse.transport.http.conn.Scheme;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
 import org.apache.synapse.transport.passthru.connections.TargetConnections;
 import org.apache.synapse.transport.passthru.jmx.LatencyCollector;
@@ -155,7 +156,7 @@ public class SourceHandler implements NHttpServerEventHandler {
         try {
             HttpContext httpContext = conn.getContext();
             setCorrelationId(conn);
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 SourceContext sourceContext = (SourceContext)
                         conn.getContext().getAttribute(TargetContext.CONNECTION_INFORMATION);
                 sourceContext.updateLastStateUpdatedTime();
@@ -404,7 +405,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                 if (!response.hasEntity()) {
                    // Update stats as outputReady will not be triggered for no entity responses
                     HttpContext context = conn.getContext();
-                    if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+                    if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                         logCorrelationRoundTrip(context,request);
                     }
                     updateMetricsView(context);
@@ -508,7 +509,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                 context.setAttribute(PassThroughConstants.RES_TO_CLIENT_WRITE_END_TIME,departure);
                 context.setAttribute(PassThroughConstants.RES_DEPARTURE_TIME,departure);
 
-                if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+                if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                     logCorrelationRoundTrip(context, request);
                 }
                 updateMetricsView(context);
@@ -588,7 +589,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                     .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn
                     + " Correlation ID : " + conn.getContext().getAttribute(
                             CorrelationConstants.CORRELATION_ID).toString());
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }
         } else if (state == ProtocolState.RESPONSE_BODY || state == ProtocolState.RESPONSE_HEAD) {
@@ -603,7 +604,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                     .getSocketTimeout() + ", CLIENT_ADDRESS = " + getClientConnectionInfo(conn) + ", CONNECTION " + conn
                     +  " Correlation ID : " + conn.getContext().getAttribute(
                     CorrelationConstants.CORRELATION_ID).toString());
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }
         } else if (state == ProtocolState.REQUEST_DONE) {
@@ -619,7 +620,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                             + ", SOCKET_TIMEOUT = " + conn.getSocketTimeout() + ", CLIENT_ADDRESS = "
                             + getClientConnectionInfo(conn) + ", CONNECTION " + conn + " Correlation ID : "
                             + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID).toString());
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "TIMEOUT in " + state.name());
             }
         }
@@ -651,7 +652,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                     .get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method") + ", CLIENT_ADDRESS = "
                     + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
 
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "Connection Closed in " + state.name());
             }
         } else if (state == ProtocolState.RESPONSE_BODY || state == ProtocolState.RESPONSE_HEAD) {
@@ -662,7 +663,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                     + "CAUSE_OF_ERROR = Connection between EI and the Client has been closed, HTTP_URL = " + logDetails
                     .get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method") + ", CLIENT_ADDRESS = "
                     + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "Connection Closed in " + state.name());
             }
         } else if (state == ProtocolState.REQUEST_DONE) {
@@ -673,7 +674,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                     + "CAUSE_OF_ERROR = Connection between EI and the Client has been closed, HTTP_URL = " + logDetails
                     .get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method") + ", CLIENT_ADDRESS = "
                     + getClientConnectionInfo(conn) + ", CONNECTION " + conn);
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "Connection Closed in " + state.name());
             }
         }
@@ -710,7 +711,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                 }
             }
             logIOException(conn, (IOException) ex);
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "IO Exception");
             }
             metrics.incrementFaultsReceiving();
@@ -732,7 +733,7 @@ public class SourceHandler implements NHttpServerEventHandler {
             sourceConfiguration.getSourceConnections().shutDownConnection(conn, true);
         } else if (ex instanceof HttpException) {
             log.error("HttpException occurred ", ex);
-            if (sourceConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "HTTP Exception");
             }
             try {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetContext.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.nio.NHttpConnection;
 import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.commons.logger.ContextAwareLogger;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 
@@ -144,7 +145,7 @@ public class TargetContext {
         TargetContext targetContext = new TargetContext(configuration);
         conn.getContext().setAttribute(CONNECTION_INFORMATION, targetContext);
         targetContext.setState(state);
-        if (targetContext.getTargetConfiguration().isCorrelationLoggingEnabled()) {
+        if (PassThroughCorrelationConfigDataHolder.isEnable()) {
             targetContext.updateLastStateUpdatedTime();
         }
     }
@@ -158,7 +159,7 @@ public class TargetContext {
                 return;
             }
             targetContext.setState(state);
-            if (targetContext.getTargetConfiguration().isCorrelationLoggingEnabled() && isCorrelationIdAvailable(conn)) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable() && isCorrelationIdAvailable(conn)) {
                 long lastStateUpdateTime = targetContext.getLastStateUpdatedTime();
                 String url = "", method = "";
                 if (targetContext.getRequest() != null) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -46,6 +46,7 @@ import org.apache.synapse.transport.http.conn.LoggingNHttpClientConnection;
 import org.apache.synapse.transport.http.conn.ProxyTunnelHandler;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
 import org.apache.synapse.transport.passthru.connections.HostConnections;
 import org.apache.synapse.transport.passthru.jmx.PassThroughTransportMetricsCollector;
@@ -387,7 +388,7 @@ public class TargetHandler implements NHttpClientEventHandler {
             context.setAttribute(PassThroughConstants.RES_HEADER_ARRIVAL_TIME, System.currentTimeMillis());
             connState = TargetContext.getState(conn);
             //check correlation logs enabled
-            if (targetConfiguration.isCorrelationLoggingEnabled()
+            if (PassThroughCorrelationConfigDataHolder.isEnable()
                     && TargetContext.isCorrelationIdAvailable(conn)) {
                 long startTime = (long) context.getAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME);
                 ContextAwareLogger.getLogger(context, correlationLog, false)
@@ -848,7 +849,7 @@ public class TargetHandler implements NHttpClientEventHandler {
                         + "CONNECTION = " + conn + ", SOCKET_TIMEOUT = " + conn.getSocketTimeout() + ", CORRELATION_ID"
                         + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID));
 
-                if (targetConfiguration.isCorrelationLoggingEnabled()) {
+                if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                     logHttpRequestErrorInCorrelationLog(conn, "Timeout in " + state);
                 }
                 if (requestMsgCtx != null) {
@@ -993,7 +994,7 @@ public class TargetHandler implements NHttpClientEventHandler {
         if (ex instanceof IOException) {
 
             logIOException(conn, (IOException) ex);
-            if (targetConfiguration.isCorrelationLoggingEnabled()){
+            if (PassThroughCorrelationConfigDataHolder.isEnable()){
                 logHttpRequestErrorInCorrelationLog(conn, "IO Exception in " + state.name());
             }
             if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
@@ -1010,7 +1011,7 @@ public class TargetHandler implements NHttpClientEventHandler {
         } else if (ex instanceof HttpException) {
             String message = getErrorMessage("HTTP protocol violation : " + ex.getMessage(), conn);
             log.error(message, ex);
-            if (targetConfiguration.isCorrelationLoggingEnabled()){
+            if (PassThroughCorrelationConfigDataHolder.isEnable()){
                 logHttpRequestErrorInCorrelationLog(conn, "HTTP Exception in " + state.name());
             }
             if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
@@ -1030,7 +1031,7 @@ public class TargetHandler implements NHttpClientEventHandler {
             } else {
                 log.error("Unexpected error.");
             }
-            if (targetConfiguration.isCorrelationLoggingEnabled()) {
+            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
                 logHttpRequestErrorInCorrelationLog(conn, "Unexpected error");
             }
             TargetContext.updateState(conn, ProtocolState.CLOSED);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -105,7 +105,7 @@ public abstract class BaseConfiguration {
         httpParams = buildHttpParams();
         ioReactorConfig = buildIOReactorConfig();
         String sysCorrelationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
-        if (sysCorrelationStatus != null) {
+        if (sysCorrelationStatus != null && !PassThroughCorrelationConfigDataHolder.isEnable()) {
             PassThroughCorrelationConfigDataHolder.setEnable(Boolean.parseBoolean(sysCorrelationStatus));
         }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -73,8 +73,6 @@ public abstract class BaseConfiguration {
 
     protected PassThroughConfiguration conf = PassThroughConfiguration.getInstance();
 
-    private Boolean correlationLoggingEnabled = false;
-
     private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
     private static final String PASSTHROUGH_THREAD_ID ="PassThroughMessageProcessor";
 
@@ -108,7 +106,7 @@ public abstract class BaseConfiguration {
         ioReactorConfig = buildIOReactorConfig();
         String sysCorrelationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
         if (sysCorrelationStatus != null) {
-            correlationLoggingEnabled = sysCorrelationStatus.equalsIgnoreCase("true");
+            PassThroughCorrelationConfigDataHolder.setEnable(Boolean.parseBoolean(sysCorrelationStatus));
         }
 
         bufferFactory = new BufferFactory(iOBufferSize, new HeapByteBufferAllocator(), 512);
@@ -193,7 +191,7 @@ public abstract class BaseConfiguration {
         return metrics;
     }
 
-    public Boolean isCorrelationLoggingEnabled() { return correlationLoggingEnabled; }
+    public Boolean isCorrelationLoggingEnabled() { return PassThroughCorrelationConfigDataHolder.isEnable(); }
 
     private Integer getSocketTimeout() {
         if (socketTimeout != null) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -106,7 +106,7 @@ public abstract class BaseConfiguration {
         ioReactorConfig = buildIOReactorConfig();
         String sysCorrelationStatus = System.getProperty(PassThroughConstants.CORRELATION_LOGS_SYS_PROPERTY);
         if (sysCorrelationStatus != null && !PassThroughCorrelationConfigDataHolder.isEnable()) {
-            PassThroughCorrelationConfigDataHolder.setEnable(Boolean.parseBoolean(sysCorrelationStatus));
+            PassThroughCorrelationConfigDataHolder.setSystemEnable(Boolean.parseBoolean(sysCorrelationStatus));
         }
 
         bufferFactory = new BufferFactory(iOBufferSize, new HeapByteBufferAllocator(), 512);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2009, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.synapse.transport.passthru.config;
+
+public class PassThroughCorrelationConfigDataHolder {
+    private static boolean enable;
+
+    private PassThroughCorrelationConfigDataHolder() {
+    }
+
+    public static boolean isEnable() {
+        return enable;
+    }
+
+    public static void setEnable(boolean enable) {
+        PassThroughCorrelationConfigDataHolder.enable = enable;
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
@@ -17,13 +17,14 @@ package org.apache.synapse.transport.passthru.config;
 
 public class PassThroughCorrelationConfigDataHolder {
     private static boolean enable;
+    private static boolean systemEnable;
     private static boolean toggled;
 
     private PassThroughCorrelationConfigDataHolder() {
     }
 
     public static boolean isEnable() {
-        return enable;
+        return (enable || systemEnable);
     }
 
     public static boolean isToggled() {
@@ -39,5 +40,13 @@ public class PassThroughCorrelationConfigDataHolder {
             toggled = true;
         }
         PassThroughCorrelationConfigDataHolder.enable = enable;
+    }
+
+    public static boolean isSystemEnable() {
+        return systemEnable;
+    }
+
+    public static void setSystemEnable(boolean systemEnable) {
+        PassThroughCorrelationConfigDataHolder.systemEnable = systemEnable;
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2009, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
@@ -17,6 +17,7 @@ package org.apache.synapse.transport.passthru.config;
 
 public class PassThroughCorrelationConfigDataHolder {
     private static boolean enable;
+    private static boolean toggled;
 
     private PassThroughCorrelationConfigDataHolder() {
     }
@@ -25,7 +26,18 @@ public class PassThroughCorrelationConfigDataHolder {
         return enable;
     }
 
+    public static boolean isToggled() {
+        return toggled;
+    }
+
+    public static void resetToggled(){
+        toggled = false;
+    }
+
     public static void setEnable(boolean enable) {
+        if(PassThroughCorrelationConfigDataHolder.enable != enable){
+            toggled = true;
+        }
         PassThroughCorrelationConfigDataHolder.enable = enable;
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughCorrelationConfigDataHolder.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Purpose
> Fix: wso2/api-manager#191
> Fix: wso2/api-manager#262


## Approach
> Replaced the correlation logging enabled flag with a dataholder to
support enable/disable correlation logs without a server restart.
Dataholder value can be directly accessed to check whether correlation
logs are enabled/disabled.
