### PR TITLE
Try to drain the ContentDecoder completely to avoid ContentDecoder ending up in an incomplete state

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -246,27 +246,27 @@ public class Pipe {
         lock.lock();
         try {
             setInputMode(buffer);
-            int totalRead = 0;
+            int totalBytesRead = 0;
             int bytesRead;
             try {
                 // Drain the decoder until the end of the underlying stream is found or until the Pipe#buffer is full.
                 // bytesRead = -1 means reached out to the end of underlying stream.
                 // bytesRead = 0 means Pipe's input buffer is full.
                 while ((bytesRead = decoder.read(buffer.getByteBuffer())) > 0) {
-                    totalRead += bytesRead;
+                    totalBytesRead += bytesRead;
                 }
-            } catch (TruncatedChunkException ignore) {
+            } catch (TruncatedChunkException ex) {
                 try {
                     // we should add the EoF character
                     buffer.putInt(-1);
                     // now the buffer's position should give us the bytes read.
-                    totalRead = buffer.position();
-                } catch (BufferOverflowException e) {
+                    totalBytesRead = buffer.position();
+                } catch (BufferOverflowException ignore) {
                     // ignore
                 }
             }
             producePostActions(decoder);
-            return totalRead;
+            return totalBytesRead;
         } finally {
             lock.unlock();
         }
@@ -288,7 +288,7 @@ public class Pipe {
         try {
             ByteBuffer duplicate = null;
             setInputMode(buffer);
-            int totalRead = 0;
+            int totalBytesRead = 0;
             int bytesRead;
             try {
                 // clone original buffer
@@ -298,21 +298,21 @@ public class Pipe {
                 // bytesRead = -1 means reached out to the end of stream.
                 // bytesRead = 0 means Pipe's input buffer is full.
                 while ((bytesRead = decoder.read(buffer.getByteBuffer())) > 0) {
-                    totalRead += bytesRead;
+                    totalBytesRead += bytesRead;
                 }
                 duplicate = originalBuffer.duplicate();
                 // replicate positions of original buffer in duplicated buffer
                 int position = originalBuffer.position();
                 duplicate.limit(position);
-                if (totalRead > 0) {
-                    duplicate.position(position - totalRead);
+                if (totalBytesRead > 0) {
+                    duplicate.position(position - totalBytesRead);
                 }
-            } catch (TruncatedChunkException ignore) {
+            } catch (TruncatedChunkException ex) {
                 try {
                     // we should add the EoF character
                     buffer.putInt(-1);
                     duplicate.putInt(-1);
-                } catch (BufferOverflowException e) {
+                } catch (BufferOverflowException ignore) {
                     // ignore
                 }
             }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -30,6 +30,7 @@ import org.apache.synapse.transport.passthru.util.ControlledByteBuffer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -245,17 +246,27 @@ public class Pipe {
         lock.lock();
         try {
             setInputMode(buffer);
+            int totalRead = 0;
             int bytesRead;
             try {
-                bytesRead = decoder.read(buffer.getByteBuffer());
+                // Drain the decoder until the end of the underlying stream is found or until the Pipe#buffer is full.
+                // bytesRead = -1 means reached out to the end of underlying stream.
+                // bytesRead = 0 means Pipe's input buffer is full.
+                while ((bytesRead = decoder.read(buffer.getByteBuffer())) > 0) {
+                    totalRead += bytesRead;
+                }
             } catch (TruncatedChunkException ignore) {
-                // we should add the EoF character
-                buffer.putInt(-1);
-                // now the buffer's position should give us the bytes read.
-                bytesRead = buffer.position();
+                try {
+                    // we should add the EoF character
+                    buffer.putInt(-1);
+                    // now the buffer's position should give us the bytes read.
+                    totalRead = buffer.position();
+                } catch (BufferOverflowException e) {
+                    // ignore
+                }
             }
             producePostActions(decoder);
-            return bytesRead;
+            return totalRead;
         } finally {
             lock.unlock();
         }
@@ -277,22 +288,33 @@ public class Pipe {
         try {
             ByteBuffer duplicate = null;
             setInputMode(buffer);
+            int totalRead = 0;
             int bytesRead;
             try {
                 // clone original buffer
                 ByteBuffer originalBuffer = buffer.getByteBuffer();
-                bytesRead = decoder.read(originalBuffer);
+
+                // Drain the decoder until the end of stream is found or until the Pipe#buffer is full.
+                // bytesRead = -1 means reached out to the end of stream.
+                // bytesRead = 0 means Pipe's input buffer is full.
+                while ((bytesRead = decoder.read(buffer.getByteBuffer())) > 0) {
+                    totalRead += bytesRead;
+                }
                 duplicate = originalBuffer.duplicate();
                 // replicate positions of original buffer in duplicated buffer
                 int position = originalBuffer.position();
                 duplicate.limit(position);
-                if (bytesRead > 0) {
-                    duplicate.position(position - bytesRead);
+                if (totalRead > 0) {
+                    duplicate.position(position - totalRead);
                 }
             } catch (TruncatedChunkException ignore) {
-                // we should add the EoF character
-                buffer.putInt(-1);
-                duplicate.putInt(-1);
+                try {
+                    // we should add the EoF character
+                    buffer.putInt(-1);
+                    duplicate.putInt(-1);
+                } catch (BufferOverflowException e) {
+                    // ignore
+                }
             }
             producePostActions(decoder);
             return duplicate;


### PR DESCRIPTION
## Purpose

According to the existing implementation of Pipe#produce method, decoder.read(buffer.getByteBuffer()) method is only called once. Hence, while consuming the input through Pipe#produce method, the content decoder is not fully drained (not consumed until the end of the stream is read). It just consumes up to the size of the SessionInputBuffer inside the content decoder and returns. 

Now suppose, the server sends a broken chunk with a smaller chunk body than that announced in the chunk header. In this case,  

- The decoder will read a portion of content from the underlying channel and will wait for more data as the chunk header announced a greater value.
- Meanwhile, after processing all the input from the backend, the SSL I/O session will be closed and the selection key's "read" interest will be lost.
- Since there is no more input to be processed and the key does not have the "read" interest, the protocol handler will not be triggered on the inputReady method again.
- This will result in the decoder ending up in an incomplete state.

So, the problem here is that the content decoder is not getting fully drained. If the logic was written to consume all the available content in the underlying channel at a given time, the content decoder would have identified the end of the stream and gone to the complete state. Otherwise, in scenarios like this, the decoder can end up in an incomplete state still waiting for more input while the opposite endpoint is done sending data. 

Fixes: https://github.com/wso2/api-manager/issues/979
