### PR TITLE
Fix misleading analytics logs at loadbalanced EP scenario

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/LoadbalanceEndpoint.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.Set;
 
 /**
  * A Load balance endpoint contains multiple child endpoints. It routes messages according to the
@@ -203,6 +204,14 @@ public class LoadbalanceEndpoint extends AbstractEndpoint {
         evaluateProperties(synCtx);
 
         if (endpoint != null) {
+            // remove the ERROR properties set by previous attempts of the same request
+            Set properties = synCtx.getPropertyKeySet();
+            if (properties != null) {
+                properties.remove(PassThroughConstants.ERROR_CODE);
+                properties.remove(PassThroughConstants.ERROR_MESSAGE);
+                properties.remove(PassThroughConstants.ERROR_EXCEPTION);
+                properties.remove(PassThroughConstants.ERROR_DETAIL);
+            }
             // if this is not a retry
             if (synCtx.getProperty(SynapseConstants.LAST_ENDPOINT) == null) {
                 // We have to build the envelop when we are supporting failover, as we


### PR DESCRIPTION
Fixes issue https://github.com/wso2/api-manager/issues/619

Root cause:

The root cause of the is that even if a loadbalanced endpoint request is successful, while the main endpoint (or other previously attempted EP) was failed, the synapse message context is set with properties ERROR_MESSAGE and ERROR_CODE. These are set when the request to the previous endpoint is failed. They are not dropped even the next try with loadbalanced endpoint is succeeded.

Because of this, in APIM, SynapseAnalyticsDataProvider decides this request as failed and logs as the request is failed with error codes/messages which were set by the initial request.

Fixing approach:

Whenever a new request is initiated to an endpoint, drop the ERROR_CODE, ERROR_MESSAGE, ERROR_DETAIL, ERROR_EXCEPTION properties from the synapse message context if they are available. This will be done before making the request to any endpoint.