### PR TITLE
Move request message discard logic from TargetHandler to ClientWorker

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
@@ -42,6 +42,7 @@ import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.transport.http.conn.SynapseDebugInfoHolder;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.config.TargetConfiguration;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -235,6 +236,11 @@ public class ClientWorker implements Runnable {
                        getContext().setAttribute(PassThroughConstants.CLIENT_WORKER_START_TIME, System.currentTimeMillis());
         }
         try {
+            // If an error has happened in the request processing, consumes the data in pipe completely and discard it
+            if (response.isForceShutdownConnectionOnComplete()) {
+                RelayUtils.discardRequestMessage(requestMessageContext);
+            }
+
             if (expectEntityBody) {
             	  String cType = response.getHeader(HTTP.CONTENT_TYPE);
                   if(cType == null){

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -94,7 +94,7 @@ public class PassThroughConstants {
             "PASS_THROUGH_TRANSPORT_WORKER_POOL";
     protected static final String PASS_THROUGH_SOURCE_CONFIGURATION =
             "PASS_THROUGH_SOURCE_CONFIGURATION";
-    protected static final String PASS_THROUGH_SOURCE_CONNECTION = "pass-through.Source-Connection";
+    public static final String PASS_THROUGH_SOURCE_CONNECTION = "pass-through.Source-Connection";
     protected static final String PASS_THROUGH_SOURCE_REQUEST = "pass-through.Source-Request";
 
     protected static final String PASS_THROUGH_TARGET_CONNECTION = "pass-through.Target-Connection";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -398,7 +398,6 @@ public class TargetHandler implements NHttpClientEventHandler {
             if (connState != ProtocolState.REQUEST_DONE) {
                 isError = true;
                 MessageContext requestMsgContext = TargetContext.get(conn).getRequestMsgCtx();
-                RelayUtils.consumeAndDiscardMessage(requestMsgContext);
                 // State is not REQUEST_DONE. i.e the request is not completely written. But the response is started
                 // receiving, therefore informing a write error has occurred. So the thread which is
                 // waiting on writing the request out, will get notified.

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetResponse.java
@@ -278,4 +278,9 @@ public class TargetResponse {
         }
         return keepAliveTimeout;
     }
+
+    public boolean isForceShutdownConnectionOnComplete() {
+
+        return forceShutdownConnectionOnComplete;
+    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -36,6 +36,11 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpRequest;
+import org.apache.http.nio.NHttpServerConnection;
+import org.apache.http.nio.reactor.IOSession;
+import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.transport.http.conn.LoggingNHttpServerConnection;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.Pipe;
@@ -520,7 +525,36 @@ public class RelayUtils {
         if (outTransportInfo instanceof ServerWorker) {
             requestContext = ((ServerWorker) outTransportInfo).getRequestContext();
         }
+        log.warn("Server encountered an error, the request message will be consumed and discarded, " +
+                getRequestInfoForLogging(requestContext) + ", Correlation ID = " +
+                requestContext.getProperty(CorrelationConstants.CORRELATION_ID));
         discardMessage(requestContext);
+    }
+
+    /**
+     * Generate a log message containing the request information for the given message context.
+     *
+     * @param msgContext Axis2 Message context which contains the data
+     * @return a log message containing the request information
+     */
+    private static String getRequestInfoForLogging(MessageContext msgContext) {
+
+        NHttpServerConnection conn = (NHttpServerConnection) msgContext.getProperty(
+                PassThroughConstants.PASS_THROUGH_SOURCE_CONNECTION);
+        if (conn instanceof LoggingNHttpServerConnection) {
+            StringBuilder requestInfo = new StringBuilder();
+            HttpRequest httpRequest = conn.getHttpRequest();
+            if (httpRequest != null) {
+                requestInfo.append("HTTP_URL = ").append(httpRequest.getRequestLine().getUri()).append(", ")
+                        .append("HTTP_METHOD = ").append(httpRequest.getRequestLine().getMethod());
+            }
+            IOSession session = ((LoggingNHttpServerConnection) conn).getIOSession();
+            if (session != null && session.getRemoteAddress() != null) {
+                requestInfo.append(", CLIENT_ADDRESS = ").append(session.getRemoteAddress().toString());
+            }
+            return requestInfo.toString();
+        }
+        return "";
     }
 
     /**


### PR DESCRIPTION
## Purpose

Previously, in error scenarios, the Passthrough Pipe was consumed and discarded in the TargetHandler. As a result, the HTTPS-Sender I/O dispatcher thread will get blocked until the timeout. Therefore the discard logic is moved to the ClientWorker, in which a PassThroughMessageProcessor thread will be used.

When the request message is discarded the following warn log will be printed,

```
WARN {RelayUtils} - Server encountered an error, the request message  will be consumed and discarded, HTTP_URL = /testing/v1, HTTP_METHOD = POST, CLIENT_ADDRESS = /127.0.0.1:47400, Correlation ID = aa63de06-9323-49e1-80c0-fe2ccad5c11d
```

In the existing code, we have return statements in the following paths before delegating the request to the client worker,

1 - [statusCode == HttpStatus.SC_REQUEST_TIMEOUT](https://github.com/wso2-support/wso2-synapse/blob/support-2.1.7-wso2v183.14-BNYMELLONPROD-hotfix-x/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java#L397)

But this path is called only when the requestMsgContext is null. Since the requestMsgContext is null, we don't need to discard the message

2 - [handleInvalidState(conn, "Receiving response")](https://github.com/wso2-support/wso2-synapse/blob/support-2.1.7-wso2v183.14-BNYMELLONPROD-hotfix-x/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java#L403)

When the BE don't send the Status line, the connection will get closed by the HTTPCore itself and the request won't reach here.

Fixes: https://github.com/wso2/api-manager/issues/1470