### PR TITLE
Fix for https://github.com/wso2/api-manager/issues/2226

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/api/API.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/API.java
@@ -457,22 +457,8 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
                 if (resource != null) {
                     if (synCtx.getEnvironment().isDebuggerEnabled()) {
                         if (!synCtx.isResponse()) {
-                            SynapseWireLogHolder wireLogHolder = (SynapseWireLogHolder) ((Axis2MessageContext) synCtx).getAxis2MessageContext()
-                                    .getProperty(SynapseDebugInfoHolder.SYNAPSE_WIRE_LOG_HOLDER_PROPERTY);
-                            if (wireLogHolder == null) {
-                                wireLogHolder = new SynapseWireLogHolder();
-                            }
-                            if (synCtx.getProperty(RESTConstants.SYNAPSE_REST_API) != null && !synCtx.getProperty(RESTConstants.SYNAPSE_REST_API).toString().isEmpty()) {
-                                wireLogHolder.setApiName(synCtx.getProperty(RESTConstants.SYNAPSE_REST_API).toString());
-                                if (resource.getDispatcherHelper() != null) {
-                                    if (resource.getDispatcherHelper().getString() != null && !resource.getDispatcherHelper().getString().isEmpty()) {
-                                        wireLogHolder.setResourceUrlString(resource.getDispatcherHelper().getString());
-                                    }
-                                }
-                            }
-                            ((Axis2MessageContext) synCtx).getAxis2MessageContext().setProperty(SynapseDebugInfoHolder.SYNAPSE_WIRE_LOG_HOLDER_PROPERTY, wireLogHolder);
+                            initWirelogHolder(synCtx, resource);
                         }
-
                     }
                     resource.process(synCtx);
                     return;
@@ -483,8 +469,9 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
             //This will get executed only in unhappy path. So ok to have the iterator.
             boolean resourceFound = false;
             boolean matchingMethodFound = false;
+            Resource resource = null;
             for (RESTDispatcher dispatcher : ApiUtils.getDispatchers()) {
-                Resource resource = dispatcher.findResource(synCtx, resources.values());
+                resource = dispatcher.findResource(synCtx, resources.values());
                 if (resource != null) {
                     resourceFound = true;
                     String method = (String) msgCtx.getProperty(Constants.Configuration.HTTP_METHOD);
@@ -495,13 +482,36 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
             if (!resourceFound) {
                 handleResourceNotFound(synCtx);
             } else if (!matchingMethodFound) {
-                handleMethodNotAllowed(synCtx);
+                String method = (String) synCtx.getProperty(RESTConstants.REST_METHOD);
+                if (RESTConstants.METHOD_OPTIONS.equals(method)) {
+                    initWirelogHolder(synCtx, resource);
+                    resource.process(synCtx);
+                } else {
+                    handleMethodNotAllowed(synCtx);
+                }
             } else {
                 //Resource found, and matching method also found, which means request is BAD_REQUEST(400)
                 msgCtx.setProperty(SynapseConstants.HTTP_SC, HttpStatus.SC_BAD_REQUEST);
                 msgCtx.setProperty("NIO-ACK-Requested", true);
             }
         }
+    }
+
+    private static void initWirelogHolder(MessageContext synCtx, Resource resource) {
+        SynapseWireLogHolder wireLogHolder = (SynapseWireLogHolder) ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .getProperty(SynapseDebugInfoHolder.SYNAPSE_WIRE_LOG_HOLDER_PROPERTY);
+        if (wireLogHolder == null) {
+            wireLogHolder = new SynapseWireLogHolder();
+        }
+        if (synCtx.getProperty(RESTConstants.SYNAPSE_REST_API) != null && !synCtx.getProperty(RESTConstants.SYNAPSE_REST_API).toString().isEmpty()) {
+            wireLogHolder.setApiName(synCtx.getProperty(RESTConstants.SYNAPSE_REST_API).toString());
+            if (resource.getDispatcherHelper() != null) {
+                if (resource.getDispatcherHelper().getString() != null && !resource.getDispatcherHelper().getString().isEmpty()) {
+                    wireLogHolder.setResourceUrlString(resource.getDispatcherHelper().getString());
+                }
+            }
+        }
+        ((Axis2MessageContext) synCtx).getAxis2MessageContext().setProperty(SynapseDebugInfoHolder.SYNAPSE_WIRE_LOG_HOLDER_PROPERTY, wireLogHolder);
     }
 
     private void handleMethodNotAllowed(MessageContext synCtx) {

--- a/modules/core/src/main/java/org/apache/synapse/api/Resource.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/Resource.java
@@ -168,9 +168,7 @@ public class Resource extends AbstractRequestProcessor implements ManagedLifecyc
      * @return true if support false otherwise.
      */
     public boolean hasMatchingMethod(String method) {
-        if (RESTConstants.METHOD_OPTIONS.equals(method)) {
-            return true; // OPTIONS requests are always welcome
-        } else if (!methods.isEmpty()) {
+        if (!methods.isEmpty()) {
             if (!methods.contains(method)) {
                 if (log.isDebugEnabled()) {
                     log.debug("HTTP method does not match");
@@ -251,9 +249,7 @@ public class Resource extends AbstractRequestProcessor implements ManagedLifecyc
         String method = (String) msgCtx.getProperty(Constants.Configuration.HTTP_METHOD);
         synCtx.setProperty(RESTConstants.REST_METHOD, method);
 
-        if (RESTConstants.METHOD_OPTIONS.equals(method)) {
-            return true; // OPTIONS requests are always welcome
-        } else if (!methods.isEmpty()) {
+        if (!methods.isEmpty()) {
             if (!methods.contains(method)) {
                 if (log.isDebugEnabled()) {
                     log.debug("HTTP method does not match");


### PR DESCRIPTION
## Overview
When an OPTIONS resource is invoked when there is another HTTP_METHOD with the same path as the OPTIONS resource, the OPTIONS call does not hit the backend and a X-JWT-ASSERTION header is added to the response of the OPTIONS call. This is happening due to improper resource filtering by HTTP_METHOD for OPTIONs call. 

When a resource is invoked, synapse gets all the resources for that api and first filters by HTTP_METHOD and then filters by the path of the resource. When an options call is sent the first filter does not work as expected and it returns all the resources. Therefore in the next filter if there is another resource with the same path as the OPTIONS call, it may get selected according to the order of the LinkedHashSet. 

In the micro-integrator, when an OPTIONS call is sent when there is no OPTIONS call defined, it returns all the allowed resources. This flow is reintroduced in this fix.

## Resolves
https://github.com/wso2/api-manager/issues/2226

