### PR TITLE
Fix the soap header mediator deforms the soap body

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/HeaderMediator.java
@@ -272,6 +272,10 @@ public class HeaderMediator extends AbstractMediator {
                 log.error("Unable to convert to SoapHeader Block", e);
             }
         }
+        if (XMLConfigConstants.SCOPE_DEFAULT.equals(scope) || scope == null) {
+            //This build is added to fix soap body getting deformed in API manager scenarios.
+            synCtx.getEnvelope().build();
+        }
     }
 
     private void removeFromHeaderList(List headersList) {


### PR DESCRIPTION
When we add the SOAP header mediator to add a new header, the SOAP envelope gets deformed.  

Fixes #wso2/api-manager#402

