### PR TITLE
Upgrade Netty, Jackson, and Guava versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1586,7 +1586,7 @@
        <slf4j.log4j.version>1.5.2</slf4j.log4j.version>
        <system.rules.version>1.17.0</system.rules.version>
        <io.netty.version>4.1.104.Final</io.netty.version>
-       <transport.http.netty.version>6.3.49</transport.http.netty.version>
+       <transport.http.netty.version>6.3.50</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
        <opentelemetry.all.version>1.11.0.wso2v5</opentelemetry.all.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1566,9 +1566,9 @@
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
       <fge.json.schema.validator.version>2.2.6.wso2v9</fge.json.schema.validator.version>
-      <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
-       <fasterxml.jackson-databind.version>2.13.4.2</fasterxml.jackson-databind.version>
-      <google.guava.version>32.1.3-jre</google.guava.version>
+      <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
+      <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
+      <google.guava.version>33.0.0-jre</google.guava.version>
       <failureaccess.version>1.0.1</failureaccess.version>
       <joda-time.version>2.9.4.wso2v1</joda-time.version>
       <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1585,7 +1585,7 @@
        <activemq.broker.version>5.9.1</activemq.broker.version>
        <slf4j.log4j.version>1.5.2</slf4j.log4j.version>
        <system.rules.version>1.17.0</system.rules.version>
-       <io.netty.version>4.1.100.Final</io.netty.version>
+       <io.netty.version>4.1.104.Final</io.netty.version>
        <transport.http.netty.version>6.3.49</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>


### PR DESCRIPTION
### Purpose

Upgrade the following depenedcies to their latest:

- Netty dependency version to 4.1.104.Final,
- Fasterxml Jackson-databind version to 2.16.1,
- Google Guava version to 33.0.0-jre.