### PR TITLE
Fix misleading analytics logs at failover scenario

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/FailoverEndpoint.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.xml.stream.XMLStreamException;
 
 /**
@@ -160,6 +161,14 @@ public class FailoverEndpoint extends AbstractEndpoint {
             boolean foundEndpoint = false;
             for (Endpoint endpoint : getChildren()) {
                 if (endpoint.readyToSend()) {
+                    // remove the ERROR properties set by previous attempts of the same request
+                    Set properties = synCtx.getPropertyKeySet();
+                    if (properties != null) {
+                        properties.remove(PassThroughConstants.ERROR_CODE);
+                        properties.remove(PassThroughConstants.ERROR_MESSAGE);
+                        properties.remove(PassThroughConstants.ERROR_EXCEPTION);
+                        properties.remove(PassThroughConstants.ERROR_DETAIL);
+                    }
                     foundEndpoint = true;
                     if (isARetry && metricsMBean != null) {
                         metricsMBean.reportSendingFault(SynapseConstants.ENDPOINT_FO_FAIL_OVER);


### PR DESCRIPTION
Fixes issue https://github.com/wso2/api-manager/issues/474.

Root cause:

The root cause of the is that even if a failover endpoint request is successful, while the main endpoint was failed, the synapse message context is set with properties ERROR_MESSAGE and ERROR_CODE. These are set when the request to the main endpoint is failed. They are not dropped even the next try with failover endpoint is succeeded.

Because of this, in APIM, SynapseAnalyticsDataProvider decides this request as failed and logs as the request is failed with error codes/messages which were set by the initial request.

Fixing approach:

Whenever a new request is initiated to an endpoint, drop the ERROR_CODE, ERROR_MESSAGE, ERROR_DETAIL, ERROR_EXCEPTION properties from the synapse message context if they are available. This will be done before making the request to any endpoint.