### PR TITLE
Porting redis throttling improvement related changes

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
@@ -20,6 +20,8 @@ package org.apache.synapse.commons.throttle.core;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.throttle.core.internal.DistributedThrottleProcessor;
+import org.apache.synapse.commons.throttle.core.internal.ThrottleServiceDataHolder;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -43,13 +45,22 @@ public abstract class CallerContext implements Serializable, Cloneable {
     private long nextTimeWindow = 0;
     /* The globalCount to keep track number of request */
     private AtomicLong globalCount = new AtomicLong(0);
-
+    private long localQuota;
     private String roleId;
     private long unitTime;
+    /*
+     This is specific for each API EP
+     if this is true, then syncing of throttle parameter with global redis counters be synced will be done in sync mode
+     */
+    private boolean isThrottleParamSyncingModeSync;
+    private ThrottleProperties throttleProperties;
+
+
     /**
      * Count to keep track of local (specific to this node) number of requests
      */
     private AtomicLong localCount = new AtomicLong(0);
+    private AtomicLong localHits = new AtomicLong(0);
 
     /**
      * Used for debugging purposes. *
@@ -83,6 +94,10 @@ public abstract class CallerContext implements Serializable, Cloneable {
             throw new InstantiationError("Couldn't create a CallContext for an empty " +
                                          "remote caller ID");
         }
+        if (throttleProperties == null) {
+            throttleProperties = ThrottleServiceDataHolder.getInstance().getThrottleProperties();
+        }
+
         this.id = ID.trim();
     }
 
@@ -111,7 +126,10 @@ public abstract class CallerContext implements Serializable, Cloneable {
         this.roleId = configuration.getID();
         //Also we need to pick counter value associated with time window.
         throttleContext.addCallerContext(this, this.id);
-        throttleContext.replicateTimeWindow(this.id);
+
+        if (!ThrottleServiceDataHolder.getInstance().getThrottleProperties().isThrottleSyncAsyncHybridModeEnabled()) {
+            throttleContext.replicateTimeWindow(this.id);
+        }
     }
 
     /**
@@ -140,7 +158,6 @@ public abstract class CallerContext implements Serializable, Cloneable {
                 // Send the current state to others (clustered env)
                 throttleContext.flushCallerContext(this, id);
                 // can complete access
-
             } else {
                 //else , if caller has not already prohibit
                 if (this.nextAccessTime == 0) {
@@ -190,7 +207,7 @@ public abstract class CallerContext implements Serializable, Cloneable {
                         throttleContext.replicateTimeWindow(this.id);
                         throttleContext.addAndFlushCallerContext(this, this.id);
 
-                        if(log.isDebugEnabled()) {
+                        if (log.isDebugEnabled()) {
                             log.debug("Caller=" + this.getId() + " has reset counters and added for replication when unit "
                                       + "time is not over");
                         }
@@ -356,6 +373,7 @@ public abstract class CallerContext implements Serializable, Cloneable {
      */
     public boolean canAccess(ThrottleContext throttleContext, CallerConfiguration configuration,
                              long currentTime) throws ThrottleException {
+        RequestContext requestContext = new RequestContext(currentTime);
         boolean canAccess;
         if (configuration == null) {
             if (log.isDebugEnabled()) {
@@ -374,15 +392,34 @@ public abstract class CallerContext implements Serializable, Cloneable {
             initAccess(configuration, throttleContext, currentTime);
         }
         // if unit time period (session time) is not over
-        if (this.nextTimeWindow > currentTime) {
-            canAccess = canAccessIfUnitTimeNotOver(configuration, throttleContext, currentTime);
-        } else {
-            canAccess = canAccessIfUnitTimeOver(configuration, throttleContext, currentTime);
+        if (log.isDebugEnabled()) {
+            log.debug("### NEW REQUEST RECEIVED ! - currentTime: " + currentTime);
         }
 
+        DistributedThrottleProcessor distributedThrottleProcessor = ThrottleServiceDataHolder.getInstance()
+                .getDistributedThrottleProcessor();
+        if (distributedThrottleProcessor != null && distributedThrottleProcessor.isEnable()) {
+            long startTime = System.currentTimeMillis();
+            canAccess = distributedThrottleProcessor.canAccessBasedOnUnitTime(this, configuration, throttleContext,
+                    requestContext);
+            long duration = System.currentTimeMillis() - startTime;
+            if (log.isDebugEnabled()) {
+                log.debug("LATENCY FOR THROTTLE PROCESSING: " + duration + " ms");
+            }
+        } else {
+            canAccess = canAccessBasedOnUnitTime(configuration, throttleContext, currentTime);
+        }
         return canAccess;
-
     }
+
+    private boolean canAccessBasedOnUnitTime(CallerConfiguration configuration, ThrottleContext throttleContext, long currentTime) {
+        if (this.nextTimeWindow > currentTime) {
+            return canAccessIfUnitTimeNotOver(configuration, throttleContext, currentTime);
+        } else {
+            return canAccessIfUnitTimeOver(configuration, throttleContext, currentTime);
+        }
+    }
+
 
     /**
      * Returns the next time window
@@ -410,11 +447,26 @@ public abstract class CallerContext implements Serializable, Cloneable {
     }
 
     public void setLocalCounter(long counter) {
+        if (log.isTraceEnabled()) {
+            log.trace("changing local counter from:" + localCount.get() + " to:" + counter);
+        }
         localCount.set(counter);
     }
 
     public long getLocalCounter() {
         return localCount.get();
+    }
+
+    public void setLocalHits(long counter) {
+        localHits.set(counter);
+    }
+
+    public long getLocalHits() {
+        return localHits.get();
+    }
+
+    public void incrementLocalHits() {
+        localHits.incrementAndGet();
     }
 
     public void resetLocalCounter() {
@@ -458,5 +510,29 @@ public abstract class CallerContext implements Serializable, Cloneable {
 
     public void setRoleId(String roleId) {
         this.roleId = roleId;
+    }
+
+    public void setIsThrottleParamSyncingModeSync(boolean isThrottleParamSyncingModeSync) {
+        this.isThrottleParamSyncingModeSync = isThrottleParamSyncingModeSync;
+    }
+
+    public boolean isThrottleParamSyncingModeSync() {
+        return isThrottleParamSyncingModeSync;
+    }
+
+    public long getLocalQuota() {
+        return localQuota;
+    }
+
+    public void setLocalQuota(long localQuota) {
+        this.localQuota = localQuota;
+    }
+
+    public long getNextAccessTime() {
+        return nextAccessTime;
+    }
+
+    public void setNextAccessTime(long nextAccessTime) {
+        this.nextAccessTime = nextAccessTime;
     }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
@@ -39,6 +39,14 @@ public interface DistributedCounterManager {
     public void setCounter(String key, long value);
 
     /**
+     * Sets the Distributed counter with the given value while setting expiry time too.
+     *
+     * @param key        counter key name
+     * @param value      counter value
+     * @param expiryTime expiry time in milliseconds
+     */
+    public void setCounterWithExpiry(String key, long value, long expiryTime);
+    /**
      * This method used to add and return the distributed counter value.
      *
      * @param key   key to add in distributed map.
@@ -55,13 +63,22 @@ public interface DistributedCounterManager {
     public void removeCounter(String key);
 
     /**
-     * This method used to update distributed counter asynchronously.
+     * This method is used to get and then increment distributed counter asynchronously.
      *
      * @param key   key to check in distributed map.
      * @param value value to add to distributed counter.
      * @return the original distributed counter value.
      */
     public long asyncGetAndAddCounter(String key, long value);
+
+    /**
+     * This method is used to increment distributed counter asynchronously.
+     *
+     * @param key   key to update in distributed map.
+     * @param value value to increment
+     * @return the updated distributed counter value.
+     */
+    public long asyncAddCounter(String key, long value);
 
     /**
      * This method used to alter the DistributedCounter.
@@ -73,11 +90,21 @@ public interface DistributedCounterManager {
     public long asyncGetAndAlterCounter(String key, long value);
 
     /**
-     * This method returns shared TimeStamp of distributed Key.
+     * This method is used to get and then alter and then set expiry time of the DistributedCounter.
      *
-     * @param key key to check in distributed map.
-     * @return timestamp value of key.
+     * @param key             key to alter in distributed counter.
+     * @param value           value to alter in distributed counter.
+     * @param expiryTimeStamp expiry time to set.
+     * @return the original distributed counter value.
      */
+    public long asyncGetAlterAndSetExpiryOfCounter(String key, long value, long expiryTimeStamp);
+
+        /**
+         * This method returns shared TimeStamp of distributed Key.
+         *
+         * @param key key to check in distributed map.
+         * @return timestamp value of key.
+         */
     public long getTimestamp(String key);
 
     /**
@@ -87,6 +114,15 @@ public interface DistributedCounterManager {
      * @param timeStamp timestamp to add.
      */
     public void setTimestamp(String key, long timeStamp);
+
+    /**
+     * This method set the Timestamp to distributed map with an expiry time.
+     *
+     * @param key             key to add in distributed map.
+     * @param timeStamp       timestamp to add.
+     * @param expiryTimeStamp expiry timestamp to set
+     */
+    public void setTimestampWithExpiry(String key, long timeStamp, long expiryTimeStamp);
 
     /**
      * This method removes the timestamp relevant to key.
@@ -100,4 +136,14 @@ public interface DistributedCounterManager {
     public String getType();
 
     void setExpiry(String key, long expiryTimeStamp);
+
+    public long getTtl(String key);
+
+    public long setLock(String key, String value);
+
+    public boolean setLockWithExpiry(String key, String value, long expiryTimeStamp);
+
+    public long getKeyLockRetrievalTimeout();
+
+    public void removeLock(String key);
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/RequestContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/RequestContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.throttle.core;
+
+public class RequestContext {
+    private long requestTime;
+
+    public RequestContext(long requestTime) {
+        this.requestTime = System.currentTimeMillis();
+    }
+
+    public long getRequestTime() {
+        return requestTime;
+    }
+
+    public void setRequestTime(long requestTime) {
+        this.requestTime = requestTime;
+    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleConstants.java
@@ -168,6 +168,7 @@ public final class ThrottleConstants {
 
     public static final String THROTTLE_TIMESTAMP_KEY = "startedTime-";
     public static final String THROTTLE_SHARED_COUNTER_KEY = "sharedCounter-";
+    public static final String THROTTLE_LOCK_KEY_PREFIX = "lock-";
     public static final String THROTTLE_CONTEXT_CLEANUP_TASK_FREQUENCY = "throttling.context.cleanup.frequency";
     public static final String THROTTLE_CONTEXT_DISTRIBUTED_CLEANUP_TASK_FREQUENCY =
             "throttling.context.distributed.cleanup.frequency";
@@ -186,5 +187,7 @@ public final class ThrottleConstants {
     public static final String WINDOW_REPLICATOR_FREQUENCY = "throttlingWindowReplicator.replication.frequency";
     public static final String DISTRIBUTED_COUNTER_TYPE = "throttling.distributed.counter.type";
     public static final String DISTRIBUTED_COUNTER_CONFIGURATIONS  = "throttling.distributed.counter.configurations.";
-
+    public static final String THROTTLE_SYNC_ASYNC_HYBRID_MODE_ENABLED = "throttling.sync-async_hybrid_mode.enable";
+    public static final String HYBRID_THROTTLE_PROCESSOR_WINDOW_TYPE = "throttling.hybrid_throttle_processor_window.type";
+    public static final String LOCAL_QUOTA_BUFFER_PERCENTAGE = "throttling.local_quota_buffer_percentage";
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContext.java
@@ -22,6 +22,7 @@ import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.throttle.core.factory.ThrottleContextFactory;
+import org.apache.synapse.commons.throttle.core.internal.ThrottleServiceDataHolder;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -336,7 +337,10 @@ public abstract class ThrottleContext {
     public void addAndFlushCallerContext(CallerContext callerContext, String id) {
         if (callerContext != null && id != null) {
             addCaller(callerContext, id);
-            replicateCaller(id);
+            if (!ThrottleServiceDataHolder.getInstance().getThrottleProperties()
+                    .isThrottleSyncAsyncHybridModeEnabled()) {
+                replicateCaller(id);
+            }
         }
     }
 
@@ -350,7 +354,10 @@ public abstract class ThrottleContext {
         if (dataHolder != null && callerContext != null && id != null) {
             dataHolder.addCallerContext(id, callerContext); // have to do, because we always get
             //  any property as non-replicable
-            replicateCaller(id);
+            if (!ThrottleServiceDataHolder.getInstance().getThrottleProperties()
+                    .isThrottleSyncAsyncHybridModeEnabled()) {
+                replicateCaller(id);
+            }
         }
     }
 
@@ -361,11 +368,14 @@ public abstract class ThrottleContext {
      */
     public void removeAndFlushCaller(String id) {
         if (id != null) {
-            if(log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("REMOVING AND FLUSHING CALLER CONTEXT WITH ID " + id);
             }
             removeCaller(id);
-            replicateCaller(id);
+            if (!ThrottleServiceDataHolder.getInstance().getThrottleProperties()
+                    .isThrottleSyncAsyncHybridModeEnabled()) {
+                replicateCaller(id);
+            }
         }
     }
 
@@ -376,8 +386,8 @@ public abstract class ThrottleContext {
      */
     public void removeAndDestroyShareParamsOfCaller(String id) {
         if (id != null) {
-            if(log.isDebugEnabled()) {
-                log.info("REMOVE AND DESTROY OF SHARED PARAM OF CALLER WITH ID " + id);
+            if (log.isDebugEnabled()) {
+                log.debug("REMOVE AND DESTROY OF SHARED PARAM OF CALLER WITH ID " + id);
             }
             removeCaller(id);
             SharedParamManager.removeTimestamp(id);

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleProperties.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleProperties.java
@@ -35,6 +35,11 @@ public class ThrottleProperties implements Serializable {
 	private String throttlingKeysToReplicates = "25000";
 	private Map<String, String> distributedCounterConfigurations = new HashMap<>();
 	private String distributedCounterType = ThrottleConstants.HAZELCAST;
+	private boolean throttleSyncAsyncHybridModeEnabled = false;
+	private String distributedThrottleProcessorType = "hybrid";
+	private String hybridThrottleProcessorWindowType = "start_time_based";
+	private String localQuotaBufferPercentage = "20";
+
 	public String getWindowReplicatorPoolSize() {
 		return windowReplicatorPoolSize;
 	}
@@ -154,5 +159,38 @@ public class ThrottleProperties implements Serializable {
 	public void setDistributedCounterType(String distributedCounterType) {
 
 		this.distributedCounterType = distributedCounterType;
+	}
+
+	public String getDistributedThrottleProcessorType() {
+		return distributedThrottleProcessorType;
+	}
+
+	public void setDistributedThrottleProcessorType(String distributedThrottleProcessorType) {
+		this.distributedThrottleProcessorType = distributedThrottleProcessorType;
+	}
+
+	public void setThrottleSyncAsyncHybridModeEnabled(boolean throttleSyncAsyncHybridModeEnabled) {
+		this.throttleSyncAsyncHybridModeEnabled = throttleSyncAsyncHybridModeEnabled;
+	}
+
+	public boolean isThrottleSyncAsyncHybridModeEnabled() {
+		return throttleSyncAsyncHybridModeEnabled;
+	}
+
+	public void setHybridThrottleProcessorWindowType(
+			String hybridThrottleProcessorWindowType) {
+		this.hybridThrottleProcessorWindowType = hybridThrottleProcessorWindowType;
+	}
+
+	public String getHybridThrottleProcessorWindowType() {
+		return hybridThrottleProcessorWindowType;
+	}
+
+	public void setLocalQuotaBufferPercentage(String localQuotaBufferPercentage) {
+		this.localQuotaBufferPercentage = localQuotaBufferPercentage;
+	}
+
+	public String getLocalQuotaBufferPercentage() {
+		return localQuotaBufferPercentage;
 	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleReplicator.java
@@ -47,7 +47,16 @@ public class ThrottleReplicator {
         throttleProperties = ThrottleServiceDataHolder.getInstance().getThrottleProperties();
         replicatorPoolSize = Integer.parseInt(throttleProperties.getThrottlingPoolSize());
 
-        log.debug("Replicator pool size set to " + replicatorPoolSize);
+        if (log.isDebugEnabled()) {
+            log.debug("Replicator pool size set to " + replicatorPoolSize);
+        }
+        if (ThrottleServiceDataHolder.getInstance().getThrottleProperties().isThrottleSyncAsyncHybridModeEnabled()) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Throttle Sync Async Hybrid Mode is enabled. So throttle replicator task will not be scheduled.");
+            }
+            return;
+        }
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(replicatorPoolSize,
                 new ThreadFactory() {
                     @Override

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleUtil.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleUtil.java
@@ -30,7 +30,6 @@ import javax.cache.Caching;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -160,6 +159,25 @@ public class ThrottleUtil {
 									getResolvedValue(secretResolver, distributedConfiguration));
 						}
 					}
+					if (key.contains(ThrottleConstants.THROTTLE_SYNC_ASYNC_HYBRID_MODE_ENABLED)) {
+						String throttleSyncAsyncHybridModeEnabled = properties.getProperty(key);
+						if (StringUtils.isNotEmpty(throttleSyncAsyncHybridModeEnabled)) {
+							throttleProperties.setThrottleSyncAsyncHybridModeEnabled(
+									Boolean.parseBoolean(throttleSyncAsyncHybridModeEnabled));
+						}
+					}
+					if (key.contains(ThrottleConstants.HYBRID_THROTTLE_PROCESSOR_WINDOW_TYPE)) {
+						String hybridThrottleProcessorWindowType = properties.getProperty(key);
+						if (StringUtils.isNotEmpty(hybridThrottleProcessorWindowType)) {
+							throttleProperties.setHybridThrottleProcessorWindowType(hybridThrottleProcessorWindowType);
+						}
+					}
+					if (key.contains(ThrottleConstants.LOCAL_QUOTA_BUFFER_PERCENTAGE)) {
+						String localQuotaBufferPercentage = properties.getProperty(key);
+						if (StringUtils.isNotEmpty(localQuotaBufferPercentage)) {
+							throttleProperties.setLocalQuotaBufferPercentage(localQuotaBufferPercentage);
+						}
+					}
 				}
 			} catch (IOException e) {
 				log.debug("Setting the Default Throttle Properties");
@@ -194,4 +212,4 @@ public class ThrottleUtil {
             }
             return cache;
         }
-    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleWindowReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleWindowReplicator.java
@@ -54,6 +54,14 @@ private ThrottleProperties throttleProperties;
 			log.debug("Throttle window replicator pool size set to " + replicatorPoolSize);
 		}
 
+		if (ThrottleServiceDataHolder.getInstance().getThrottleProperties().isThrottleSyncAsyncHybridModeEnabled()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Throttle Sync Async Hybrid Mode is enabled. So throttle window replicator task will not be "
+						+ "scheduled.");
+			}
+			return;
+		}
+
 		ScheduledExecutorService executor = Executors.newScheduledThreadPool(replicatorPoolSize,
 				new ThreadFactory() {
 					public Thread newThread(Runnable r) {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/DistributedThrottleProcessor.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/DistributedThrottleProcessor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.commons.throttle.core.internal;
+
+import org.apache.synapse.commons.throttle.core.CallerConfiguration;
+import org.apache.synapse.commons.throttle.core.CallerContext;
+import org.apache.synapse.commons.throttle.core.RequestContext;
+import org.apache.synapse.commons.throttle.core.ThrottleContext;
+
+public interface DistributedThrottleProcessor {
+
+    public boolean canAccessBasedOnUnitTime(CallerContext callerContext, CallerConfiguration configuration,
+            ThrottleContext throttleContext, RequestContext requestContext);
+
+    public boolean canAccessIfUnitTimeNotOver(CallerContext callerContext, CallerConfiguration configuration,
+            ThrottleContext throttleContext, RequestContext requestContext);
+
+    public boolean canAccessIfUnitTimeOver(CallerContext callerContext, CallerConfiguration configuration,
+            ThrottleContext throttleContext, RequestContext requestContext);
+
+    public void syncThrottleCounterParams(CallerContext callerContext, boolean incrementLocalCounter,
+            RequestContext requestContext);
+
+    public void syncThrottleWindowParams(CallerContext callerContext, boolean isInvocationFlow);
+
+    public String getType();
+
+    public boolean isEnable();
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceComponent.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceComponent.java
@@ -69,4 +69,19 @@ public class ThrottleServiceComponent {
 	protected void removeDistributedCounterManagerInstance(DistributedCounterManager distributedCounterManager) {
 		ThrottleServiceDataHolder.getInstance().removeDistributedCounterManager(distributedCounterManager);
 	}
+
+	@Reference(
+			name = "distributedThrottleProcessor.instance.service",
+			service = DistributedThrottleProcessor.class,
+			cardinality = ReferenceCardinality.MULTIPLE,
+			policy = ReferencePolicy.DYNAMIC,
+			unbind = "removeDistributedThrottleProcessorInstance"
+	)
+	protected void addDistributedThrottleProcessorInstance(DistributedThrottleProcessor distributedThrottleProcessor) {
+		ThrottleServiceDataHolder.getInstance().addDistributedThrottleProcessor(distributedThrottleProcessor);
+	}
+
+	protected void removeDistributedThrottleProcessorInstance(DistributedThrottleProcessor distributedThrottleProcessor) {
+		ThrottleServiceDataHolder.getInstance().removeDistributedThrottleProcessor(distributedThrottleProcessor);
+	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceDataHolder.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/internal/ThrottleServiceDataHolder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class ThrottleServiceDataHolder {
 	private static final Log log  = LogFactory.getLog(ThrottleServiceDataHolder.class.getName());
 	private Map<String,DistributedCounterManager> distributedCounterManagerMap = new HashMap<>();
+	private Map<String,DistributedThrottleProcessor> distributedThrottleProcessorMap = new HashMap<>();
 
 	private ThrottleServiceDataHolder() {
 
@@ -67,4 +68,20 @@ public class ThrottleServiceDataHolder {
 		String distributedCounterType = throttleProperties.getDistributedCounterType();
 		return distributedCounterManagerMap.get(distributedCounterType);
 	}
+
+	public void addDistributedThrottleProcessor(DistributedThrottleProcessor distributedThrottleProcessor) {
+		distributedThrottleProcessorMap.put(distributedThrottleProcessor.getType(), distributedThrottleProcessor);
+	}
+
+	public void removeDistributedThrottleProcessor(DistributedThrottleProcessor distributedThrottleProcessor) {
+		if (distributedThrottleProcessor != null) {
+			distributedThrottleProcessorMap.remove(distributedThrottleProcessor.getType());
+		}
+	}
+
+	public DistributedThrottleProcessor getDistributedThrottleProcessor() {
+		String distributedThrottleProcessorType = throttleProperties.getDistributedThrottleProcessorType();
+		return distributedThrottleProcessorMap.get(distributedThrottleProcessorType);
+	}
+
 }


### PR DESCRIPTION
**Problem**

We have had implemented distributed backend throttling and distributed burst control support with the use of the Redis cluster. This is done by periodically syncing throttling-related parameters such as counter values, first access timestamp, time window, etc. between the Redis server and the Gateway nodes. But the related throttling limits are not accurate due to the periodic sync time. There is a considerable slippage prior to throttling taking place until the sync takes place between gateways and the Redis server. This needs to be reduced to achieve better accuracy at high-load use cases, where conforming to the defined backend throttling limits is critical.

Git issue: https://github.com/wso2/api-manager/issues/1791

**Solution:**

The presented solution by this PR is a Sync-Async Hybrid model where current asynchronous throttle decision evaluation would take place until exhausting a local quota limit and then the flow would be synchronous. All the gateways will be acknowledged through a pub/sub approach, whenever any gateway node would exhaust the local quota. Once the acknowledgment is received, each gateway would query the Redis server synchronously to fetch the shared counter, so that the throttling decision will be evaluated globally. So there would be no slippage taking place as the counter evaluation will be done through a sync flow when the API request counts come closer to the specified throttle limits. Hence this approach solves the evident problem caused by the existing asynchronous periodically-syncing-based approach.