### PR TITLE
Remove msgCtx in SchemaResourceResolver after the Validate mediation

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -416,14 +416,16 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
                         // Generating a cached schema key
                         cachedSchemaKey.append(propName);
                     }
+                    SchemaResourceResolver schemaResourceResolver =
+                            new SchemaResourceResolver(synCtx.getConfiguration(), resourceMap);
                     // load the UserDefined SchemaURIResolver implementations
                     try {
                         SynapseConfiguration synCfg = synCtx.getConfiguration();
                         if (synCfg.getProperty(SynapseConstants.SYNAPSE_SCHEMA_RESOLVER) != null) {
                             setUserDefinedSchemaResourceResolver(synCtx);
                         } else {
-                            factory.setResourceResolver(
-                                    new SchemaResourceResolver(synCtx.getConfiguration(), resourceMap, synCtx));
+                            if (resourceMap != null) schemaResourceResolver.setMessageContext(synCtx);
+                            factory.setResourceResolver(schemaResourceResolver);
                         }
                         if (cacheSchema) {
                             cachedSchema = factory.newSchema(sources);
@@ -452,6 +454,8 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
                     } catch (RuntimeException e) {
                         handleException("Error creating a new schema objects for " +
                                         "schemas : " + schemaKeys.toString(), e, synCtx);
+                    } finally {
+                        schemaResourceResolver.setMessageContext(null);
                     }
 
                     if (errorHandler.isValidationError()) {

--- a/modules/core/src/main/java/org/apache/synapse/util/jaxp/SchemaResourceResolver.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/jaxp/SchemaResourceResolver.java
@@ -28,6 +28,11 @@ public class SchemaResourceResolver implements LSResourceResolver {
         this.messageContext = messageContext;
     }
 
+    public SchemaResourceResolver(SynapseConfiguration synCfg, ResourceMap resourceMap) {
+        this.resourceMap = resourceMap;
+        this.synCfg = synCfg;
+    }
+
     /**
      * Lookup in {@link org.apache.synapse.util.resolver.ResourceMap} and returns
      * {@link org.apache.synapse.util.jaxp.SchemaResourceLSInput}
@@ -58,6 +63,10 @@ public class SchemaResourceResolver implements LSResourceResolver {
         schemaResourceLSInput.setPublicId(publicId);
         schemaResourceLSInput.setBaseURI(baseURI);
         return schemaResourceLSInput;
+    }
+
+    public void setMessageContext(MessageContext messageContext) {
+        this.messageContext = messageContext;
     }
 }
 


### PR DESCRIPTION
## Purpose
Remove msgCtx in SchemaResourceResolver after the Validate mediation to fix the high heap utilization issue when a large number of Validate mediators are used.

Fixes: https://github.com/wso2/api-manager/issues/1897