### PR TITLE
Support invalidating connections when related local entry changed

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -155,6 +155,8 @@ public final class SynapseConstants {
     
     /** The name of the Parameter set on the Axis2Configuration to hold the Synapse Configuration */
     public static final String SYNAPSE_CONFIG = "synapse.config";
+    /** EIP pattern name */
+    public static final String INIT_EIP_PATTERN = "init";
     /** The name of the Parameter set on the Axis2Configuration to hold the Synapse Environment */
     public static final String SYNAPSE_ENV = "synapse.env";
     /** The name of the Parameter set on AxisConfiguration to hold the ServerContextInformation */

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/InvokeMediator.java
@@ -76,12 +76,15 @@ public class InvokeMediator extends AbstractMediator implements
 	private Map<String, Value> pName2ExpressionMap;
 
 	private boolean dynamicMediator = false;
-
-	/** The local registry key which is used to pick a sequence definition */
+	
 	private Value key = null;
 
-    /** Reference to the synapse environment */
-    private SynapseEnvironment synapseEnv;
+	private String localEntryKey = null;
+
+	/**
+	 * Reference to the synapse environment
+	 */
+	private SynapseEnvironment synapseEnv;
 
 	public InvokeMediator() {
 		// LinkedHashMap is used to preserve tag order
@@ -129,6 +132,10 @@ public class InvokeMediator extends AbstractMediator implements
 		if (executePreFetchingSequence && key != null) {
 			String defaultConfiguration = key.evaluateValue(synCtx);
 			Mediator m = synCtx.getDefaultConfiguration(defaultConfiguration);
+			if (m instanceof InvokeMediator) {
+				InvokeMediator invokeMediator = (InvokeMediator) m;
+				invokeMediator.setLocalEntryKey(defaultConfiguration);
+			}
 			if (m == null) {
 				handleException("Sequence named " + key + " cannot be found", synCtx);
 
@@ -149,6 +156,9 @@ public class InvokeMediator extends AbstractMediator implements
 		}
 
 		if (mediator != null && mediator instanceof TemplateMediator) {
+			if (localEntryKey != null) {
+				((TemplateMediator) mediator).setLocalEntryKey(localEntryKey);
+			}
 			populateParameters(synCtx, ((TemplateMediator) mediator).getName());
 			if (executePreFetchingSequence) {
 				ContinuationStackManager.addReliantContinuationState(synCtx,
@@ -318,6 +328,12 @@ public class InvokeMediator extends AbstractMediator implements
 
 	public void setKey(Value key) {
 		this.key = key;
+	}
+	public void setLocalEntryKey(String localEntryKey) {
+		this.localEntryKey = localEntryKey;
+	}
+	public String getLocalEntryKey() {
+		return localEntryKey;
 	}
 
 	public String getPackageName() {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
@@ -51,10 +51,15 @@ public class TemplateContext {
      * refers to the parameters of the function
      */
     private Collection<TemplateParam> parameters;
+    private final String INIT_CONFIG_KEY = "INIT_CONFIG_KEY";
     /**
      * contains a map for parameterNames to evaluated values
      */
     private Map mappedValues;
+    /**
+     * The local entry key name
+     */
+    private String localEntryKey = null;
 
     public TemplateContext(String name, Collection<TemplateParam> parameters) {
         this.fName = name;
@@ -68,6 +73,9 @@ public class TemplateContext {
      * @param synCtxt Synapse MessageContext
      */
     public void setupParams(MessageContext synCtxt) {
+        if (SynapseConstants.INIT_EIP_PATTERN.equals(fName) && getLocalEntryKey() != null) {
+            mappedValues.put(INIT_CONFIG_KEY, getLocalEntryKey());
+        }
         Iterator<TemplateParam> paramNames = parameters.iterator();
         while (paramNames.hasNext()) {
             TemplateParam parameter = paramNames.next();
@@ -180,6 +188,14 @@ public class TemplateContext {
 
     public Map getMappedValues() {
         return mappedValues;
+    }
+
+    public String getLocalEntryKey() {
+        return localEntryKey;
+    }
+
+    public void setLocalEntryKey(String localEntryKey) {
+        this.localEntryKey = localEntryKey;
     }
 
     public void setMappedValues(Map map) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateMediator.java
@@ -55,6 +55,17 @@ public class TemplateMediator extends AbstractListMediator {
 
     private String errorHandler = null;
 
+    /** The local entry key name */
+    private String localEntryKey = null;
+
+    public String getLocalEntryKey() {
+        return localEntryKey;
+    }
+
+    public void setLocalEntryKey(String localEntryKey) {
+        this.localEntryKey = localEntryKey;
+    }
+
     public void setParameters(Collection<TemplateParam> paramNames) {
         this.templateParams = paramNames;
     }
@@ -161,6 +172,9 @@ public class TemplateMediator extends AbstractListMediator {
      */
     private void pushFuncContextTo(MessageContext synCtx) {
         TemplateContext funcContext = new TemplateContext(eipPatternName, templateParams);
+        if (localEntryKey != null) {
+            funcContext.setLocalEntryKey(localEntryKey);
+        }
         //process the raw parameters parsed in
         funcContext.setupParams(synCtx);
 


### PR DESCRIPTION


## Purpose
I introduced an enhancement to the way we handle connections in relation to local entries.
A mechanism was established where the key associated with a localEntry is passed from the InvokeMediator
to the TemplateMediator then further propagated to the TemplateContext, ensuring that the specific localEntry is accessible from the connection handling code.

With the availability of the localEntry key, each active connection(dynamic/static) has been bound to its respective localEntry in a map.

So when a localEntry is undeployed or removed, this change is detected by the Synapse Observer, and the connections associated with that specific localEntry are invalidated.

 Fixes: https://github.com/wso2/micro-integrator/issues/3002
