### PR TITLE
Add transport parameters transport.vfs.MinimumAge and transport.vfs.MaximumAge

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
@@ -200,6 +200,11 @@ public final class VFSConstants {
     public static final String SCHEME_FTPS = "ftps";
     // sftp scheme file option list
     public static enum SFTP_FILE_OPTION {Identities, UserDirIsRoot, IdentityPassPhrase};
+    
+    /** Parameter for minimum age **/
+    public static final String TRANSPORT_FILE_MINIMUM_AGE = "transport.vfs.MinimumAge";
+    /** Parameter for maximum age **/
+    public static final String TRANSPORT_FILE_MAXIMUM_AGE = "transport.vfs.MaximumAge";
 
     public static final String FILE_TYPE_PREFIX = "transport.vfs.fileType";
     public static final String FILE_TYPE = "filetype";

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
@@ -531,7 +531,6 @@ public class PollTableEntry extends AbstractPollTableEntry {
     }
 
     protected boolean loadConfigurationsFromService(ParameterInclude params) throws AxisFault {
-        System.out.println("loading config from service");
         fileURI = ParamUtils.getOptionalParam(params, VFSConstants.TRANSPORT_FILE_FILE_URI);
         if (fileURI == null) {
             log.warn("transport.vfs.FileURI parameter is missing in the proxy service configuration");

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
@@ -511,10 +511,6 @@ public class PollTableEntry extends AbstractPollTableEntry {
         return maximumAge;
     }
     
-    public boolean hasAgeCheck(){
-        return minimumAge != null||maximumAge != null;
-    }
-    
     @Override
     public boolean loadConfiguration(ParameterInclude params) throws AxisFault {
 

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
@@ -143,6 +143,10 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
     private static final Log log = LogFactory.getLog(PollTableEntry.class);
     
+    private Long minimumAge = null; //defines a minimum age of a file before being consumed. Use to avoid just written files to be consumed
+    private Long maximumAge = null; //defines a maximum age of a file being consumed. Old files will stay in the directory
+
+    
     public PollTableEntry(boolean fileLocking) {
         this.fileLocking = fileLocking;
     }
@@ -499,6 +503,18 @@ public class PollTableEntry extends AbstractPollTableEntry {
         this.subfolderTimestamp = subfolderTimestamp;
     }
 
+    public Long getMinimumAge() {
+        return minimumAge;
+    }
+
+    public Long getMaximumAge() {
+        return maximumAge;
+    }
+    
+    public boolean hasAgeCheck(){
+        return minimumAge != null||maximumAge != null;
+    }
+    
     @Override
     public boolean loadConfiguration(ParameterInclude params) throws AxisFault {
 
@@ -515,6 +531,7 @@ public class PollTableEntry extends AbstractPollTableEntry {
     }
 
     protected boolean loadConfigurationsFromService(ParameterInclude params) throws AxisFault {
+        System.out.println("loading config from service");
         fileURI = ParamUtils.getOptionalParam(params, VFSConstants.TRANSPORT_FILE_FILE_URI);
         if (fileURI == null) {
             log.warn("transport.vfs.FileURI parameter is missing in the proxy service configuration");
@@ -690,6 +707,23 @@ public class PollTableEntry extends AbstractPollTableEntry {
                 }
             }
 
+            String strMinimumAge = ParamUtils.getOptionalParam(params, VFSConstants.TRANSPORT_FILE_MINIMUM_AGE);
+            if(strMinimumAge != null){
+                try {
+                    minimumAge = Long.parseLong(strMinimumAge);
+                } catch (NumberFormatException nfe) {
+                    log.warn("VFS File MinimumAge value is invalid : " + strMinimumAge, nfe);
+                }
+            }
+            String strMaximumAge = ParamUtils.getOptionalParam(params, VFSConstants.TRANSPORT_FILE_MAXIMUM_AGE);
+            if(strMaximumAge != null){
+                try {
+                    maximumAge = Long.parseLong(strMaximumAge);
+                } catch (NumberFormatException nfe) {
+                    log.warn("VFS File MaximumAge value is invalid : " + strMinimumAge, nfe);
+                }
+            }
+            
             String strAutoLock = ParamUtils.getOptionalParam(params,
                                                              VFSConstants.TRANSPORT_AUTO_LOCK_RELEASE);
             autoLockRelease = false;

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -37,7 +37,7 @@ import org.apache.axis2.transport.base.AbstractPollingTransportListener;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.axis2.transport.base.ManagementSupport;
-import org.apache.axis2.transport.base.threads.WorkerPool;
+import org.apache.axis2.transport.base.threads.WorkerPool; 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -452,6 +452,22 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
                             isFailedRecord = isFailedRecord(child, entry);
                         }
 
+                        if(entry.getMinimumAge() != null){
+                            long age = child.getContent().getLastModifiedTime();
+                            long time = System.currentTimeMillis();
+                            if((time-age)/1000 <= entry.getMinimumAge()){
+                                continue;
+                            }
+                        }
+                        
+                        if(entry.getMaximumAge() != null){
+                            long age = child.getContent().getLastModifiedTime();
+                            long time = System.currentTimeMillis();
+                            if((time-age)/1000 >= entry.getMaximumAge()){
+                                continue;
+                            }
+                        }
+                        
                         if(entry.getFileNamePattern()!=null &&
                                 child.getName().getBaseName().matches(entry.getFileNamePattern())){
                             //child's file name matches the file name pattern

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -37,7 +37,7 @@ import org.apache.axis2.transport.base.AbstractPollingTransportListener;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.axis2.transport.base.ManagementSupport;
-import org.apache.axis2.transport.base.threads.WorkerPool; 
+import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang3.StringUtils;


### PR DESCRIPTION
###Goal
This adds the transport parameters transport.vfs.MinimumAge and transport.vfs.MaximumAge which check for file age since last mod in seconds.

###Sample
`<parameter name="transport.vfs.MinimumAge">10</parameter>	
  <parameter name="transport.vfs.MaximumAge">60</parameter>`
reads files that are atleast 10 seconds old but no older than a minute.




