### PR TITLE
Update the URL pattern regex to correctly mask the SMB2 passwords

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSUtils.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSUtils.java
@@ -67,7 +67,7 @@ public class VFSUtils {
     /**
      * URL pattern
      */
-    private static final Pattern URL_PATTERN = Pattern.compile("[a-z]+://.*");
+    private static final Pattern URL_PATTERN = Pattern.compile("[a-zA-Z0-9]+://.*");
 
     /**
      * Password pattern
@@ -350,7 +350,7 @@ public class VFSUtils {
         String maskUrl;
         if (urlMatcher.find()) {
             final Matcher pwdMatcher = PASSWORD_PATTERN.matcher(url);
-            maskUrl = pwdMatcher.replaceFirst("\":***@\"");
+            maskUrl = pwdMatcher.replaceFirst(":***@");
             return maskUrl;
         }
         return url;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Since the existing URL pattern regex does not capture the numeric characters, it fails to match the smb2 URL that has a numeric character in it. Therefore, the password masking mechanism does not work as intended. This PR updates the URL pattern regex accordingly to overcome this issue.

Fixes wso2/product-ei#5522