### PR TITLE
Add support to read freemarker template as registry resource

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -38,6 +38,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.config.Entry;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.Value;
@@ -68,6 +69,9 @@ public class PayloadFactoryMediator extends AbstractMediator {
     private String mediaType = XML_TYPE;
     private static final String XML_CONTENT_TYPE = "application/xml";
     private boolean escapeXmlChars = false;
+    /* Latest version of dynamic registry resource.
+    Default is set to -1 as the initial version will be 0 */
+    private long version = -1;
     private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
     private static final String JSON_CONTENT_TYPE = "application/json";
     private static final String TEXT_CONTENT_TYPE = "text/plain";
@@ -148,7 +152,15 @@ public class PayloadFactoryMediator extends AbstractMediator {
      * @param format
      */
     private void transform(StringBuilder result, MessageContext synCtx, String format) {
+        boolean reCreate = false;
         if (isFormatDynamic()) {
+            if (templateType.equals(FREEMARKER_TEMPLATE_TYPE)) {
+                Entry template = synCtx.getConfiguration().getEntryDefinition(formatKey.getKeyValue());
+                if ((!template.isCached() || template.isExpired()) && version != template.getVersion()) {
+                    reCreate = true;
+                    version = template.getVersion();
+                }
+            }
             String key = formatKey.evaluateValue(synCtx);
             Object entry = synCtx.getEntry(key);
             if (entry == null) {
@@ -163,6 +175,10 @@ public class PayloadFactoryMediator extends AbstractMediator {
                 text = ((OMText) entry).getText();
             } else if (entry instanceof String) {
                 text = (String) entry;
+            }
+            if (reCreate) {
+                templateProcessor.setFormat(text);
+                templateProcessor.init();
             }
             processTemplate(result, synCtx, text);
         } else {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -98,7 +98,10 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     @Override
     public void init() {
 
-        compileFreeMarkerTemplate(getFormat(), getMediaType());
+        String format = getFormat();
+        if (format != null) {
+            compileFreeMarkerTemplate(format, getMediaType());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
The integration studio branch was missing the support to read freemarker template as a registry resource. As a result, the mediator validation failed in the source view.

Fixes https://github.com/wso2/api-manager/issues/662
