### PR TITLE
Change the URL Matching Logic Order

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingHelper.java
@@ -44,14 +44,14 @@ public class URLMappingHelper implements DispatcherHelper {
     }
 
     public boolean isExactMatch(String url) {
-        if (!"/".equals(url)) {
-            url = ApiUtils.trimTrailingSlashes(url);
-        }
         int index = url.indexOf('?');
         if (index > 0) {
             url = url.substring(0, index);
         } else if (index == 0) {
             url = "/";
+        }
+        if (!"/".equals(url)) {
+            url = ApiUtils.trimTrailingSlashes(url);
         }
         return exactMatch != null && exactMatch.equals(url);
     }


### PR DESCRIPTION
## Purpose
In order to resolve https://github.com/wso2/product-apim/issues/12837

## Approach
In URLMappingHelper, there is the method isExactMatch to match URL. Even-though this method is removing the trailing "/" as a part of it, it fails to remove "/" if it has "?" after that. 

Because  the method to remove trailing slash is like below.
```
public static String trimTrailingSlashes(String url) {
    while (url.endsWith("/")) {
        url = url.substring(0, url.length() - 1);
    }
    return url;
}
```
    
But after getting rid of the after part of question mark (including ?), if there is a trailing slash (for an example, like mentioned in the issue) method is not removing the trailing slash in that specific scenario. This results a mismatch because one will have the trailing "/".

In order to address this, trimTrailingSlashes method has been moved to the end of the method in this PR.

