### PR TITLE
Upgrade netty, guava and fasterxml versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1566,9 +1566,9 @@
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
       <fge.json.schema.validator.version>2.2.6.wso2v8</fge.json.schema.validator.version>
-      <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
-       <fasterxml.jackson-databind.version>2.13.4.2</fasterxml.jackson-databind.version>
-      <google.guava.version>31.0.1-jre</google.guava.version>
+      <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
+      <fasterxml.jackson-databind.version>2.15.0</fasterxml.jackson-databind.version>
+      <google.guava.version>32.1.2-jre</google.guava.version>
       <failureaccess.version>1.0.1</failureaccess.version>
       <joda-time.version>2.9.4.wso2v1</joda-time.version>
       <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>
@@ -1585,11 +1585,11 @@
        <activemq.broker.version>5.9.1</activemq.broker.version>
        <slf4j.log4j.version>1.5.2</slf4j.log4j.version>
        <system.rules.version>1.17.0</system.rules.version>
-       <io.netty.version>4.1.80.Final</io.netty.version>
-       <transport.http.netty.version>6.3.42</transport.http.netty.version>
+       <io.netty.version>4.1.97.Final</io.netty.version>
+       <transport.http.netty.version>6.3.47</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <opentelemetry.all.version>1.11.0.wso2v3</opentelemetry.all.version>
+       <opentelemetry.all.version>1.11.0.wso2v5</opentelemetry.all.version>
        <okhttp.wso2.version>4.9.3.wso2v2</okhttp.wso2.version>
        <okio.wso2.version>2.8.0.wso2v2</okio.wso2.version>
        <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>


### PR DESCRIPTION
## Purpose
Upgrade following dependency versions
- netty -> 4.1.97.Final
- transport-http-netty -> 6.3.47
- guava -> 32.1.2-jre
- fasterxml-jackson-databind -> 2.15.0