### PR TITLE
Using tomcat dbcp2 instead of commons dbcp

### DIFF
--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -142,8 +142,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.osgi</groupId>

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -142,8 +142,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-dbcp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.osgi</groupId>

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DataSourceConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DataSourceConstants.java
@@ -124,7 +124,7 @@ public class DataSourceConstants {
     public static final String PROP_CLASS_NAME = "className";
 
     public static final String PROP_CPDS_ADAPTER_DRIVER
-            = "org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS";
+            = "org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS";
 
     public static final String PROP_FACTORY = "factory";
 

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DataSourceConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/DataSourceConstants.java
@@ -124,7 +124,7 @@ public class DataSourceConstants {
     public static final String PROP_CLASS_NAME = "className";
 
     public static final String PROP_CPDS_ADAPTER_DRIVER
-            = "org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS";
+            = "org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS";
 
     public static final String PROP_FACTORY = "factory";
 

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/JNDIBasedDataSourceRepository.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/JNDIBasedDataSourceRepository.java
@@ -132,7 +132,7 @@ public class JNDIBasedDataSourceRepository implements DataSourceRepository {
         if (DataSourceInformation.BASIC_DATA_SOURCE.equals(dsType)) {
 
             Reference ref = new Reference("javax.sql.DataSource",
-                    "org.apache.commons.dbcp2.BasicDataSourceFactory", null);
+                    "org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory", null);
 
             ref.add(new StringRefAddr(DataSourceConstants.PROP_DRIVER_CLS_NAME,
                     driver));
@@ -196,10 +196,8 @@ public class JNDIBasedDataSourceRepository implements DataSourceRepository {
             }
 
             // Construct PerUserPoolDataSource reference
-            Reference ref =
-                    new Reference("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource",
-                            "org.apache.commons.dbcp2.datasources.PerUserPoolDataSourceFactory",
-                            null);
+            Reference ref = new Reference("org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource",
+                    "org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSourceFactory", null);
 
             ref.add(new BinaryRefAddr(
                     DataSourceConstants.PROP_JNDI_ENV,

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/JNDIBasedDataSourceRepository.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/JNDIBasedDataSourceRepository.java
@@ -132,7 +132,7 @@ public class JNDIBasedDataSourceRepository implements DataSourceRepository {
         if (DataSourceInformation.BASIC_DATA_SOURCE.equals(dsType)) {
 
             Reference ref = new Reference("javax.sql.DataSource",
-                    "org.apache.commons.dbcp.BasicDataSourceFactory", null);
+                    "org.apache.commons.dbcp2.BasicDataSourceFactory", null);
 
             ref.add(new StringRefAddr(DataSourceConstants.PROP_DRIVER_CLS_NAME,
                     driver));
@@ -197,8 +197,8 @@ public class JNDIBasedDataSourceRepository implements DataSourceRepository {
 
             // Construct PerUserPoolDataSource reference
             Reference ref =
-                    new Reference("org.apache.commons.dbcp.datasources.PerUserPoolDataSource",
-                            "org.apache.commons.dbcp.datasources.PerUserPoolDataSourceFactory",
+                    new Reference("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource",
+                            "org.apache.commons.dbcp2.datasources.PerUserPoolDataSourceFactory",
                             null);
 
             ref.add(new BinaryRefAddr(

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/factory/DataSourceFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/factory/DataSourceFactory.java
@@ -18,14 +18,15 @@
  */
 package org.apache.synapse.commons.datasource.factory;
 
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS;
-import org.apache.commons.dbcp.datasources.PerUserPoolDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
+import org.apache.commons.dbcp2.datasources.PerUserPoolDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.SynapseCommonsException;
 import org.apache.synapse.commons.datasource.DataSourceInformation;
 
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
@@ -93,9 +94,9 @@ public class DataSourceFactory {
                 basicDataSource.setPassword(password);
             }
 
-            basicDataSource.setMaxActive(dataSourceInformation.getMaxActive());
+            basicDataSource.setMaxTotal(dataSourceInformation.getMaxActive() + dataSourceInformation.getMaxIdle());
             basicDataSource.setMaxIdle(dataSourceInformation.getMaxIdle());
-            basicDataSource.setMaxWait(dataSourceInformation.getMaxWait());
+            basicDataSource.setMaxWaitMillis(dataSourceInformation.getMaxWait());
             basicDataSource.setMinIdle(dataSourceInformation.getMinIdle());
             basicDataSource.setDefaultAutoCommit(dataSourceInformation.isDefaultAutoCommit());
             basicDataSource.setDefaultReadOnly(dataSourceInformation.isDefaultReadOnly());
@@ -161,19 +162,20 @@ public class DataSourceFactory {
             PerUserPoolDataSource perUserPoolDataSource = new PerUserPoolDataSource();
             perUserPoolDataSource.setConnectionPoolDataSource(adapterCPDS);
 
-            perUserPoolDataSource.setDefaultMaxActive(dataSourceInformation.getMaxActive());
+            perUserPoolDataSource
+                    .setDefaultMaxTotal(dataSourceInformation.getMaxActive() + dataSourceInformation.getMaxIdle());
             perUserPoolDataSource.setDefaultMaxIdle(dataSourceInformation.getMaxIdle());
-            perUserPoolDataSource.setDefaultMaxWait((int) dataSourceInformation.getMaxWait());
+            perUserPoolDataSource.setDefaultMaxWait(Duration.ofMillis((int) dataSourceInformation.getMaxWait()));
             perUserPoolDataSource.setDefaultAutoCommit(dataSourceInformation.isDefaultAutoCommit());
             perUserPoolDataSource.setDefaultReadOnly(dataSourceInformation.isDefaultReadOnly());
-            perUserPoolDataSource.setTestOnBorrow(dataSourceInformation.isTestOnBorrow());
-            perUserPoolDataSource.setTestOnReturn(dataSourceInformation.isTestOnReturn());
-            perUserPoolDataSource.setTestWhileIdle(dataSourceInformation.isTestWhileIdle());
-            perUserPoolDataSource.setMinEvictableIdleTimeMillis(
+            perUserPoolDataSource.setDefaultTestOnBorrow(dataSourceInformation.isTestOnBorrow());
+            perUserPoolDataSource.setDefaultTestOnReturn(dataSourceInformation.isTestOnReturn());
+            perUserPoolDataSource.setDefaultTestWhileIdle(dataSourceInformation.isTestWhileIdle());
+            perUserPoolDataSource.setDefaultMinEvictableIdleTimeMillis(
                     (int) dataSourceInformation.getMinEvictableIdleTimeMillis());
-            perUserPoolDataSource.setTimeBetweenEvictionRunsMillis(
+            perUserPoolDataSource.setDefaultTimeBetweenEvictionRunsMillis(
                     (int) dataSourceInformation.getTimeBetweenEvictionRunsMillis());
-            perUserPoolDataSource.setNumTestsPerEvictionRun(
+            perUserPoolDataSource.setDefaultNumTestsPerEvictionRun(
                     dataSourceInformation.getNumTestsPerEvictionRun());
 
             if (defaultTransactionIsolation != -1) {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/datasource/factory/DataSourceFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/datasource/factory/DataSourceFactory.java
@@ -18,9 +18,9 @@
  */
 package org.apache.synapse.commons.datasource.factory;
 
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
-import org.apache.commons.dbcp2.datasources.PerUserPoolDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS;
+import org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.SynapseCommonsException;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
@@ -21,8 +21,8 @@ package org.apache.synapse.mediators.db;
 
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.dbcp.datasources.PerUserPoolDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp2.datasources.PerUserPoolDataSource;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/db/AbstractDBMediator.java
@@ -21,8 +21,8 @@ package org.apache.synapse.mediators.db;
 
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.dbcp2.datasources.PerUserPoolDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2 .datasources.PerUserPoolDataSource;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -100,8 +100,8 @@
             <artifactId>asm</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp.wso2</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-pool.wso2</groupId>
@@ -160,7 +160,7 @@
                                 <bundleDef>javax.annotation:javax.annotation-api</bundleDef>
                             </bundles>
                             <importBundles>
-                                <importBundleDef>commons-dbcp.wso2:commons-dbcp</importBundleDef>
+                                <importBundleDef>org.wso2.orbit.org.apache.commons:commons-dbcp2</importBundleDef>
                                 <importBundleDef>commons-pool.wso2:commons-pool</importBundleDef>
                                 <importBundleDef>org.antlr.wso2:antlr-runtime</importBundleDef>
                             </importBundles>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -100,8 +100,8 @@
             <artifactId>asm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
+            <groupId>org.wso2.orbit.org.apache.tomcat</groupId>
+            <artifactId>tomcat</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-pool.wso2</groupId>
@@ -160,7 +160,7 @@
                                 <bundleDef>javax.annotation:javax.annotation-api</bundleDef>
                             </bundles>
                             <importBundles>
-                                <importBundleDef>org.wso2.orbit.org.apache.commons:commons-dbcp2</importBundleDef>
+                                <importBundleDef>org.wso2.orbit.org.apache.tomcat:tomcat</importBundleDef>
                                 <importBundleDef>commons-pool.wso2:commons-pool</importBundleDef>
                                 <importBundleDef>org.antlr.wso2:antlr-runtime</importBundleDef>
                             </importBundles>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -415,8 +415,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -415,8 +415,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-dbcp</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -50,8 +50,8 @@
             <artifactId>synapse-commons</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-dbcp2</artifactId>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-dbcp</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -50,8 +50,8 @@
             <artifactId>synapse-commons</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>commons-dbcp</groupId>
-                    <artifactId>commons-dbcp</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-dbcp2</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -999,13 +999,13 @@
             <version>${sandesha2.version}</version>
          </dependency>
          <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <version>${commons.dbcp.version}</version>
          </dependency>
          <dependency>
-            <groupId>commons-dbcp.wso2</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <version>${commons.dbcp.wso2.version}</version>
          </dependency>
          <dependency>
@@ -1445,8 +1445,8 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!-- Synapse and related components -->
       <synapse.version>${project.version}</synapse.version>
-      <commons.dbcp.version>1.2.2</commons.dbcp.version>
-      <commons.dbcp.wso2.version>1.4.0.wso2v1</commons.dbcp.wso2.version>
+      <commons.dbcp.version>2.9.0</commons.dbcp.version>
+      <commons.dbcp.wso2.version>2.9.0.wso2v1</commons.dbcp.wso2.version>
       <commons.pool.version>1.3</commons.pool.version>
       <commons.pool.wso2.version>1.5.0.wso2v1</commons.pool.wso2.version>
       <commons.vfs.version>2.2.0-wso2v13</commons.vfs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -998,16 +998,16 @@
             <artifactId>sandesha2-core</artifactId>
             <version>${sandesha2.version}</version>
          </dependency>
-         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <version>${commons.dbcp.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.wso2.orbit.org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <version>${commons.dbcp.wso2.version}</version>
-         </dependency>
+          <dependency>
+              <groupId>org.apache.tomcat</groupId>
+              <artifactId>tomcat-dbcp</artifactId>
+              <version>${version.tomcat}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.wso2.orbit.org.apache.tomcat</groupId>
+              <artifactId>tomcat</artifactId>
+              <version>${orbit.version.tomcat}</version>
+          </dependency>
          <dependency>
             <groupId>commons-pool</groupId>
             <artifactId>commons-pool</artifactId>
@@ -1445,8 +1445,8 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!-- Synapse and related components -->
       <synapse.version>${project.version}</synapse.version>
-      <commons.dbcp.version>2.9.0</commons.dbcp.version>
-      <commons.dbcp.wso2.version>2.9.0.wso2v1</commons.dbcp.wso2.version>
+       <version.tomcat>9.0.58</version.tomcat>
+       <orbit.version.tomcat>${version.tomcat}.wso2v1</orbit.version.tomcat>
       <commons.pool.version>1.3</commons.pool.version>
       <commons.pool.wso2.version>1.5.0.wso2v1</commons.pool.wso2.version>
       <commons.vfs.version>2.2.0-wso2v13</commons.vfs.version>

--- a/src/site/xdoc/1_2/Synapse_Samples_Setup.xml
+++ b/src/site/xdoc/1_2/Synapse_Samples_Setup.xml
@@ -785,8 +785,8 @@ synapse.datasources.lookupds.maxIdle=20
 synapse.datasources.lookupds.maxWait=10000
 
 synapse.datasources.reportds.type=PerUserPoolDataSource
-synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS
-synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
 synapse.datasources.reportds.cpdsadapter.name=cpds
 synapse.datasources.reportds.dsName=reportdb
 synapse.datasources.reportds.driverClassName=org.apache.derby.jdbc.ClientDriver

--- a/src/site/xdoc/1_2/Synapse_Samples_Setup.xml
+++ b/src/site/xdoc/1_2/Synapse_Samples_Setup.xml
@@ -785,8 +785,8 @@ synapse.datasources.lookupds.maxIdle=20
 synapse.datasources.lookupds.maxWait=10000
 
 synapse.datasources.reportds.type=PerUserPoolDataSource
-synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
-synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.factory=org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.className=org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS
 synapse.datasources.reportds.cpdsadapter.name=cpds
 synapse.datasources.reportds.dsName=reportdb
 synapse.datasources.reportds.driverClassName=org.apache.derby.jdbc.ClientDriver

--- a/src/site/xdoc/Synapse_Samples_Setup.xml
+++ b/src/site/xdoc/Synapse_Samples_Setup.xml
@@ -1071,8 +1071,8 @@ synapse.datasources.lookupds.maxIdle=20
 synapse.datasources.lookupds.maxWait=10000
 
 synapse.datasources.reportds.type=PerUserPoolDataSource
-synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS
-synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
 synapse.datasources.reportds.cpdsadapter.name=cpds
 synapse.datasources.reportds.dsName=reportdb
 synapse.datasources.reportds.driverClassName=org.apache.derby.jdbc.ClientDriver

--- a/src/site/xdoc/Synapse_Samples_Setup.xml
+++ b/src/site/xdoc/Synapse_Samples_Setup.xml
@@ -1071,8 +1071,8 @@ synapse.datasources.lookupds.maxIdle=20
 synapse.datasources.lookupds.maxWait=10000
 
 synapse.datasources.reportds.type=PerUserPoolDataSource
-synapse.datasources.reportds.cpdsadapter.factory=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
-synapse.datasources.reportds.cpdsadapter.className=org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.factory=org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS
+synapse.datasources.reportds.cpdsadapter.className=org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS
 synapse.datasources.reportds.cpdsadapter.name=cpds
 synapse.datasources.reportds.dsName=reportdb
 synapse.datasources.reportds.driverClassName=org.apache.derby.jdbc.ClientDriver


### PR DESCRIPTION
## Purpose
commons-dbcp is an old release [1], whereas the new releases are being maintained by tomcat [2]. Hence, upgrading to the tomcat dbcp2 because tomcat jar is already getting packed in the products. After this fix, in the future when upgrading the tomcat, dbcp will also get upgraded.

## Goals
Upgrading the commons-dbcp to tomcat-dbcp2

## Approach
- Changed the package names where necessary
- Changed the functions appropriately

[1] https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2
[2] https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-dbcp