### PR TITLE
Log the local entry endpoint value when local entry is defined as an endpoint key (master fix)

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/EndpointFactory.java
@@ -146,6 +146,11 @@ public abstract class EndpointFactory implements XMLToObjectMapper {
             ep.setDescription(descriptionElem.getText());
         }
 
+        //include the config of local entries in the endpoint object
+        if (ep instanceof AbstractEndpoint && epConfig != null){
+            ((AbstractEndpoint) ep).setValue(epConfig);
+        }
+
         // if the endpoint doesn't have a name we will generate a unique name.
         if (anonymousEndpoint && ep.getName() == null) {
 //            String uuid = UIDGenerator.generateUID();

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/AbstractEndpoint.java
@@ -74,6 +74,9 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
     /** Hold the logical name of an endpoint */
     private String endpointName = null;
 
+    /** Hold the value of the registry entry of an endpoint */
+    private Object value = null;
+
     /** Hold the description of an endpoint */
     private String description = null;
 
@@ -150,6 +153,8 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
         return endpointName;
     }
 
+    public Object getValue() { return value; }
+
     public boolean isInitialized() {
         return initialized;
     }
@@ -225,6 +230,14 @@ public abstract class AbstractEndpoint extends FaultHandler implements Endpoint,
 
             MBeanRegistrar.getInstance().registerMBean(metricsMBean, "Endpoint", endpointName);
         }
+    }
+
+    /**
+     * Set the value of the registry entry of an endpoint
+     * @param value
+     */
+    public void setValue(Object value) {
+        this.value = value;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseXPath.java
@@ -43,6 +43,7 @@ import org.apache.synapse.config.xml.OMElementUtils;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.endpoints.AddressEndpoint;
 import org.apache.synapse.transport.util.MessageHandlerProvider;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
@@ -465,6 +466,14 @@ public class SynapseXPath extends SynapsePath {
                         // Xpath evaluation can return a JSON Elements since property mediator
                         // can store JSON payloads
                         textValue.append(o.toString());
+                    } else if (o instanceof AddressEndpoint) {
+                        // Xpath evaluation can return a AddressEndpoint since call mediator
+                        // can store AddressEndpoint payloads
+                        if (((AddressEndpoint) o).getValue() != null) {
+                            Object tmp = ((AddressEndpoint) o).getValue();
+                            String value = tmp.toString();
+                            textValue.append(value);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Purpose: To resolve issues when logging local entry endpoints when the local entry is defined as an endpoint key.

Fix: Added a value property for endpoint-type objects to return the endpoint def upon request.

The fix is done for wso2mi-4.0.0 in update level 69.