### PR TITLE
Add dynamic expression support for additional headers in the EI endpoint level OAuth feature

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -31,6 +31,7 @@ import org.apache.synapse.endpoints.auth.AuthHandler;
 
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
@@ -86,7 +87,7 @@ public abstract class OAuthHandler implements AuthHandler {
                 public String call() throws AuthException, IOException {
                     return OAuthClient.generateToken(OAuthUtils.resolveExpression(tokenApiUrl, messageContext),
                             buildTokenRequestPayload(messageContext), getEncodedCredentials(messageContext),
-                                                     messageContext, customHeadersMap);
+                            messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext));
                 }
             });
         } catch (ExecutionException e) {
@@ -282,5 +283,27 @@ public abstract class OAuthHandler implements AuthHandler {
 
     public void setCustomHeaders(Map<String, String> customHeadersMap) {
         this.customHeadersMap = customHeadersMap;
+    }
+
+    /**
+     * This method will resolve the dynamic expressions used in custom headers and return a new map containing the
+     * resolved expressions.
+     *
+     * @param customHeadersMap The custom headers map
+     * @param messageContext   Message Context of the request which will be used to resolve dynamic expressions
+     * @return Map<String, String> Resolved custom headers
+     */
+    private Map<String, String> getResolvedCustomHeadersMap(Map<String, String> customHeadersMap,
+                                                            MessageContext messageContext) throws AuthException {
+
+        Map<String, String> resolvedCustomHeadersMap = null;
+        if (!(customHeadersMap == null || customHeadersMap.isEmpty())) {
+            resolvedCustomHeadersMap = new HashMap<>();
+            for (Map.Entry<String, String> entry : customHeadersMap.entrySet()) {
+                resolvedCustomHeadersMap.put(entry.getKey(), OAuthUtils.resolveExpression(entry.getValue(),
+                        messageContext));
+            }
+        }
+        return resolvedCustomHeadersMap;
     }
 }

--- a/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
+++ b/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
@@ -66,7 +66,7 @@ public class FoodService {
 
         String basicHeader = httpHeaders.getHeaderString("Authorization");
 
-        if (validateBasicAuthHeader(basicHeader) && validateCustomParams(tokenRequestParams)) {
+        if (validateBasicAuthHeader(basicHeader) && validateCustomHeader(httpHeaders) && validateCustomParams(tokenRequestParams)) {
             return Response.status(Response.Status.OK).entity(new Token(Constants.accessToken, Constants.expiresIn,
                     Constants.tokenType)).build();
         }
@@ -154,5 +154,12 @@ public class FoodService {
         String userRole = tokenRequestParams.getFirst("user_role");
 
         return accountId.equals("1234") && userRole.equals("tester");
+    }
+
+    private boolean validateCustomHeader(HttpHeaders httpHeaders) {
+        String userTokenHeader = httpHeaders.getHeaderString("user_token");
+        String accountTokenHeader = httpHeaders.getHeaderString("account_token");
+
+        return userTokenHeader.equals("abc#123") && accountTokenHeader.equals("zxy@123");
     }
 }

--- a/repository/conf/sample/synapse_sample_63.xml
+++ b/repository/conf/sample/synapse_sample_63.xml
@@ -108,6 +108,7 @@
                     </case>
                     <case regex="withCustomParams">
                         <property name="clientID" value="my_client_id"/>
+                        <property name="account_token" value="zxy@123"/>
                         <payloadFactory media-type="json">
                             <format>{"account_id" : "$1"}</format>
                             <args>
@@ -127,6 +128,10 @@
                                                     <parameter name="account_id">{json-eval($.account_id)}</parameter>
                                                     <parameter name="user_role">tester</parameter>
                                                 </requestParameters>
+                                                <customHeaders>
+                                                    <header name="user_token">abc#123</header>
+                                                    <header name="account_token">{$ctx:account_token}</header>
+                                                </customHeaders>
                                             </clientCredentials>
                                         </oauth>
                                     </authentication>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/739

## User stories
With this improvement, users can use expressions such as `$ctx:some_prop`, `json-eval()`, `hashicorp:vault-lookup`, etc for these header values. You need to define the expressions within **{ }**.

```xml
<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
    <http method="get" uri-template="http://localhost:9192/service/foodservice">
        <authentication>
            <oauth>
                <clientCredentials>
                    <clientId>K2RbnGP7VS</clientId>
                    <clientSecret>abc#$^!72ksdfn</clientSecret>
                    <tokenUrl>http://localhost:8678/token</tokenUrl>
	            <customHeaders>
                        <header name="user_token">{hashicorp:vault-lookup('secret/hello', 'userToken')}</header>
                        <header name="account_token">{$ctx:account_token}</header>
                    </customHeaders>
                </clientCredentials>
            </oauth>
        </authentication>
    </http>
</endpoint>
```