### PR TITLE
Fix Passthrough Threads getting stuck due to request message discard

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
@@ -263,11 +263,6 @@ public class ClientWorker implements Runnable {
                        getContext().setAttribute(PassThroughConstants.CLIENT_WORKER_START_TIME, System.currentTimeMillis());
         }
         try {
-            // If an error has happened in the request processing, consumes the data in pipe completely and discard it
-            // If the consumeAndDiscard property is set to true
-            if (response.isForceShutdownConnectionOnComplete() && conf.isConsumeAndDiscard()) {
-                RelayUtils.discardRequestMessage(requestMessageContext);
-            }
             if (expectEntityBody) {
             	  String cType = response.getHeader(HTTP.CONTENT_TYPE);
                   if(cType == null){

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/MessageDiscardWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/MessageDiscardWorker.java
@@ -1,0 +1,97 @@
+/**
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.synapse.transport.passthru;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.nio.NHttpClientConnection;
+import org.apache.http.nio.NHttpServerConnection;
+import org.apache.synapse.transport.passthru.config.TargetConfiguration;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+
+public class MessageDiscardWorker implements Runnable {
+
+    private Log log = LogFactory.getLog(MessageDiscardWorker.class);
+    private ClientWorker clientWorker = null;
+
+    TargetConfiguration targetConfiguration = null;
+
+    private TargetResponse response = null;
+
+    private MessageContext requestMessageContext;
+
+    NHttpClientConnection conn = null;
+
+    public MessageDiscardWorker(MessageContext requestMsgContext, TargetResponse response,
+                                TargetConfiguration targetConfiguration, ClientWorker clientWorker, NHttpClientConnection conn) {
+        this.response = response;
+        this.requestMessageContext = requestMsgContext;
+        this.targetConfiguration = targetConfiguration;
+        this.clientWorker = clientWorker;
+        this.conn = conn;
+    }
+
+    public void run() {
+
+        // If an error has happened in the request processing, consumes the data in pipe completely and discard it
+        try {
+            RelayUtils.discardRequestMessage(requestMessageContext);
+        } catch (AxisFault af) {
+            log.error("Fault discarding request message", af);
+        }
+
+        targetConfiguration.getWorkerPool().execute(clientWorker);
+
+        targetConfiguration.getMetrics().incrementMessagesReceived();
+
+        NHttpServerConnection sourceConn = (NHttpServerConnection) requestMessageContext.getProperty(
+                PassThroughConstants.PASS_THROUGH_SOURCE_CONNECTION);
+        if (sourceConn != null) {
+            sourceConn.getContext().setAttribute(PassThroughConstants.RES_HEADER_ARRIVAL_TIME,
+                    conn.getContext()
+                            .getAttribute(PassThroughConstants.RES_HEADER_ARRIVAL_TIME)
+            );
+            conn.getContext().removeAttribute(PassThroughConstants.RES_HEADER_ARRIVAL_TIME);
+
+            sourceConn.getContext().setAttribute(PassThroughConstants.REQ_DEPARTURE_TIME,
+                    conn.getContext()
+                            .getAttribute(PassThroughConstants.REQ_DEPARTURE_TIME)
+            );
+            conn.getContext().removeAttribute(PassThroughConstants.REQ_DEPARTURE_TIME);
+            sourceConn.getContext().setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME,
+                    conn.getContext()
+                            .getAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME)
+            );
+
+            conn.getContext().removeAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_START_TIME);
+            sourceConn.getContext().setAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME,
+                    conn.getContext()
+                            .getAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME)
+            );
+            conn.getContext().removeAttribute(PassThroughConstants.REQ_TO_BACKEND_WRITE_END_TIME);
+            sourceConn.getContext().setAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_START_TIME,
+                    conn.getContext()
+                            .getAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_START_TIME)
+            );
+            conn.getContext().removeAttribute(PassThroughConstants.RES_FROM_BACKEND_READ_START_TIME);
+
+        }
+
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/MessageDiscardWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/MessageDiscardWorker.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org)
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -663,16 +663,16 @@ public class SourceHandler implements NHttpServerEventHandler {
             if (msg.indexOf("broken") != -1) {
                 log.warn("I/O error (Probably the connection "
                         + "was closed by the remote party):" + e.getMessage()
-                        + "CORRELATION_ID = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID));
+                        + ", CORRELATION_ID = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID));
             } else {
-                log.error("I/O error: " + e.getMessage() + "CORRELATION_ID = "
+                log.error("I/O error: " + e.getMessage() + ", CORRELATION_ID = "
                         + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID), e);
             }
 
             metrics.incrementFaultsReceiving();
         } else {
             log.error("Unexpected I/O error: " + e.getClass().getName()
-                    + "CORRELATION_ID = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID), e);
+                    + ", CORRELATION_ID = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID), e);
 
             metrics.incrementFaultsReceiving();
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -515,6 +515,14 @@ public class TargetHandler implements NHttpClientEventHandler {
             if (statusCode == HttpStatus.SC_ACCEPTED && handle202(requestMsgContext)) {
                 return;
             }
+            if (targetResponse.isForceShutdownConnectionOnComplete() && conf.isConsumeAndDiscard()) {
+                ClientWorker clientWorker = new ClientWorker(targetConfiguration, requestMsgContext, targetResponse,
+                        allowedResponseProperties);
+                targetConfiguration.getSecondaryWorkerPool().execute(new MessageDiscardWorker(requestMsgContext,
+                        targetResponse, targetConfiguration, clientWorker, conn));
+                return;
+            }
+
             WorkerPool workerPool = targetConfiguration.getWorkerPool();
             workerPool.execute(
                     new ClientWorker(targetConfiguration, requestMsgContext, targetResponse,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/BaseConfiguration.java
@@ -49,6 +49,9 @@ public abstract class BaseConfiguration {
     /** The thread pool for executing the messages passing through */
     private WorkerPool workerPool = null;
 
+    /** The secondary thread pool for executing the messages passing through */
+    private WorkerPool secondaryWorkerPool = null;
+
     /** The Axis2 ConfigurationContext */
     protected ConfigurationContext configurationContext = null;
 
@@ -76,6 +79,10 @@ public abstract class BaseConfiguration {
     private static final String PASSTHROUGH_THREAD_GROUP = "Pass-through Message Processing Thread Group";
     private static final String PASSTHROUGH_THREAD_ID ="PassThroughMessageProcessor";
 
+    private static final String SECONDARY_PASSTHROUGH_THREAD_GROUP = "Secondary Pass-through Message Processing "
+            + "Thread Group";
+    private static final String SECONDARY_PASSTHROUGH_THREAD_ID = "PassThroughMessageSecondaryProcessor";
+
     private Integer socketTimeout = null;
     private Integer connectionTimeout = null;
 
@@ -100,6 +107,16 @@ public abstract class BaseConfiguration {
                             conf.getWorkerPoolQueueLen(),
                             PASSTHROUGH_THREAD_GROUP,
                             PASSTHROUGH_THREAD_ID);
+        }
+
+        if (secondaryWorkerPool == null) {
+            secondaryWorkerPool = WorkerPoolFactory.getWorkerPool(
+                    conf.getSecondaryWorkerPoolCoreSize(),
+                    conf.getSecondaryWorkerPoolMaxSize(),
+                    conf.getSecondaryWorkerThreadKeepaliveSec(),
+                    conf.getSecondaryWorkerPoolQueueLen(),
+                    SECONDARY_PASSTHROUGH_THREAD_GROUP,
+                    SECONDARY_PASSTHROUGH_THREAD_ID);
         }
 
         httpParams = buildHttpParams();
@@ -147,6 +164,9 @@ public abstract class BaseConfiguration {
 
     public WorkerPool getWorkerPool() {
         return workerPool;
+    }
+    public WorkerPool getSecondaryWorkerPool() {
+        return secondaryWorkerPool;
     }
 
     public ConfigurationContext getConfigurationContext() {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -50,6 +50,26 @@ public interface PassThroughConfigPNames {
     public String IO_THREADS_PER_REACTOR = "io_threads_per_reactor";
 
     /**
+     * Defines the core size (number of threads) of the secondary worker thread pool.
+     */
+    public String SECONDARY_WORKER_POOL_SIZE_CORE = "secondary_worker_pool_size_core";
+
+    /**
+     * Defines the maximum size (number of threads) of the secondary worker thread pool.
+     */
+    public String SECONDARY_WORKER_POOL_SIZE_MAX = "secondary_worker_pool_size_max";
+
+    /**
+     * Defines the keep-alive time for extra threads in the secondary worker pool.
+     */
+    public String SECONDARY_WORKER_THREAD_KEEPALIVE_SEC = "secondary_worker_thread_keepalive_sec";
+
+    /**
+     * Defines the length of the queue that is used to hold Runnable tasks to be executed by the
+     * secondary worker pool.
+     */
+    public String SECONDARY_WORKER_POOL_QUEUE_LENGTH = "secondary_worker_pool_queue_length";
+    /**
      * Defines the IO buffer size
      */
     public String IO_BUFFER_SIZE = "io_buffer_size";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -91,9 +91,17 @@ public class PassThroughConfiguration {
         return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.WORKER_POOL_SIZE_CORE,
                 DEFAULT_WORKER_POOL_SIZE_CORE, props);
     }
+    public int getSecondaryWorkerPoolCoreSize() {
+        return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.SECONDARY_WORKER_POOL_SIZE_CORE,
+                DEFAULT_WORKER_POOL_SIZE_CORE, props);
+    }
 
     public int getWorkerPoolMaxSize() {
         return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.WORKER_POOL_SIZE_MAX,
+                DEFAULT_WORKER_POOL_SIZE_MAX, props);
+    }
+    public int getSecondaryWorkerPoolMaxSize() {
+        return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.SECONDARY_WORKER_POOL_SIZE_MAX,
                 DEFAULT_WORKER_POOL_SIZE_MAX, props);
     }
 
@@ -102,8 +110,18 @@ public class PassThroughConfiguration {
                 DEFAULT_WORKER_THREAD_KEEPALIVE_SEC, props);
     }
 
+    public int getSecondaryWorkerThreadKeepaliveSec() {
+        return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.SECONDARY_WORKER_THREAD_KEEPALIVE_SEC,
+                DEFAULT_WORKER_THREAD_KEEPALIVE_SEC, props);
+    }
+
     public int getWorkerPoolQueueLen() {
         return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.WORKER_POOL_QUEUE_LENGTH,
+                DEFAULT_WORKER_POOL_QUEUE_LENGTH, props);
+    }
+
+    public int getSecondaryWorkerPoolQueueLen() {
+        return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.SECONDARY_WORKER_POOL_QUEUE_LENGTH,
                 DEFAULT_WORKER_POOL_QUEUE_LENGTH, props);
     }
 


### PR DESCRIPTION


## Purpose
Adding new worker pool (RequestMessageDiscardWorkerPool) to discard request messages So ClientWorker (Passthrough Message Processor) threads won't get stucked while draining the input stream. Also remove setting REQUEST_DONE state in SourceContext when Error Scenario since when discarding the message we automatically set REQUEST_DONE in SourceHandler.

Fixes: https://github.com/wso2/api-manager/issues/1792