### PR TITLE
Added OtlpExporter with OpenTelemetry Support

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/OpenTelemetryManagerHolder.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/OpenTelemetryManagerHolder.java
@@ -20,6 +20,7 @@ package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.TelemetryConstants;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.OpenTelemetryManager;
 import org.apache.synapse.config.SynapsePropertiesLoader;
@@ -49,8 +50,8 @@ public class OpenTelemetryManagerHolder {
         try {
             openTelemetryManager = (OpenTelemetryManager) Class.forName(classpath).newInstance();
             openTelemetryManager.init();
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException exception) {
-            logger.error("Failed to initialize OpenTelemetryManager for class name: " + classpath, exception);
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | SynapseException e) {
+            logger.error("Failed to initialize OpenTelemetryManager for class name: " + classpath, e);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
@@ -53,7 +53,7 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
 
         String headerProperty = getHeaderKeyProperty();
         if (headerProperty == null) {
-            throw new SynapseException("No properties found starting with opentelemetry.otlp.header_properties");
+            throw new SynapseException("No properties found starting with opentelemetry.properties");
         }
         String headerKey = headerProperty.substring(TelemetryConstants.OPENTELEMETRY_PROPERTIES_PREFIX.length());
         String endPointURL = SynapsePropertiesLoader.getPropertyValue(TelemetryConstants.OPENTELEMETRY_URL, null);

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -33,7 +51,10 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
     public void init() {
 
         String headerProperty = getHeaderKeyProperty();
-        String headerKey = headerProperty.substring(TelemetryConstants.OPENTELEMETRY_PROPERTIES.length());
+        if (headerProperty == null) {
+            logger.error("opentelemetry.otlp.header_properties not found");
+        }
+        String headerKey = headerProperty.substring(TelemetryConstants.OPENTELEMETRY_PROPERTIES_PREFIX.length());
         String endPointURL = SynapsePropertiesLoader.getPropertyValue(TelemetryConstants.OPENTELEMETRY_URL, null);
         String headerValue = SynapsePropertiesLoader.getPropertyValue(headerProperty, null);
         OtlpGrpcSpanExporterBuilder otlpGrpcSpanExporterBuilder = OtlpGrpcSpanExporter.builder()
@@ -97,7 +118,7 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
         Enumeration<?> synapsePropertyKeys = SynapsePropertiesLoader.loadSynapseProperties().propertyNames();
         while (synapsePropertyKeys.hasMoreElements()) {
             String property = (String) synapsePropertyKeys.nextElement();
-            if (property.startsWith(TelemetryConstants.OPENTELEMETRY_PROPERTIES)) {
+            if (property.startsWith(TelemetryConstants.OPENTELEMETRY_PROPERTIES_PREFIX)) {
                 return property;
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
@@ -1,0 +1,106 @@
+package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.handling.span.OpenTelemetrySpanHandler;
+import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.handling.span.SpanHandler;
+import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.scoping.TracingScopeManager;
+import org.apache.synapse.config.SynapsePropertiesLoader;
+
+import java.util.Enumeration;
+
+public class OTLPTelemetryManager implements OpenTelemetryManager {
+
+    private Log logger = LogFactory.getLog(OTLPTelemetryManager.class);
+    private SdkTracerProvider sdkTracerProvider;
+    private OpenTelemetry openTelemetry;
+    private TelemetryTracer tracer;
+    private SpanHandler handler;
+
+    @Override
+    public void init() {
+
+        String headerProperty = getHeaderKeyProperty();
+        String headerKey = headerProperty.substring(TelemetryConstants.OPENTELEMETRY_PROPERTIES.length());
+        String endPointURL = SynapsePropertiesLoader.getPropertyValue(TelemetryConstants.OPENTELEMETRY_URL, null);
+        String headerValue = SynapsePropertiesLoader.getPropertyValue(headerProperty, null);
+        OtlpGrpcSpanExporterBuilder otlpGrpcSpanExporterBuilder = OtlpGrpcSpanExporter.builder()
+                .setEndpoint(endPointURL)
+                .setCompression("gzip")
+                .addHeader(headerKey, headerValue);
+
+        Resource serviceNameResource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME,
+                TelemetryConstants.SERVICE_NAME));
+
+        sdkTracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(BatchSpanProcessor.builder(otlpGrpcSpanExporterBuilder.build()).build())
+                .setResource(Resource.getDefault().merge(serviceNameResource))
+                .build();
+
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                .setPropagators(ContextPropagators.create(JaegerPropagator.getInstance()))
+                .build();
+
+        this.tracer = new TelemetryTracer(getTelemetryTracer());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Tracer: " + this.tracer + " is configured");
+        }
+        this.handler = new SpanHandler(tracer, openTelemetry, new TracingScopeManager());
+    }
+
+    @Override
+    public Tracer getTelemetryTracer() {
+
+        return openTelemetry.getTracer(TelemetryConstants.OPENTELEMETRY_INSTRUMENTATION_NAME);
+    }
+
+    @Override
+    public void close() {
+
+        if (sdkTracerProvider != null) {
+            sdkTracerProvider.close();
+        }
+    }
+
+    @Override
+    public String getServiceName() {
+
+        return TelemetryConstants.SERVICE_NAME;
+    }
+
+    @Override
+    public OpenTelemetrySpanHandler getHandler() {
+
+        return this.handler;
+    }
+
+    /**
+     * Return the header key from synapse.properties file for specific OTLP based APM.
+     *
+     * @return Header key.
+     */
+    public String getHeaderKeyProperty() {
+
+        Enumeration<?> synapsePropertyKeys = SynapsePropertiesLoader.loadSynapseProperties().propertyNames();
+        while (synapsePropertyKeys.hasMoreElements()) {
+            String property = (String) synapsePropertyKeys.nextElement();
+            if (property.startsWith(TelemetryConstants.OPENTELEMETRY_PROPERTIES)) {
+                return property;
+            }
+        }
+        return null;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
@@ -32,6 +32,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.handling.span.OpenTelemetrySpanHandler;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.handling.span.SpanHandler;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.scoping.TracingScopeManager;
@@ -52,7 +53,7 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
 
         String headerProperty = getHeaderKeyProperty();
         if (headerProperty == null) {
-            logger.error("opentelemetry.otlp.header_properties not found");
+            throw new SynapseException("No properties found starting with opentelemetry.otlp.header_properties");
         }
         String headerKey = headerProperty.substring(TelemetryConstants.OPENTELEMETRY_PROPERTIES_PREFIX.length());
         String endPointURL = SynapsePropertiesLoader.getPropertyValue(TelemetryConstants.OPENTELEMETRY_URL, null);

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -55,7 +55,7 @@ public class TelemetryConstants {
     public static final String DEFAULT_ZIPKIN_HOST = "localhost";
     public static final String DEFAULT_ZIPKIN_PORT = "9411";
     public static final String ZIPKIN_API_CONTEXT = "/api/v2/spans";
-    public static final String OPENTELEMETRY_PROPERTIES = "opentelemetry.otlp.header_properties.";
+    public static final String OPENTELEMETRY_PROPERTIES_PREFIX = "opentelemetry.otlp.header_properties.";
     static final String LATENCY = "Latency";
     static final String SPAN_NAME = "Span Name";
     static final String ATTRIBUTES = "Tags";

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -55,7 +55,7 @@ public class TelemetryConstants {
     public static final String DEFAULT_ZIPKIN_HOST = "localhost";
     public static final String DEFAULT_ZIPKIN_PORT = "9411";
     public static final String ZIPKIN_API_CONTEXT = "/api/v2/spans";
-    public static final String OPENTELEMETRY_PROPERTIES_PREFIX = "opentelemetry.otlp.header_properties.";
+    public static final String OPENTELEMETRY_PROPERTIES_PREFIX = "opentelemetry.properties.";
     static final String LATENCY = "Latency";
     static final String SPAN_NAME = "Span Name";
     static final String ATTRIBUTES = "Tags";

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -55,6 +55,7 @@ public class TelemetryConstants {
     public static final String DEFAULT_ZIPKIN_HOST = "localhost";
     public static final String DEFAULT_ZIPKIN_PORT = "9411";
     public static final String ZIPKIN_API_CONTEXT = "/api/v2/spans";
+    public static final String OPENTELEMETRY_PROPERTIES = "opentelemetry.otlp.header_properties.";
     static final String LATENCY = "Latency";
     static final String SPAN_NAME = "Span Name";
     static final String ATTRIBUTES = "Tags";

--- a/pom.xml
+++ b/pom.xml
@@ -1552,7 +1552,7 @@
        <transport.http.netty.version>6.3.35</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <opentelemetry.all.version>1.11.0.wso2v2</opentelemetry.all.version>
+       <opentelemetry.all.version>1.11.0.wso2v3</opentelemetry.all.version>
        <okhttp.wso2.version>4.9.3.wso2v1</okhttp.wso2.version>
        <okio.wso2.version>2.8.0.wso2v1</okio.wso2.version>
        <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>


### PR DESCRIPTION
## Purpose
> Added the OtlpExporter with OpenTelemetry support to enable tracing.

## Goals
> This exporter support for APMs such as NewRelic, Elastic, etc.
> Recommended to use OtlpExporter with following configuration types to view traces in respective APMs.

## Approach
> The following configurations should be added in deployment.toml file,
```
[opentelemetry]
enable = true
logs = true
type = “otlp”
url = “endpoint-url”

[[opentelemetry.properties]]
name = “name-of-the-header”
value = “key-value-of-the-header” 
```
if anyone uses NewRelic APM to view the traces, the following configurations should be added.
```
[opentelemetry]
enable = true
logs = true
type = “otlp”
url = “https://otlp.nr-data.net:4317/v1/traces”

[[opentelemetry.properties]]
name = “api-key”
value = “<your-insight-insert-key>” 
```

## Related PRs
> https://github.com/wso2/micro-integrator/pull/2736
