### PR TITLE
Downgrade Rhino

### DIFF
--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
@@ -20,7 +20,6 @@
 package org.apache.synapse.mediators.bsf.javascript;
 
 import junit.framework.TestCase;
-
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.mediators.bsf.ScriptMediator;
@@ -51,5 +50,17 @@ public class JavaScriptMediatorTest extends TestCase {
 
         mc = TestUtils.getTestContext("<a><b>petra</b></a>", null);
         assertTrue(mediator.mediate(mc));
+    }
+
+    public void testInlineMediatorWithImports() throws Exception {
+
+        String scriptSourceCode = "importClass(Packages.java.util.UUID);\n" +
+                "var uuid = java.util.UUID.randomUUID().toString().replace('-','');\n";
+
+        MessageContext mc = TestUtils.getTestContext("<foo/>", null);
+        ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
+
+        boolean response = mediator.mediate(mc);
+        assertTrue(response);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1518,7 +1518,7 @@
       <xmlsec.version>1.4.2</xmlsec.version>
       <xalan.version>2.7.2</xalan.version>
       <xerces.version>2.12.2.wso2v1</xerces.version>
-      <js.version>1.7.14.wso2v1</js.version>
+      <js.version>1.7.13.wso2v1</js.version>
       <!-- startup, quartz -->
       <commons-collections.version>3.2.1</commons-collections.version>
       <quartz.version>2.3.2</quartz.version>
@@ -1576,7 +1576,7 @@
       <jacoco.ant.version>0.8.6</jacoco.ant.version>
       <dataprovider.version>1.13.1</dataprovider.version>
       <activemq.version>5.2.0</activemq.version>
-      <rhino.version>1.7.14</rhino.version>
+      <rhino.version>1.7.13</rhino.version>
       <jetty.version>7.2.0.v20101020</jetty.version>
        <xml.apis.version>1.4.01</xml.apis.version>
       <!-- The Java version used to execute maven-antrun-plugin in the integration module.


### PR DESCRIPTION
## Purpose

Due to an API change in the latest Mozilla Rhino version 1.7.14, Script Mediator's `importClass` method was throwing an error.
Therefore, rhino will be downgraded to version 1.7.13

Fixes https://github.com/wso2/api-manager/issues/1337