### PR TITLE
Add a synapse property to handle excluding payload details in error logs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -613,6 +613,7 @@ public final class SynapseConstants {
     public static final String MAX_FAILOVER_RECUSIVE_RETRIES_CONFIG = "maximum.failover.recursive.retries";
     public static final String SUSPEND_DURATION_ON_MAX_RECURSIVE_FAILOVER_CONFIG =
             "suspend.duration.on.maximum.recursive.failover";
+    public static final String EXCLUDE_PAYLOAD_DETAILS_FROM_ERROR = "exclude.payload.details.from.error";
 
     /**
      * Synapse Configuration holder property name, used for handling synapse import deployments

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java
@@ -38,6 +38,7 @@ import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseHandler;
 import org.apache.synapse.commons.throttle.core.ConcurrentAccessController;
 import org.apache.synapse.commons.throttle.core.ConcurrentAccessReplicator;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.inbound.InboundEndpointConstants;
 import org.apache.synapse.inbound.InboundResponseSender;
@@ -61,6 +62,8 @@ public class Axis2Sender {
      * Content type header name.
      */
     private static final String CONTENT_TYPE_STRING = "Content-Type";
+    private static final boolean removeHeaders = SynapsePropertiesLoader
+            .getBooleanProperty(SynapseConstants.EXCLUDE_PAYLOAD_DETAILS_FROM_ERROR, false);
 
     /**
      * Send a message out from the Synapse engine to an external service
@@ -299,7 +302,7 @@ public class Axis2Sender {
             }
             Map<String, Object> mHeader = (Map<String, Object>) msgContext.getProperty
                     (org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-            if (mHeader != null) {
+            if (!removeHeaders && mHeader != null) {
                 for (String strKey : mHeader.keySet()) {
                     sb.append(strKey + ":" + mHeader.get(strKey).toString() + ",");
                 }


### PR DESCRIPTION
## Purpose
This PR adds a synapse property to exclude payload details from the error messages. This can be enabled from the deployment.toml as follows. The default value for this would be false in order to preserve the existing behaviour.

```
[synapse_properties]
'exclude.payload.details.from.error' = true
```

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5133