### PR TITLE
Close target connection upon endpoint timeout

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
@@ -21,6 +21,7 @@ package org.apache.synapse.core.axis2;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axis2.description.TransportOutDescription;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.FaultHandler;
@@ -233,8 +234,11 @@ public class TimeoutHandler extends TimerTask {
                     if (RuntimeStatisticCollector.isStatisticsEnabled()) {
                         CallbackStatisticCollector.callbackCompletionEvent(callback.getSynapseOutMsgCtx(), (String) key);
                     }
-                    // Call the TransportSender's onAppError method to release any resources
-                    callback.getAxis2OutMsgCtx().getTransportOut().getSender().onAppError(callback.getAxis2OutMsgCtx());
+                    TransportOutDescription transportOut = callback.getAxis2OutMsgCtx().getTransportOut();
+                    if (transportOut != null && transportOut.getSender() != null) {
+                        // Call the TransportSender's onAppError method to release any resources
+                        transportOut.getSender().onAppError(callback.getAxis2OutMsgCtx());
+                    }
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/TimeoutHandler.java
@@ -233,6 +233,8 @@ public class TimeoutHandler extends TimerTask {
                     if (RuntimeStatisticCollector.isStatisticsEnabled()) {
                         CallbackStatisticCollector.callbackCompletionEvent(callback.getSynapseOutMsgCtx(), (String) key);
                     }
+                    // Call the TransportSender's onAppError method to release any resources
+                    callback.getAxis2OutMsgCtx().getTransportOut().getSender().onAppError(callback.getAxis2OutMsgCtx());
                 }
             }
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -259,6 +259,9 @@ public class DeliveryAgent {
                 MessageContext messageContext = queue.poll();
 
                 if (messageContext != null) {
+                    messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONNECTION, conn);
+                    messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONFIGURATION,
+                            targetConfiguration);
                     tryNextMessage(messageContext, route, conn);
                     conn = null;
                 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -96,7 +96,7 @@ public class PassThroughConstants {
             "PASS_THROUGH_SOURCE_CONFIGURATION";
     public static final String PASS_THROUGH_SOURCE_CONNECTION = "pass-through.Source-Connection";
     protected static final String PASS_THROUGH_SOURCE_REQUEST = "pass-through.Source-Request";
-
+    protected static final String PASS_THROUGH_TARGET_CONFIGURATION = "PASS_THROUGH_TARGET_CONFIGURATION";
     protected static final String PASS_THROUGH_TARGET_CONNECTION = "pass-through.Target-Connection";
     protected static final String PASS_THROUGH_TARGET_RESPONSE = "pass-through.Target-Response";
 


### PR DESCRIPTION
## Purpose
In the current architecture, when the endpoint timeouts the timeout handler will call the fault sequence and finish the mediation flow for that request. But the connection to the backend is not closed until the socket timeout.

This fix will improve the architecture to close the socket connection when an endpoint timeout happens for HTTP transport.

Fixes: https://github.com/wso2/api-manager/issues/1746