### PR TITLE
Add support sending additional headers to the backend token API in OAuth

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -38,6 +38,8 @@ public class AuthConstants {
     public static final String OAUTH_REFRESH_TOKEN = "refreshToken";
     public static final String REQUEST_PARAMETERS = "requestParameters";
     public static final String REQUEST_PARAMETER = "parameter";
+    public static final String CUSTOM_HEADERS = "customHeaders";
+    public static final String CUSTOM_HEADER = "header";
     public static final String NAME = "name";
 
     public static final String AUTHORIZATION_HEADER = "Authorization";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
@@ -97,7 +97,7 @@ public class OAuthClient {
      * @throws IOException    In the event of a problem parsing the response from the server
      */
     public static String generateToken(String tokenApiUrl, String payload, String credentials,
-                                       MessageContext messageContext) throws AuthException, IOException {
+                                       MessageContext messageContext, Map<String, String> customHeaders) throws AuthException, IOException {
         CloseableHttpClient httpClient = getSecureClient(tokenApiUrl, messageContext);
         if (log.isDebugEnabled()) {
             log.debug("Initializing token generation request: [token-endpoint] " + tokenApiUrl);
@@ -105,6 +105,11 @@ public class OAuthClient {
 
         HttpPost httpPost = new HttpPost(tokenApiUrl);
         httpPost.setHeader(AuthConstants.CONTENT_TYPE_HEADER, AuthConstants.APPLICATION_X_WWW_FORM_URLENCODED);
+        if (!(customHeaders == null || customHeaders.isEmpty())) {
+            for (Map.Entry<String, String> entry : customHeaders.entrySet()) {
+                httpPost.setHeader(entry.getKey(), entry.getValue());
+            }
+        }
         if (credentials != null) {
             httpPost.setHeader(AuthConstants.AUTHORIZATION_HEADER, AuthConstants.BASIC + credentials);
         }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
@@ -107,7 +107,8 @@ public class OAuthClientTest extends TestCase {
         SynapseConfiguration synapseConfiguration = new SynapseConfiguration();
         SynapseEnvironment synapseEnvironment = new Axis2SynapseEnvironment(synapseConfiguration);
         String token = OAuthClient.generateToken("https://localhost:8280/token1/1.0.0", "body", "credentials",
-                                                 new Axis2MessageContext(messageContext, new SynapseConfiguration(), synapseEnvironment));
+                                                 new Axis2MessageContext(messageContext, new SynapseConfiguration(),
+                                                         synapseEnvironment), null);
 
         assertEquals("abc123", token);
     }


### PR DESCRIPTION
## Purpose
 Add support sending additional headers to the backend token API in OAuth

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes