### PR TITLE
Avoid emitting close events after event collection is finished in inbound endpoint non-sequential mode

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/StatisticsCloseEventListener.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/StatisticsCloseEventListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.synapse.aspects.flow.statistics;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.aspects.ComponentType;
+import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
+
+public class StatisticsCloseEventListener {
+
+    protected String componentName;
+
+    protected ComponentType componentType;
+
+    protected Integer statisticReportingIndex;
+
+    public StatisticsCloseEventListener() {
+    }
+
+    public StatisticsCloseEventListener(String componentName, ComponentType componentType,
+                                        Integer statisticReportingIndex) {
+        this.componentName = componentName;
+        this.componentType = componentType;
+        this.statisticReportingIndex = statisticReportingIndex;
+    }
+
+    /**
+     * This method implements how to close the statistic events from synapse mediation engine.
+     *
+     * @param synCtx synapse message context
+     */
+    public void invokeCloseEventEntry(MessageContext synCtx) {
+        CloseEventCollector.closeFlowForcefully(synCtx, false);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/inbound/InboundEndpointStatisticsCloseEventListener.java
+++ b/modules/core/src/main/java/org/apache/synapse/inbound/InboundEndpointStatisticsCloseEventListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.synapse.inbound;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.aspects.ComponentType;
+import org.apache.synapse.aspects.flow.statistics.StatisticsCloseEventListener;
+import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
+
+public class InboundEndpointStatisticsCloseEventListener extends StatisticsCloseEventListener {
+
+    public InboundEndpointStatisticsCloseEventListener(String componentName, Integer statisticReportingIndex) {
+        super(componentName, ComponentType.INBOUNDENDPOINT, statisticReportingIndex);
+    }
+
+    public void invokeCloseEventEntry(MessageContext synCtx) {
+        CloseEventCollector.tryEndFlow(synCtx, this.componentName, this.componentType,
+                this.statisticReportingIndex, false);
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -22,8 +22,7 @@ package org.apache.synapse.mediators;
 import org.apache.synapse.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
-import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
+import org.apache.synapse.aspects.flow.statistics.StatisticsCloseEventListener;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
 import org.apache.synapse.debug.SynapseDebugManager;
@@ -43,6 +42,9 @@ public class MediatorWorker implements Runnable {
 
     /** MessageContext to be mediated using the mediator */
     private MessageContext synCtx = null;
+
+    /** StatisticsCloseEventListener to be used to close the statistics events at the end of the flow. */
+    private StatisticsCloseEventListener statisticsCloseEventListener = new StatisticsCloseEventListener();
 
     /**
      * Constructor of the MediatorWorker which sets the sequence and the message context
@@ -124,7 +126,7 @@ public class MediatorWorker implements Runnable {
                 debugManager.releaseMediationFlowLock();
             }
             if (RuntimeStatisticCollector.isStatisticsEnabled()) {
-                CloseEventCollector.closeFlowForcefully(synCtx, false);
+                this.statisticsCloseEventListener.invokeCloseEventEntry(synCtx);
             }
         }
         synCtx = null;
@@ -145,4 +147,7 @@ public class MediatorWorker implements Runnable {
         }
     }
 
+    public void setStatisticsCloseEventListener(StatisticsCloseEventListener statisticsCloseEventListener) {
+        this.statisticsCloseEventListener = statisticsCloseEventListener;
+    }
 }


### PR DESCRIPTION
This PR avoids the following WARN log getting printed continuously in the EI carbon logs when an inbound endpoint is used in non-sequential mode with analytics enabled. Earlier, the close event was emitted twice in this flow—one event from the main thread and one from the spawned MediatorWorker thread.

Fixes https://github.com/wso2/api-manager/issues/786