### PR TITLE
Remove stale connections from the Connection pool

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/HostConnections.java
@@ -114,7 +114,8 @@ public class HostConnections {
                                                                                         CONNECTION_INIT_TIME);
                 long expiryTime = (Long) conn.getContext().getAttribute(PassThroughConstants.
                         CONNECTION_EXPIRY_TIME);
-                if (isMaximumLifeSpanExceeded(currentTime, connectionInitTime) ||  currentTime >= expiryTime ) {
+                if (isMaximumLifeSpanExceeded(currentTime, connectionInitTime) ||  currentTime >= expiryTime
+                        || conn.isStale()) {
                     freeConnections.remove(conn);
                     try {
                         conn.shutdown();


### PR DESCRIPTION
The stale connections should be removed from the Target connection pool and only an open connection should be returned from the getConnection() method. This PR ensures that the below issue does not occur due to a stale connection returned from this method.

Fixes https://github.com/wso2/product-ei/issues/5564