### PR TITLE
Properly destroy passthru worker pools during Listener destroy stage

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpListener.java
@@ -445,7 +445,6 @@ public class PassThroughHttpListener implements TransportListener {
                 }
             }
             serviceTracker.stop();
-            handler.stop();
         } catch (IOException e) {
             handleException("Error shutting down " + namePrefix + " listening IO reactor", e);
         } catch (InterruptedException e) {
@@ -461,6 +460,7 @@ public class PassThroughHttpListener implements TransportListener {
                 getAxisConfiguration().getObserversList().remove(axisObserver);*/
 //        serviceTracker.stop();
         sourceConfiguration.getMetrics().destroy();
+        handler.stop();
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/wso2/micro-integrator/issues/2963

HTTP and HTTPS transport listeners are sharing the Passthru worker pool threads. Hence it is wrong to shutdown the worker pool for one Listener while the other Listener is active. This fix will ensure that the worker pool threads are shutdown when the listeners are destroyed.