### PR TITLE
Add aouth connection timeout for endpoint

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -42,6 +42,12 @@ public class AuthConstants {
     public static final String CUSTOM_HEADER = "header";
     public static final String NAME = "name";
 
+    public static final String OAUTH_CONNECTION_TIMEOUT = "connectionTimeout";
+
+    public static final String OAUTH_CONNECTION_REQUEST_TIMEOUT = "connectionRequestTimeout";
+
+    public static final String OAUTH_SOCKET_TIMEOUT = "socketTimeout";
+
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER = "Bearer ";
     public static final String BASIC = "Basic ";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthException.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthException.java
@@ -33,6 +33,11 @@ public class AuthException extends Exception {
         super(message);
     }
 
+    public AuthException(String message, Exception e) {
+
+        super(message, e);
+    }
+
     public AuthException(Throwable e) {
 
         super(e);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -34,9 +34,11 @@ public class AuthorizationCodeHandler extends OAuthHandler {
     private final String refreshToken;
 
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret,
-                                    String refreshToken, String authMode) {
+                                    String refreshToken, String authMode, int connectionTimeout,
+                                    int connectionRequestTimeout, int socketTimeout) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode);
+        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout,
+                socketTimeout);
         this.refreshToken = refreshToken;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -31,9 +31,10 @@ import org.apache.synapse.endpoints.auth.AuthException;
  */
 public class ClientCredentialsHandler extends OAuthHandler {
 
-    public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode) {
+    public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
+                                    int connectionTimeout, int connectionRequestTimeout, int socketTimeout) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode);
+        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -53,14 +53,21 @@ public abstract class OAuthHandler implements AuthHandler {
     private Map<String, String> requestParametersMap;
     private Map<String, String> customHeadersMap;
     private final String authMode;
+    protected final int connectionTimeout;
+    protected final int connectionRequestTimeout;
+    protected final int socketTimeout;
 
-    protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode) {
+    protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
+                           int connectionTimeout, int connectionRequestTimeout, int socketTimeout) {
 
         this.id = OAuthUtils.getRandomOAuthHandlerID();
         this.tokenApiUrl = tokenApiUrl;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authMode = authMode;
+        this.connectionTimeout = connectionTimeout;
+        this.connectionRequestTimeout = connectionRequestTimeout;
+        this.socketTimeout = socketTimeout;
     }
 
     @Override
@@ -87,7 +94,8 @@ public abstract class OAuthHandler implements AuthHandler {
                 public String call() throws AuthException, IOException {
                     return OAuthClient.generateToken(OAuthUtils.resolveExpression(tokenApiUrl, messageContext),
                             buildTokenRequestPayload(messageContext), getEncodedCredentials(messageContext),
-                            messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext));
+                            messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext), connectionTimeout,
+                            connectionRequestTimeout, socketTimeout);
                 }
             });
         } catch (ExecutionException e) {
@@ -200,6 +208,18 @@ public abstract class OAuthHandler implements AuthHandler {
             oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
                     AuthConstants.OAUTH_AUTHENTICATION_MODE, getAuthMode()));
         }
+        if (getConnectionTimeout() != -1) {
+            oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
+                    AuthConstants.OAUTH_CONNECTION_TIMEOUT, String.valueOf(getConnectionTimeout())));
+        }
+        if (getConnectionRequestTimeout() != -1) {
+            oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
+                    AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT, String.valueOf(getConnectionRequestTimeout())));
+        }
+        if (getSocketTimeout() != -1) {
+            oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
+                    AuthConstants.OAUTH_SOCKET_TIMEOUT, String.valueOf(getSocketTimeout())));
+        }
 
         return oauthCredentials;
     }
