### PR TITLE
Integration studio synapse

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 
 	<groupId>org.apache.synapse</groupId>
-	<artifactId>synapse-core</artifactId>
+	<artifactId>synapse-core-integration-studio</artifactId>
 
 	<name>Apache Synapse - Core</name>
 	<description>Apache Synapse - Core</description>


### PR DESCRIPTION
## Purpose
Releasing a custom synapse-core for integration studio. Therefore changing the artifact-id from synapse-core to synapse-core-integration-studio. 

Resolves : https://github.com/wso2-enterprise/wso2-apim-internal/issues/3797