### PR TITLE
Fix copying jms params to synapse messsage context via in proxy listener

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -139,6 +139,7 @@ public final class SynapseConstants {
      * Content-Type property of Axis2MessageContext
      */
     public static final String AXIS2_PROPERTY_CONTENT_TYPE = "ContentType";
+    public static final String SET_JMS_SVC_PARAMS_AS_MSG_CTX_PARAM = "SET_JMS_SVC_PARAMS_AS_MSG_CTX";
 
     /** Parameter names in the axis2.xml that can be used to configure the synapse */
     public static final class Axis2Param {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -20,6 +20,7 @@
 package org.apache.synapse.core.axis2;
 
 import org.apache.axis2.AxisFault;
+import org.apache.axis2.description.Parameter;
 import org.apache.axis2.description.TransportInDescription;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -102,6 +103,15 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
         }
 
         MessageContext synCtx = MessageContextCreatorForAxis2.getSynapseMessageContext(mc);
+        // Read parameters from the axis2 service and set into the synapseMessageCtx
+        Parameter setJmsSvcParamsAsMsgCtxParam = mc.getAxisService()
+                .getParameter(SynapseConstants.SET_JMS_SVC_PARAMS_AS_MSG_CTX_PARAM);
+        if (setJmsSvcParamsAsMsgCtxParam != null && "true".equals(setJmsSvcParamsAsMsgCtxParam.getValue())) {
+            for (Parameter parameter : mc.getAxisService().getParameters()) {
+                synCtx.setProperty(parameter.getName(), parameter.getValue());
+            }
+        }
+
         Integer statisticReportingIndex = null;
         //Statistic reporting
         boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyServiceMessageReceiver.java
@@ -104,11 +104,13 @@ public class ProxyServiceMessageReceiver extends SynapseMessageReceiver {
 
         MessageContext synCtx = MessageContextCreatorForAxis2.getSynapseMessageContext(mc);
         // Read parameters from the axis2 service and set into the synapseMessageCtx
-        Parameter setJmsSvcParamsAsMsgCtxParam = mc.getAxisService()
-                .getParameter(SynapseConstants.SET_JMS_SVC_PARAMS_AS_MSG_CTX_PARAM);
-        if (setJmsSvcParamsAsMsgCtxParam != null && "true".equals(setJmsSvcParamsAsMsgCtxParam.getValue())) {
-            for (Parameter parameter : mc.getAxisService().getParameters()) {
-                synCtx.setProperty(parameter.getName(), parameter.getValue());
+        if (mc != null && mc.getAxisService() != null) {
+            Parameter setJmsSvcParamsAsMsgCtxParam = mc.getAxisService()
+                    .getParameter(SynapseConstants.SET_JMS_SVC_PARAMS_AS_MSG_CTX_PARAM);
+            if (setJmsSvcParamsAsMsgCtxParam != null && "true".equals(setJmsSvcParamsAsMsgCtxParam.getValue())) {
+                for (Parameter parameter : mc.getAxisService().getParameters()) {
+                    synCtx.setProperty(parameter.getName(), parameter.getValue());
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose
This PR copies Proxy listener parameters into the Synapse Message Context.

Fixes https://github.com/wso2/api-manager/issues/936

## Approach
This PR introduces the following parameter in the Proxy listener to copy the parameters into the Synapse Message Context.

```xml
<parameter name="SET_JMS_SVC_PARAMS_AS_MSG_CTX">true</parameter>
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes