### PR TITLE
Handle NPE when healthz EP is invoked before server startup

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/MultiListenerServerIODispatch.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/MultiListenerServerIODispatch.java
@@ -50,18 +50,17 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
         if (handler == null) {
-            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            log.error("The request to the port " + localPort + " cannot be processed further as the Listener has not started yet on port " + localPort);
             try {
                 defaultNHttpServerConnection.shutdown();
-            } catch (IOException ex) {
-                log.error("Error shutting down the connection", ex);
+            } catch (IOException ignored) {
             }
-        } else {
-            try {
-                handler.connected(defaultNHttpServerConnection);
-            } catch (final Exception ex) {
-                handler.exception(defaultNHttpServerConnection, ex);
-            }
+            return;
+        }
+        try {
+            handler.connected(defaultNHttpServerConnection);
+        } catch (final Exception ex) {
+            handler.exception(defaultNHttpServerConnection, ex);
         }
     }
 
@@ -70,18 +69,17 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
         if (handler == null) {
-            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            log.error("The request to the port " + localPort + " cannot be processed further as the Listener has not started yet on port " + localPort);
             try {
                 defaultNHttpServerConnection.shutdown();
-            } catch (IOException ex) {
-                log.error("Error shutting down the connection", ex);
+            } catch (IOException ignored) {
             }
-        } else {
-            try {
-                handler.closed(defaultNHttpServerConnection);
-            } catch (final Exception ex) {
-                handler.exception(defaultNHttpServerConnection, ex);
-            }
+            return;
+        }
+        try {
+            handler.closed(defaultNHttpServerConnection);
+        } catch (final Exception ex) {
+            handler.exception(defaultNHttpServerConnection, ex);
         }
     }
 
@@ -90,18 +88,17 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
         if (handler == null) {
-            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            log.error("The request to the port " + localPort + " cannot be processed further as the Listener has not started yet on port " + localPort);
             try {
                 defaultNHttpServerConnection.shutdown();
-            } catch (IOException ex) {
-                log.error("Error shutting down the connection", ex);
+            } catch (IOException ignored) {
             }
-        } else {
-            try {
-                handler.exception(defaultNHttpServerConnection, e);
-            } catch (final Exception ex) {
-                handler.exception(defaultNHttpServerConnection, ex);
-            }
+            return;
+        }
+        try {
+            handler.exception(defaultNHttpServerConnection, e);
+        } catch (final Exception ex) {
+            handler.exception(defaultNHttpServerConnection, ex);
         }
     }
 
@@ -132,18 +129,17 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
         if (handler == null) {
-            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            log.error("The request to the port " + localPort + " cannot be processed further as the Listener has not started yet on port " + localPort);
             try {
                 defaultNHttpServerConnection.shutdown();
-            } catch (IOException ex) {
-                log.error("Error shutting down the connection", ex);
+            } catch (IOException ignored) {
             }
-        } else {
-            try {
-                handler.timeout(defaultNHttpServerConnection);
-            } catch (final Exception ex) {
-                handler.exception(defaultNHttpServerConnection, ex);
-            }
+            return;
+        }
+        try {
+            handler.timeout(defaultNHttpServerConnection);
+        } catch (final Exception ex) {
+            handler.exception(defaultNHttpServerConnection, ex);
         }
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/MultiListenerServerIODispatch.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/core/MultiListenerServerIODispatch.java
@@ -18,6 +18,8 @@
 
 package org.apache.synapse.transport.passthru.core;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.impl.nio.DefaultNHttpServerConnection;
 import org.apache.http.nio.NHttpServerEventHandler;
 import org.apache.synapse.transport.http.conn.ServerConnFactory;
@@ -34,6 +36,7 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
     //Need Thread safe handler for get NHttpServerEventHandlers
     private volatile Map<Integer, NHttpServerEventHandler> handlers;
 
+    private static Log log = LogFactory.getLog(MultiListenerServerIODispatch.class);
 
     public MultiListenerServerIODispatch(final Map<Integer, NHttpServerEventHandler> handlers,
                                          final NHttpServerEventHandler nHttpServerEventHandler,
@@ -46,10 +49,19 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
     protected void onConnected(final DefaultNHttpServerConnection defaultNHttpServerConnection) {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
-        try {
-            handler.connected(defaultNHttpServerConnection);
-        } catch (final Exception ex) {
-            handler.exception(defaultNHttpServerConnection, ex);
+        if (handler == null) {
+            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            try {
+                defaultNHttpServerConnection.shutdown();
+            } catch (IOException ex) {
+                log.error("Error shutting down the connection", ex);
+            }
+        } else {
+            try {
+                handler.connected(defaultNHttpServerConnection);
+            } catch (final Exception ex) {
+                handler.exception(defaultNHttpServerConnection, ex);
+            }
         }
     }
 
@@ -57,10 +69,19 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
     protected void onClosed(final DefaultNHttpServerConnection defaultNHttpServerConnection) {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
-        try {
-            handler.closed(defaultNHttpServerConnection);
-        } catch (final Exception ex) {
-            handler.exception(defaultNHttpServerConnection, ex);
+        if (handler == null) {
+            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            try {
+                defaultNHttpServerConnection.shutdown();
+            } catch (IOException ex) {
+                log.error("Error shutting down the connection", ex);
+            }
+        } else {
+            try {
+                handler.closed(defaultNHttpServerConnection);
+            } catch (final Exception ex) {
+                handler.exception(defaultNHttpServerConnection, ex);
+            }
         }
     }
 
@@ -68,10 +89,19 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
     protected void onException(final DefaultNHttpServerConnection defaultNHttpServerConnection, IOException e) {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
-        try {
-            handler.exception(defaultNHttpServerConnection, e);
-        } catch (final Exception ex) {
-            handler.exception(defaultNHttpServerConnection, ex);
+        if (handler == null) {
+            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            try {
+                defaultNHttpServerConnection.shutdown();
+            } catch (IOException ex) {
+                log.error("Error shutting down the connection", ex);
+            }
+        } else {
+            try {
+                handler.exception(defaultNHttpServerConnection, e);
+            } catch (final Exception ex) {
+                handler.exception(defaultNHttpServerConnection, ex);
+            }
         }
     }
 
@@ -101,10 +131,19 @@ public class MultiListenerServerIODispatch extends ServerIODispatch {
     protected void onTimeout(final DefaultNHttpServerConnection defaultNHttpServerConnection) {
         int localPort = defaultNHttpServerConnection.getLocalPort();
         NHttpServerEventHandler handler = handlers.get(localPort);
-        try {
-            handler.timeout(defaultNHttpServerConnection);
-        } catch (final Exception ex) {
-            handler.exception(defaultNHttpServerConnection, ex);
+        if (handler == null) {
+            log.error("Listener has not started yet on " + localPort + ". Hence shutting down the connection");
+            try {
+                defaultNHttpServerConnection.shutdown();
+            } catch (IOException ex) {
+                log.error("Error shutting down the connection", ex);
+            }
+        } else {
+            try {
+                handler.timeout(defaultNHttpServerConnection);
+            } catch (final Exception ex) {
+                handler.exception(defaultNHttpServerConnection, ex);
+            }
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/wso2/api-manager/issues/164
Now the NPE is handled and further the connection is shutdown when a request is made before the server getting started.