### PR TITLE
Serialize OMNode after replace dynamic Inline expressions

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
@@ -287,7 +287,10 @@ public class EnrichMediator extends AbstractMediator {
         try {
             // After the expressions in the inline text is replaced with the value, the string must be parsed
             // again to identify whether it has changed to a XML
-            source.setInlineOMNode(AXIOMUtil.stringToOM(inlineString));
+            OMNode inlineOMNode = AXIOMUtil.stringToOM(inlineString);
+            // serialize inlineOMNode
+            inlineOMNode.buildWithAttachments();
+            source.setInlineOMNode(inlineOMNode);
             isInlineTextXML = true;
         } catch (XMLStreamException | OMException e) {
             // The string is considered as a text / JSON


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

An issue can occur in Enrich mediator if the enriched content is not properly serialized before getting cloned. This PR will serialize the OMNode after creation so that the clone operation that occurs after this, will proceed without any issues.

Fixes https://github.com/wso2/micro-integrator/issues/3070