### PR TITLE
Added log telemetry with OpenTelemetry support and removed resolveHandler method.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/JaegerTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/JaegerTelemetryManager.java
@@ -91,7 +91,7 @@ public class JaegerTelemetryManager implements OpenTelemetryManager {
         if (logger.isDebugEnabled()) {
             logger.debug("Tracer: " + this.tracer + " is configured");
         }
-        resolveHandler();
+        this.handler = new SpanHandler(tracer, openTelemetry, new TracingScopeManager());
     }
 
     @Override
@@ -112,12 +112,6 @@ public class JaegerTelemetryManager implements OpenTelemetryManager {
     public String getServiceName() {
 
         return TelemetryConstants.SERVICE_NAME;
-    }
-
-    @Override
-    public void resolveHandler() {
-
-        this.handler = new SpanHandler(tracer, openTelemetry, new TracingScopeManager());
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * This class used to generate log telemetry tracer related logs.
+ */
+public class LogExporter implements SpanExporter {
+
+    private final Log log = LogFactory.getLog(TelemetryConstants.TRACER);
+    private final JsonFactory jsonFactory = new JsonFactory();
+
+    public static LogExporter create() {
+
+        return new LogExporter();
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+
+        Iterator var3 = spans.iterator();
+        while (var3.hasNext()) {
+            try {
+                StringWriter writer = new StringWriter();
+                JsonGenerator generator = this.jsonFactory.createGenerator(writer);
+                generator.writeStartObject();
+                SpanData span = (SpanData) var3.next();
+                generator.writeStringField(TelemetryConstants.SPAN_ID, span.getSpanId());
+                generator.writeStringField(TelemetryConstants.TRACER_ID, span.getTraceId());
+                generator.writeStringField(TelemetryConstants.OPERATION_NAME, span.getName());
+                generator.writeStringField(TelemetryConstants.LATENCY,
+                        ((int) (span.getEndEpochNanos() - span.getStartEpochNanos()) / 1000000) + "ms");
+                generator.writeStringField(TelemetryConstants.ATTRIBUTES, String.valueOf(span.getAttributes()));
+                generator.writeEndObject();
+                generator.close();
+                writer.close();
+                log.trace(writer.toString());
+            } catch (IOException e) {
+                log.error("Error in structured message when exporting", e);
+            }
+        }
+
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+
+        return CompletableResultCode.ofSuccess();
+    }
+}
+

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 /**
- * This class used to generate log telemetry tracer related logs.
+ * This class is used to generate logs representing OpenTelemetry spans.
  */
 public class LogExporter implements SpanExporter {
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
@@ -47,16 +47,16 @@ public class LogExporter implements SpanExporter {
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
 
-        Iterator var3 = spans.iterator();
-        while (var3.hasNext()) {
+        Iterator iterator = spans.iterator();
+        while (iterator.hasNext()) {
             try {
                 StringWriter writer = new StringWriter();
                 JsonGenerator generator = this.jsonFactory.createGenerator(writer);
                 generator.writeStartObject();
-                SpanData span = (SpanData) var3.next();
+                SpanData span = (SpanData) iterator.next();
                 generator.writeStringField(TelemetryConstants.SPAN_ID, span.getSpanId());
-                generator.writeStringField(TelemetryConstants.TRACER_ID, span.getTraceId());
-                generator.writeStringField(TelemetryConstants.OPERATION_NAME, span.getName());
+                generator.writeStringField(TelemetryConstants.TRACE_ID, span.getTraceId());
+                generator.writeStringField(TelemetryConstants.SPAN_NAME, span.getName());
                 generator.writeStringField(TelemetryConstants.LATENCY,
                         ((int) (span.getEndEpochNanos() - span.getStartEpochNanos()) / 1000000) + "ms");
                 generator.writeStringField(TelemetryConstants.ATTRIBUTES, String.valueOf(span.getAttributes()));

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogExporter.java
@@ -49,13 +49,17 @@ public class LogExporter implements SpanExporter {
 
         Iterator iterator = spans.iterator();
         while (iterator.hasNext()) {
+            String traceId = null;
+            String spanId = null;
+            SpanData span = (SpanData) iterator.next();
             try {
                 StringWriter writer = new StringWriter();
                 JsonGenerator generator = this.jsonFactory.createGenerator(writer);
                 generator.writeStartObject();
-                SpanData span = (SpanData) iterator.next();
-                generator.writeStringField(TelemetryConstants.SPAN_ID, span.getSpanId());
-                generator.writeStringField(TelemetryConstants.TRACE_ID, span.getTraceId());
+                traceId = span.getTraceId();
+                spanId = span.getSpanId();
+                generator.writeStringField(TelemetryConstants.SPAN_ID, spanId);
+                generator.writeStringField(TelemetryConstants.TRACE_ID, traceId);
                 generator.writeStringField(TelemetryConstants.SPAN_NAME, span.getName());
                 generator.writeStringField(TelemetryConstants.LATENCY,
                         ((int) (span.getEndEpochNanos() - span.getStartEpochNanos()) / 1000000) + "ms");
@@ -65,7 +69,8 @@ public class LogExporter implements SpanExporter {
                 writer.close();
                 log.trace(writer.toString());
             } catch (IOException e) {
-                log.error("Error in structured message when exporting", e);
+                log.error("Error while structuring the log message when exporting Trace ID: " + traceId + ", Span ID:" +
+                        " " + spanId, e);
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/LogTelemetryManager.java
@@ -21,8 +21,8 @@ package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.managem
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -60,7 +60,7 @@ public class LogTelemetryManager implements OpenTelemetryManager {
 
         openTelemetry = OpenTelemetrySdk.builder()
                 .setTracerProvider(sdkTracerProvider)
-                .setPropagators(ContextPropagators.create(B3Propagator.injectingMultiHeaders()))
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
 
         this.tracer = new TelemetryTracer(getTelemetryTracer());

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OpenTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OpenTelemetryManager.java
@@ -33,6 +33,7 @@ public interface OpenTelemetryManager {
 
     /**
      * Return the OpenTelemetry tracer from the initialized openTelemetry instance.
+     *
      * @return OpenTelemetry tracer.
      */
     Tracer getTelemetryTracer();
@@ -44,17 +45,14 @@ public interface OpenTelemetryManager {
 
     /**
      * Return the service name.
+     *
      * @return service name.
      */
     String getServiceName();
 
     /**
-     * Resolves the OpenTelemetry compatible span handler.
-     */
-    void resolveHandler();
-
-    /**
      * Returns the OpenTelemetry compatible span handler.
+     *
      * @return An OpenTelemetry compatible span handler.
      */
     OpenTelemetrySpanHandler getHandler();

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -55,6 +55,12 @@ public class TelemetryConstants {
     public static final String DEFAULT_ZIPKIN_HOST = "localhost";
     public static final String DEFAULT_ZIPKIN_PORT = "9411";
     public static final String ZIPKIN_API_CONTEXT = "/api/v2/spans";
+    static final String LATENCY = "Latency";
+    static final String OPERATION_NAME = "Operation";
+    static final String ATTRIBUTES = "Tags";
+    static final String TRACER_ID = "Trace Id";
+    static final String SPAN_ID = "Span Id";
+    static final String TRACER = "tracer";
 
     //span attributes
     public static final String BEFORE_PAYLOAD_ATTRIBUTE_KEY = "beforePayload";

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -56,9 +56,9 @@ public class TelemetryConstants {
     public static final String DEFAULT_ZIPKIN_PORT = "9411";
     public static final String ZIPKIN_API_CONTEXT = "/api/v2/spans";
     static final String LATENCY = "Latency";
-    static final String OPERATION_NAME = "Operation";
+    static final String SPAN_NAME = "Span Name";
     static final String ATTRIBUTES = "Tags";
-    static final String TRACER_ID = "Trace Id";
+    static final String TRACE_ID = "Trace Id";
     static final String SPAN_ID = "Span Id";
     static final String TRACER = "tracer";
 


### PR DESCRIPTION
## Purpose
> Added the log tracing with OpenTelemetry support for WSO2 MI and removed resolverHandler method in OpenTelemetryManager interface.

New OpenTelemetry configurations in deployment.toml file for WSO2 synapse.

**OpenTelemetry for Log,**
```
[opentelemetry]
enable = true
logs = true
type = "log"
```
After you invoke the APIs you will be able to see telemetry data in the `wso2-mi-open-telemetry.log` in the `<MI_HOME>/repository/logs` folder.

## Related PRs
> https://github.com/wso2/micro-integrator/pull/2727
