### PR TITLE
Remove obsolete implementation from VFSTransportListener

### DIFF
--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -201,23 +201,8 @@ public class VFSTransportListener extends AbstractPollingTransportListener<PollT
             log.debug("Polling: " + VFSUtils.maskURLPassword(fileURI));
         }
         if (entry.isClusterAware()) {
-            boolean leader = true;
-            ClusteringAgent agent = getConfigurationContext().getAxisConfiguration().getClusteringAgent();
-            log.warn("Although proxy is cluster aware, clustering config are not present, hence running the" +
-                         " the polling task in this node");
-            if (!leader) {
-                if (log.isDebugEnabled()) {
-                    log.debug("This Member is not the leader");
-                }
-                entry.setLastPollState(PollTableEntry.NONE);
-                long now = System.currentTimeMillis();
-                entry.setLastPollTime(now);
-                entry.setNextPollTime(now + entry.getPollInterval());
-                onPollCompletion(entry);
-                return;
-            }
             if (log.isDebugEnabled()) {
-                log.debug("This Member is the leader");
+                log.debug("Cluster aware flag is enabled.");
             }
         }
         FileSystemOptions fso = null;


### PR DESCRIPTION
$subject 

This will avoid printing unnecessary warn logs when the following parameter is configured.

`<parameter name="transport.vfs.ClusterAware">true</parameter> `

Resolves https://github.com/wso2/api-manager/issues/2231