### PR TITLE
Add improvement to store messages in the failed message store for retry scenarios.

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorSerializer.java
@@ -101,6 +101,9 @@ public class MessageProcessorSerializer {
                 if (ForwardingProcessorConstants.NON_RETRY_STATUS_CODES.equals(name)) {
                     Object statusCode = processor.getParameters().get(ForwardingProcessorConstants.NON_RETRY_STATUS_CODES);
                     value = StringUtils.join((String[]) statusCode, ",");
+                } else if (ForwardingProcessorConstants.NON_RETRY_STORE_STATUS_CODES.equals(name)) {
+                    Object statusCode = processor.getParameters().get(ForwardingProcessorConstants.NON_RETRY_STORE_STATUS_CODES);
+                    value = StringUtils.join((String[]) statusCode, ",");
                 } else {
                     value = (String) processor.getParameters().get(name);
                 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
@@ -71,6 +71,7 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
      * This is specially used for REST scenarios where http status codes can take semantics in a RESTful architecture.
      */
     protected String[] nonRetryStatusCodes = null;
+	protected String[] nonRetryStoreStatusCodes = null;
 
 	protected BlockingMsgSender sender;
 
@@ -241,6 +242,10 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 				// we take it out of param set and send it because we need split
 				// the array.
 				nonRetryStatusCodes = o.toString().split(",");
+			}
+			o = parameters.get(ForwardingProcessorConstants.NON_RETRY_STORE_STATUS_CODES);
+			if (o != null) {
+				nonRetryStoreStatusCodes = o.toString().split(",");
 			}
 		}
 	}

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingProcessorConstants.java
@@ -61,6 +61,11 @@ public final class ForwardingProcessorConstants {
     public static final String NON_RETRY_STATUS_CODES = "non.retry.status.codes";
 
     /**
+     * Indicates the error status codes that need not retry, but want to store in the failed message store
+     */
+    public static final String NON_RETRY_STORE_STATUS_CODES = "non.retry.store.status.codes";
+
+    /**
      * Used th throttle forwarding-processor when it is used with cron expressions
      */
     public static final String THROTTLE_INTERVAL = "throttle.interval";

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ScheduledMessageForwardingProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ScheduledMessageForwardingProcessor.java
@@ -43,6 +43,9 @@ public class ScheduledMessageForwardingProcessor extends ScheduledMessageProcess
 			parameters.put(ForwardingProcessorConstants.NON_RETRY_STATUS_CODES, nonRetryStatusCodes);
 		}
 
+		if (nonRetryStoreStatusCodes != null) {
+			parameters.put(ForwardingProcessorConstants.NON_RETRY_STORE_STATUS_CODES, nonRetryStoreStatusCodes);
+		}
 		// Setting the end-point here. If target endpoint is not defined at the MP,
 		// target.endpoint property is used to fetch the endpoint
         if (targetEndpoint != null) {


### PR DESCRIPTION
### Just a suggestion for a future release
### I have not tested the feature nor run integration tests. Do not merge. I repeat DO NOT MERGE.

## Purpose
> Introduces **non.retry.store.status.codes** parameter.
> Add a failed message to a message store without retrying, specify the HTTP SC 
