### PR TITLE
Fix services getting disabled in a clustered setup when deploying

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ProxyServiceDeployer.java
@@ -103,7 +103,7 @@ public class ProxyServiceDeployer extends AbstractSynapseArtifactDeployer {
                     log.info("ProxyService named '" + proxy.getName()
                              + "' has been deployed from file : " + filePath);
 
-                    if (!proxy.isStartOnLoad() || !axisService.isActive()) {
+                    if (!proxy.isStartOnLoad()) {
                         proxy.stop(getSynapseConfiguration());
                         log.info("ProxyService named '" + proxy.getName()
                                  + "' has been stopped as startOnLoad parameter is set to false");


### PR DESCRIPTION


## Purpose
Revert fix for: https://github.com/wso2/product-ei/issues/1465

Since the StartOnLoad property should get the priority This issue is not a valid requirement (A fix for a DevInternal - DEVINTERNAL-354).

Fixes: https://github.com/wso2/api-manager/issues/891