### PR TITLE
Remove msgCtx in resolver after the XSLT mediation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/XSLTMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/XSLTMediator.java
@@ -463,8 +463,9 @@ public class XSLTMediator extends AbstractMediator {
         // Set an error listener (SYNAPSE-307).
         transFact.setErrorListener(new ErrorListenerImpl(synLog, STYLESHEET_PARSING_ACTIVITY));
         // Allow xsl:import and xsl:include resolution
-        transFact.setURIResolver(new CustomJAXPURIResolver(resourceMap, synCtx.getConfiguration(), synCtx));
-
+        CustomJAXPURIResolver customJAXPURIResolver = new CustomJAXPURIResolver(resourceMap, synCtx.getConfiguration());
+        transFact.setURIResolver(customJAXPURIResolver);
+        if (resourceMap != null) customJAXPURIResolver.setMessageContext(synCtx);
         try {
             cachedTemplates = transFact.newTemplates(
                     SynapseConfigUtils.getStreamSource(synCtx.getEntry(generatedXsltKey)));
@@ -480,6 +481,8 @@ public class XSLTMediator extends AbstractMediator {
         } catch (Exception e) {
             handleException("Error creating XSLT transformer using : " + xsltKey, e, synCtx);
         }
+        // Release the message context variable
+        customJAXPURIResolver.setMessageContext(null);
         return cachedTemplates;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/util/resolver/CustomJAXPURIResolver.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/resolver/CustomJAXPURIResolver.java
@@ -35,7 +35,7 @@ import org.xml.sax.InputSource;
 public class CustomJAXPURIResolver implements URIResolver {
     private final ResourceMap resourceMap;
     private final SynapseConfiguration synCfg;
-    private final MessageContext messageContext;
+    private MessageContext messageContext;
 
     /**
      * Constructor.
@@ -43,10 +43,9 @@ public class CustomJAXPURIResolver implements URIResolver {
      * @param resourceMap the resource map; may be null if no resource map is configured
      * @param synCfg the Synapse configuration
      */
-    public CustomJAXPURIResolver(ResourceMap resourceMap, SynapseConfiguration synCfg, MessageContext messageContext) {
+    public CustomJAXPURIResolver(ResourceMap resourceMap, SynapseConfiguration synCfg) {
         this.resourceMap = resourceMap;
         this.synCfg = synCfg;
-        this.messageContext = messageContext;
     }
 
     /**
@@ -69,5 +68,9 @@ public class CustomJAXPURIResolver implements URIResolver {
             result = new StreamSource(SynapseConfigUtils.resolveRelativeURI(base, href));
         }
         return result;
+    }
+
+    public void setMessageContext(MessageContext messageContext) {
+        this.messageContext = messageContext;
     }
 }


### PR DESCRIPTION
## Purpose
> Remove msgCtx in resolver after the XSLT mediation so it will get GCed.
Fixes wso2/api-manager/issues/210