### PR TITLE
Upgraded jackson-databind,jackson-core and jackson-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1079,7 +1079,7 @@
          <dependency>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-databind</artifactId>
-              <version>${fasterxml.jackson.version}</version>
+              <version>${fasterxml.jackson-databind.version}</version>
          </dependency>
          <dependency>
               <groupId>com.fasterxml.jackson.core</groupId>
@@ -1566,7 +1566,8 @@
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
       <fge.json.schema.validator.version>2.2.6.wso2v8</fge.json.schema.validator.version>
-      <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
+      <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
+       <fasterxml.jackson-databind.version>2.13.4.2</fasterxml.jackson-databind.version>
       <google.guava.version>31.0.1-jre</google.guava.version>
       <failureaccess.version>1.0.1</failureaccess.version>
       <joda-time.version>2.9.4.wso2v1</joda-time.version>


### PR DESCRIPTION
## Purpose
Upgraded dependencies:
 Jackson Annotations v2.13.1 upgraded to v2.13.4
 Jackson Core v2.13.1 upgraded to v2.13.4
 Jackson Databind v2.13.3 upgraded to v2.13.4.2

## Related issues
[api-manager#1257](https://github.com/wso2/api-manager/issues/1257)
