### PR TITLE
Introduce system property to change crypto provider

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/crypto/CryptoConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/crypto/CryptoConstants.java
@@ -65,6 +65,11 @@ public interface CryptoConstants {
      */
     public final static String BOUNCY_CASTLE_PROVIDER = "BC";
 
+    /**
+     * BouncyCastle FIPS provider "BCFIPS"
+     */
+    public final static String BOUNCY_CASTLE_FIPS_PROVIDER = "BCFIPS";
+
 
     /**
      * Secure vault namespace to be used when resolving axis2 config passwords.

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/certificatevalidation/Constants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/certificatevalidation/Constants.java
@@ -29,4 +29,7 @@ public interface Constants {
     public static final int CACHE_MAX_DELAY_MINS = 60 * 24;
     public static final int CACHE_MIN_DELAY_MINS = 1;
     public static final int CACHE_DEFAULT_DELAY_MINS = 15;
+
+    public static final String BOUNCY_CASTLE_PROVIDER = "BC";
+    public static final String BOUNCY_CASTLE_FIPS_PROVIDER = "BCFIPS";
 }


### PR DESCRIPTION
## Purpose
This PR introduces a new System property `security.jce.provider` which can be used to change the Crypto Provider from its default `BouncyCastleProvider` for  `BouncyCastleFipsProvider`.

Related to https://github.com/wso2/api-manager/issues/1219

## Approach
To toggle the Crypto Provider to the `BouncyCastleFipsProvider` provider, provide the following system provider while starting up the server.

```sh
... -Dsecurity.jce.provider=BCFIPS ...
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes