### PR TITLE
Add config to disable passthrough access logging

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
@@ -149,7 +149,9 @@ public class Access {
         }
         String logString = result.toString();
         log.debug(logString);      //log to the console
-        accessLogger.log(logString);      //log to the file
+        if (accessLogger.isLoggingEnabled) {
+            accessLogger.log(logString);      //log to the file
+        }
     }
 
     /**
@@ -873,6 +875,8 @@ public class Access {
         }
         String logString = result.toString();
         log.debug(logString);      //log to the console
-        accessLogger.log(logString);      //log to the file
+        if (accessLogger.isLoggingEnabled) {
+            accessLogger.log(logString);      //log to the file
+        }
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
@@ -75,6 +75,8 @@ public class AccessConstants {
 
     public static final String CONFIG_FILE_DATE_FORMAT = "access_log_file_date_format";
 
+    public static final String CONFIG_ENABLE_LOGGING = "access_log_enable";
+
 
     public static String getLogPattern() {
         return AccessConfiguration.getInstance().getStringProperty(CONFIG_PATTERN, LOG_PATTERN);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java
@@ -41,6 +41,8 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.synapse.transport.http.access.AccessConstants.CONFIG_ENABLE_LOGGING;
+
 /**
  * Class that logs the Http Accesses to the access log files. Code segment borrowed from
  * Apache Tomcat's org.apache.catalina.valves.AccessLogValve with thanks.
@@ -64,7 +66,9 @@ public class AccessLogger {
 
     public AccessLogger(final Log log) {
         super();
-        this.initOpen();
+        if (isLoggingEnabled) {
+            this.initOpen();
+        }
         AccessLogger.log = log;
         buffered = true;
         checkExists = false;
@@ -113,6 +117,11 @@ public class AccessLogger {
      * Can the log file be rotated.
      */
     private boolean isRotatable = getBooleanValue(IS_LOG_ROTATABLE, true);
+
+    /**
+     * Enable logging.
+     */
+    public boolean isLoggingEnabled = getBooleanValue(CONFIG_ENABLE_LOGGING, true);
 
     /**
      * Log the specified message to the log file, switching files if the date


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/2357

### Description

- In the current implementation passthrough access logs are taken through `modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessLogger.java` class. However users can not disable this. 
- This update adds a new config `access_log_enable` to `repository/conf/access-log.properties` file which enables users to enable or disable the above logs. By default this will be set to `true` to avoid interfering with current use cases.
