### PR TITLE
Removing the deprecated getPeerCertificateChain() and using getPeerCertificates() instead

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/NhttpConstants.java
@@ -234,7 +234,13 @@ public class NhttpConstants {
     /**
      * X509 certificate chain for Mutual SSL connections
      */
+    @Deprecated
     public static final String SSL_CLIENT_AUTH_CERT_X509 = "ssl.client.auth.cert.X509";
+
+    /**
+     * Certificates for Mutual SSL connections
+     */
+    public static final String SSL_CLIENT_AUTH_CERT = "ssl.client.auth.cert";
 
     /**
      * axis2 configuration to enable Mutual SSL - verify client's certificate

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -70,11 +70,15 @@ import org.apache.synapse.transport.passthru.util.SourceResponseFactory;
 
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.CertificateException;
+import javax.security.cert.X509Certificate;
 import javax.xml.parsers.FactoryConfigurationError;
 
 /**
@@ -548,8 +552,18 @@ public class ServerWorker implements Runnable {
             if (ssliosession != null && msgContext.getTransportIn() != null
                 && msgContext.getTransportIn().getParameter(NhttpConstants.SSL_VERIFY_CLIENT) != null) {
                 try {
-                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509,
-                                           ssliosession.getSSLSession().getPeerCertificates());
+                    Certificate[] certificates = ssliosession.getSSLSession().getPeerCertificates();
+                    X509Certificate[] x509Certificates = new X509Certificate[certificates.length];
+                    for (int i = 0; i < certificates.length; i++) {
+                        try {
+                            x509Certificates[i] = X509Certificate.getInstance(certificates[i].getEncoded());
+                        } catch (CertificateException | CertificateEncodingException e) {
+                            log.error("Error while converting client certificate", e);
+                        }
+                    }
+                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509, x509Certificates);
+                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT,
+                            ssliosession.getSSLSession().getPeerCertificates());
                 } catch (SSLPeerUnverifiedException e) {
                     //Peer Certificate Chain may not be available always.(in case of Mutual SSL is not enabled)
                     if (log.isTraceEnabled()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -549,7 +549,7 @@ public class ServerWorker implements Runnable {
                 && msgContext.getTransportIn().getParameter(NhttpConstants.SSL_VERIFY_CLIENT) != null) {
                 try {
                     msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509,
-                                           ssliosession.getSSLSession().getPeerCertificateChain());
+                                           ssliosession.getSSLSession().getPeerCertificates());
                 } catch (SSLPeerUnverifiedException e) {
                     //Peer Certificate Chain may not be available always.(in case of Mutual SSL is not enabled)
                     if (log.isTraceEnabled()) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/636
**This should be merged after merging [1]**

## Test environment
- OpenJDK 11.0.16+8
- OpenJDK 17.0.4+8

[1] https://github.com/wso2/wso2-synapse/pull/1965