### PR TITLE
Fix input read failure when connection is reused

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
@@ -187,6 +187,8 @@ public class TargetConnections {
                 PassThroughConstants.CONNECTION_POOL);
 
         TargetContext.get(conn).reset(false);
+        //Set the event mask to Read since connection is released to the pool and should be ready to read
+        conn.requestInput();
 
         if (pool != null) {
             pool.release(conn);


### PR DESCRIPTION
Issue here is when there is an exact amount of bytes equal to the buffer (or Greater than the buffer), in the producePostActions() method we call suspendInput() in the underlying connection.
So when we write back bytes to the source, we are supposed to reset this flag in consumePostActions() method to free the connection to use for consuming backend input. But in the first case (bytes are exactly equal to buffer size) we are not free up the connection. So as the solution lift the event mask when releasing the connection

Fixes: wso2/api-manager#1779