### PR TITLE
Disable external entity support in javax.xml

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -533,6 +533,7 @@ public abstract class TemplateProcessor {
     public void readInputFactoryProperties() {
         //ignore DTDs for XML Input
         inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         inputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
         Map props = StAXUtils.loadFactoryProperties("XMLInputFactory.properties");
         if (props != null) {


### PR DESCRIPTION
## Purpose
> Disable external entity support in javax.xml
refer https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/general-recommendations-for-secure-coding/#xmlinputfactory-stax-parser