### PR TITLE
Fix the importing custom mediators issue in the integration studio

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorSerializer.java
@@ -19,11 +19,13 @@
 
 package org.apache.synapse.config.xml;
 
+import java.io.StringReader;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMComment;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.om.OMXMLBuilderFactory;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -241,6 +243,13 @@ public abstract class AbstractMediatorSerializer implements MediatorSerializer {
      * @param m      Comment mediator instance which contains comment information
      */
     protected OMElement serializeComments(OMElement parent, Mediator m) {
+        String comment = ((CommentMediator) m).getCommentText();
+        if (comment.startsWith("<CUSTOM_")) {
+            StringReader xmlText = new StringReader(comment);
+            OMElement elementNode = OMXMLBuilderFactory.createOMBuilder(xmlText).getDocumentElement();
+            parent.addChild(elementNode);
+            return parent;
+        }
         OMComment commendNode = fac.createOMComment(parent, "comment");
         commendNode.setValue(((CommentMediator) m).getCommentText());
         parent.addChild(commendNode);


### PR DESCRIPTION
Custom Mediators are considered as comment mediators to be able to import the sequences with custom mediators. When deserializing custom mediators which starts as "CUSTOM_" is considered as comment mediators and is added to the mediators sequence. This fix will treat the comment mediators starting with the comment text of "<CUSTOM_" as custom mediators and will add the comment text ( custom mediator) as a child to the OM parent.

> Fix: wso2-enterprise/wso2-apim-internal#477