### PR TITLE
Fix mismatch in axis service and proxy(synapse) service state

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -798,7 +798,7 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
                     axisCfg.addServiceToExistingServiceGroup(axisService, serviceGroup);
                 }
             }
-            this.setRunning(true);
+            this.setRunning(axisService.isActive());
         } catch (AxisFault axisFault) {
             try {
                 if (axisCfg.getService(axisService.getName()) != null) {


### PR DESCRIPTION


## Purpose
For MI we have introduced this feature using a DeploymentInterceptor. But to enable that we have to add the following service parameter to the proxy

<parameter name="keepServiceHistory">true</parameter>

But there is an issue with MI where it does not properly propagate this state since be due to a mismatch in axis service and proxy(synapse) service state.

Fixes: https://github.com/wso2/micro-integrator/issues/2981