### PR TITLE
Bumping the netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1541,7 +1541,7 @@
        <activemq.broker.version>5.9.1</activemq.broker.version>
        <slf4j.log4j.version>1.5.2</slf4j.log4j.version>
        <system.rules.version>1.17.0</system.rules.version>
-       <io.netty.version>4.1.34.Final</io.netty.version>
+       <io.netty.version>4.1.80.Final</io.netty.version>
        <transport.http.netty.version>6.3.35</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>


### PR DESCRIPTION
## Purpose
Prior porting the fix to master which was done for [1] for APIM 3.2.0, the master carbon-apimgt needed a new netty-http-codec version (which has the class _io.netty.handler.codec.http.websocketx.CorruptedWebSocketFrameException_) during the compilation. Carbon-apimgt takes the netty version from the synapse repository. Hence, bumping the netty version here to the latest will solve that problem.

## Goals
Bumping the netty version

[1] https://github.com/wso2/api-manager/issues/661