### PR TITLE
Add a null check for response message context to skip engaging interceptors

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -624,7 +624,8 @@ public class TargetHandler implements NHttpClientEventHandler {
                 int responseRead = -1;
                 boolean interceptionEnabled = false;
                 Boolean[] interceptorResults = new Boolean[noOfInterceptors];
-                if (interceptStream) {
+                if (conn.getContext().getAttribute(PassThroughConstants.RESPONSE_MESSAGE_CONTEXT) != null
+                        && interceptStream) {
                     int index = 0;
                     for (StreamInterceptor interceptor : streamInterceptors) {
                         interceptorResults[index] = interceptor.interceptTargetResponse(


### PR DESCRIPTION
## Purpose

This PR adds a null check for response message context to skip engaging the streaming interceptors. This value becomes null in a passthru scenario when a request payload with a large content length is sent to a backend which does not support chunking. Since this occurs only in such a scenario, we can skip engaging the interceptors based on the null check.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5221
Fixes: https://github.com/wso2/api-manager/issues/2343