### PR TITLE
Fix last-modified timestamp not getting honored when using VFSTransportSender

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSOutTransportInfo.java
@@ -53,6 +53,7 @@ public class VFSOutTransportInfo implements OutTransportInfo {
     private boolean sendFileSynchronously = false;
     //When the folder structure does not exists forcefully create
     private boolean forceCreateFolder = false;
+    private boolean updateLastModified = true;
     
     private static final String[] uriParamsToDelete = {VFSConstants.APPEND+"=true", VFSConstants.APPEND+"=false"};
 
@@ -144,6 +145,11 @@ public class VFSOutTransportInfo implements OutTransportInfo {
         if (properties.containsKey(VFSConstants.APPEND)) {
             String strAppend = properties.get(VFSConstants.APPEND);
             append = Boolean.parseBoolean(strAppend);
+        }
+
+        if (properties.containsKey(VFSConstants.UPDATE_LAST_MODIFIED)) {
+            String strUpdateLastModified = properties.get(VFSConstants.UPDATE_LAST_MODIFIED);
+            updateLastModified = Boolean.parseBoolean(strUpdateLastModified);
         }
 
         if (log.isDebugEnabled()) {
@@ -286,5 +292,9 @@ public class VFSOutTransportInfo implements OutTransportInfo {
     public void setForceCreateFolder(boolean forceCreateFolder) {
         this.forceCreateFolder = forceCreateFolder;
     }
-    
+
+    public boolean isUpdateLastModified() {
+
+        return updateLastModified;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1490,7 +1490,7 @@
        <orbit.version.tomcat>${version.tomcat}.wso2v1</orbit.version.tomcat>
       <commons.pool.version>1.3</commons.pool.version>
       <commons.pool.wso2.version>1.5.0.wso2v1</commons.pool.wso2.version>
-      <commons.vfs.version>2.2.0-wso2v15</commons.vfs.version>
+      <commons.vfs.version>2.2.0-wso2v16</commons.vfs.version>
       <truezip.version>6.6</truezip.version>
       <commons.net.version>3.9.0</commons.net.version>
       <commons.net.wso2.version>${commons.net.version}.wso2v1</commons.net.wso2.version>


### PR DESCRIPTION
## Purpose

Fix the last-modified timestamp not getting honored when using VFSTransportSender.

We have read the `transport.vfs.UpdateLastModified` query param from the final output file URI. In case we have specified a directory as the endpoint URI, the generated output file URI, will not contain the query params.
Therefore we should read `transport.vfs.UpdateLastModified` param from the endpoint URI and update the VFSOutTransportInfo accordingly.

By default, `transport.vfs.UpdateLastModified` will be set to true and the newly created file will have the same timestamp as the original file.

Fixes: https://github.com/wso2/api-manager/issues/1909