@@ -306,4 +326,17 @@ public abstract class OAuthHandler implements AuthHandler {
         }
         return resolvedCustomHeadersMap;
     }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public int getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -119,13 +119,17 @@ public class OAuthUtils {
         String refreshToken = getChildValue(authCodeElement, AuthConstants.OAUTH_REFRESH_TOKEN);
         String tokenApiUrl = getChildValue(authCodeElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(authCodeElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        int connectionTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(authCodeElement,
+                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
 
         if (clientId == null || clientSecret == null || refreshToken == null || tokenApiUrl == null) {
             log.error("Invalid AuthorizationCode configuration");
             return null;
         }
         AuthorizationCodeHandler handler = new AuthorizationCodeHandler(tokenApiUrl, clientId, clientSecret,
-                refreshToken, authMode);
+                refreshToken, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout);
         if (hasRequestParameters(authCodeElement)) {
             Map<String, String> requestParameters = getRequestParameters(authCodeElement);
             if (requestParameters == null) {
@@ -156,12 +160,17 @@ public class OAuthUtils {
         String clientSecret = getChildValue(clientCredentialsElement, AuthConstants.OAUTH_CLIENT_SECRET);
         String tokenApiUrl = getChildValue(clientCredentialsElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(clientCredentialsElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        int connectionTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(clientCredentialsElement,
+                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
 
         if (clientId == null || clientSecret == null || tokenApiUrl == null) {
             log.error("Invalid ClientCredentials configuration");
             return null;
         }
-        ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret, authMode);
+        ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret, authMode,
+                connectionTimeout, connectionRequestTimeout, socketTimeout);
         if (hasRequestParameters(clientCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(clientCredentialsElement);
             if (requestParameters == null) {
@@ -194,13 +203,17 @@ public class OAuthUtils {
         String password = getChildValue(passwordCredentialsElement, AuthConstants.OAUTH_PASSWORD);
         String tokenApiUrl = getChildValue(passwordCredentialsElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(passwordCredentialsElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        int connectionTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(passwordCredentialsElement,
+                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
 
         if (username == null || password == null || tokenApiUrl == null || clientId == null || clientSecret == null) {
             log.error("Invalid PasswordCredentials configuration");
             return null;
         }
         PasswordCredentialsHandler handler = new PasswordCredentialsHandler(tokenApiUrl, clientId, clientSecret,
-                username, password, authMode);
+                username, password, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout);
         if (hasRequestParameters(passwordCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(passwordCredentialsElement);
             if (requestParameters == null) {
@@ -333,6 +346,20 @@ public class OAuthUtils {
             return ResolverFactory.getInstance().getResolver(childElement.getText().trim()).resolve();
         }
         return null;
+    }
+
+    public static int getOauthTimeouts(OMElement parentElement, String childName) {
+        String value = getChildValue(parentElement, childName);
+        try {
+            if (value == null) {
+                return -1;
+            } else {
+                return Integer.parseInt(value);
+            }
+        } catch (NumberFormatException e) {
+            log.warn("Error while parsing the value of " + value + " as an integer. Using default timeout", e);
+            return -1;
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -35,9 +35,10 @@ public class PasswordCredentialsHandler extends OAuthHandler {
     private final String password;
 
     protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
-                                         String password, String authMode) {
+                                         String password, String authMode, int connectionTimeout,
+                                         int connectionRequestTimeout, int socketTimeout) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode);
+        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout);
         this.username = username;
         this.password = password;
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
@@ -24,6 +24,7 @@ import org.apache.axis2.description.TransportOutDescription;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -41,6 +42,7 @@ import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.transport.passthru.PassThroughHttpSender;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -82,6 +84,7 @@ public class OAuthClientTest extends TestCase {
         PowerMockito.mockStatic(HttpClientBuilder.class);
 
         PowerMockito.when(HttpClientBuilder.class, "create").thenReturn(mockClientBuilder);
+        PowerMockito.when(mockClientBuilder.setDefaultRequestConfig(Mockito.any(RequestConfig.class))).thenReturn(mockClientBuilder);
         PowerMockito.when(mockClientBuilder.setConnectionManager(any(HttpClientConnectionManager.class))).thenReturn(mockClientBuilder);
         PowerMockito.when(mockClientBuilder.setSSLSocketFactory(any())).thenReturn(mockClientBuilder);
         PowerMockito.when(mockClientBuilder.build()).thenReturn(mockHttpClient);
@@ -108,7 +111,7 @@ public class OAuthClientTest extends TestCase {
         SynapseEnvironment synapseEnvironment = new Axis2SynapseEnvironment(synapseConfiguration);
         String token = OAuthClient.generateToken("https://localhost:8280/token1/1.0.0", "body", "credentials",
                                                  new Axis2MessageContext(messageContext, new SynapseConfiguration(),
-                                                         synapseEnvironment), null);
+                                                         synapseEnvironment), null, -1, -1, -1);
 
         assertEquals("abc123", token);
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
@@ -303,7 +303,7 @@ public class OAuthUtilsTest {
 
             OAuthHandler oAuthHandler =
                     new AuthorizationCodeHandler("oauth_server_url", "client_id", "client_secret",
-                            "refresh_token", "header");
+                            "refresh_token", "header", -1, -1, -1);
 
             OAuthConfiguredHTTPEndpoint httpEndpoint = new OAuthConfiguredHTTPEndpoint(oAuthHandler);
 


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1939
The following three properties added as timeout for oauth endpoint validation:
- connectionTimeout: the time to establish the connection with the remote host
- connectionRequestTimeout:  This timeout is used to determine how long the client will wait for a connection from the connection manager before giving up.
- socketTimeout: the time waiting for data – after establishing the connection; maximum time of inactivity between two data packets
```
<authentication>
<oauth>
<clientCredentials>
<clientId>8ghGvzmw3itBfNSkicxs2aWQzzoa</clientId>
<clientSecret>XXXXXXXXXXXXXXx</clientSecret>
<tokenUrl>https://localhost:9444/oauth2/token</tokenUrl>
<connectionTimeout>1000</connectionTimeout>
<connectionRequestTimeout>1000</connectionRequestTimeout>
<socketTimeout>1000</socketTimeout>
</clientCredentials>
</oauth>
</authentication>
```