### PR TITLE
Fix ClassNotFoundException due to X509V1CertImpl removed in JDK 17

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerWorker.java
@@ -49,6 +49,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.*;
 
 /**
@@ -166,8 +168,16 @@ public class ServerWorker implements Runnable {
             if (session != null && msgContext.getTransportIn() != null
                 && msgContext.getTransportIn().getParameter(NhttpConstants.SSL_VERIFY_CLIENT) != null) {
                 try {
-                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509,
-                                           session.getSSLSession().getPeerCertificateChain());
+                    Certificate[] certificates = session.getSSLSession().getPeerCertificates();
+                    X509Certificate[] x509Certificates = new X509Certificate[certificates.length];
+                    for (int i = 0; i < certificates.length; i++) {
+                        if (certificates[i] instanceof X509Certificate) {
+                            x509Certificates[i] = (X509Certificate) certificates[i];
+                        }
+                    }
+                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509, x509Certificates);
+                    msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT,
+                            session.getSSLSession().getPeerCertificates());
                 } catch (SSLPeerUnverifiedException e) {
                     //Peer Certificate Chain may not be available always.(in case of verify client is optional)
                     if (log.isTraceEnabled()) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -71,14 +71,12 @@ import org.apache.synapse.transport.passthru.util.SourceResponseFactory;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.CertificateException;
-import javax.security.cert.X509Certificate;
 import javax.xml.parsers.FactoryConfigurationError;
 
 /**
@@ -555,10 +553,8 @@ public class ServerWorker implements Runnable {
                     Certificate[] certificates = ssliosession.getSSLSession().getPeerCertificates();
                     X509Certificate[] x509Certificates = new X509Certificate[certificates.length];
                     for (int i = 0; i < certificates.length; i++) {
-                        try {
-                            x509Certificates[i] = X509Certificate.getInstance(certificates[i].getEncoded());
-                        } catch (CertificateException | CertificateEncodingException e) {
-                            log.error("Error while converting client certificate", e);
+                        if (certificates[i] instanceof X509Certificate) {
+                            x509Certificates[i] = (X509Certificate) certificates[i];
                         }
                     }
                     msgContext.setProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509, x509Certificates);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/1123