### PR TITLE
Fixed ftl file reference issue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -189,7 +189,8 @@ public class PayloadFactoryMediator extends AbstractMediator {
             } else if (entry instanceof String) {
                 text = (String) entry;
             }
-            if (reCreate) {
+            boolean templateLoaded = templateProcessor.getTemplateStatus();
+            if (reCreate || !templateLoaded) {
                 templateProcessor.setFormat(text);
                 templateProcessor.init();
             }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/FreeMarkerTemplateProcessor.java
@@ -90,6 +90,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
     private boolean usingArgs;
 
     private static final Log log = LogFactory.getLog(FreeMarkerTemplateProcessor.class);
+    private boolean templateLoaded = false;
 
     private static final String DEFAULT_FREEMARKER_BASE_PATH_CONF = "conf:/";
     private static final String DEFAULT_FREEMARKER_BASE_PATH_GOV = "gov:/";
@@ -116,6 +117,7 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
         String format = getFormat();
         if (format != null) {
             compileFreeMarkerTemplate(format, getMediaType());
+            templateLoaded = true;
         }
     }
 
@@ -491,4 +493,14 @@ public class FreeMarkerTemplateProcessor extends TemplateProcessor {
 
         return NOT_SUPPORTING_PAYLOAD_TYPE;
     }
+
+    /**
+     * Get whether the template format was received
+     *
+     * @return Status of the format of the template
+     */
+    public boolean getTemplateStatus(){
+        return templateLoaded;
+    }
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -97,4 +97,15 @@ public class RegexTemplateProcessor extends TemplateProcessor {
         replacement = argValues[argIndex - 1];
         return replacement;
     }
+
+    /**
+     * Get whether the template format was received
+     *
+     * @return Status of the format of the template
+     */
+    public boolean getTemplateStatus(){
+        // since this method is added to the freemarker template, it is here for consistency
+        return true;
+    }
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -524,4 +524,6 @@ public abstract class TemplateProcessor {
         throw new TemplateProcessorException(msg);
     }
 
+    public abstract boolean getTemplateStatus();
+
 }


### PR DESCRIPTION
The reason for the issue was the expiring time of the template which was set to 1500ms. Due to that when accessing ftl via a proxy service after the API call, if the expiry time is not reached, the payload was not used.

Public Git Issue: https://github.com/wso2/api-manager/issues/1520