### PR TITLE
Fix inconsistency in CORS

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/api/cors/CORSHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/cors/CORSHelper.java
@@ -20,9 +20,11 @@ package org.apache.synapse.api.cors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
 
 import java.util.Map;
 import java.util.Set;
@@ -82,6 +84,12 @@ public class CORSHelper {
                         corsConfiguration.getAllowedHeaders());
                 synCtx.setProperty(RESTConstants.INTERNAL_CORS_HEADER_ORIGIN,
                         transportHeaders.get(RESTConstants.CORS_HEADER_ORIGIN));
+
+                // If the request origin is not allowed, set the status code to 403
+                if (isOptionsRequest(synCtx) && allowedOrigin == null) {
+                    ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                            .setProperty(PassThroughConstants.HTTP_SC, HttpStatus.SC_FORBIDDEN);
+                }
             }
         }
 
@@ -123,4 +131,9 @@ public class CORSHelper {
         }
     }
 
+    private static boolean isOptionsRequest(MessageContext synCtx) {
+
+        String method = (String) synCtx.getProperty(RESTConstants.REST_METHOD);
+        return RESTConstants.METHOD_OPTIONS.equals(method);
+    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/SourceResponseFactory.java
@@ -153,11 +153,32 @@ public class SourceResponseFactory {
 	private static void addResponseHeader(SourceResponse sourceResponse, Map transportHeaders) {
 	    for (Object entryObj : transportHeaders.entrySet()) {
 	        Map.Entry entry = (Map.Entry) entryObj;
-	        if (entry.getValue() != null && entry.getKey() instanceof String &&
-	                entry.getValue() instanceof String) {
-	            sourceResponse.addHeader((String) entry.getKey(), (String) entry.getValue());
+	        String headerValue = getHeaderValueAsString(entry.getValue());
+	        if (entry.getKey() instanceof String && headerValue != null) {
+	            sourceResponse.addHeader((String) entry.getKey(), headerValue);
 	        }
 	    }
+    }
+
+    /**
+     * Get the header value as a string.
+     * <p>
+     * If the header value is a string, return it
+     * If the header value is null, return empty string. otherwise the header will get dropped
+     * Else return null to drop the header
+     * </p>
+     *
+     * @param value the header value
+     * @return the header value as a string
+     */
+    private static String getHeaderValueAsString(Object value) {
+
+        if (value instanceof String) {
+            return (String) value;
+        } else if (value == null) {
+            return "";
+        }
+        return null;
     }
 
     private static boolean isPayloadOptionalMethod(String httpMethod) {


### PR DESCRIPTION
## Purpose
This PR will fix the following inconsistencies in CORS If the CORS validation is failed, 

- A `403 Forbidden` HTTP status code will be sent to the client
- Respond back with an empty `Access-Control-Allow-Origin` header

Fixes: https://github.com/wso2/api-manager/issues/1567