### PR TITLE
Use endpoint URL and OAuth credentials when caching token

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/HTTPEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/HTTPEndpoint.java
@@ -140,7 +140,18 @@ public class HTTPEndpoint extends AbstractEndpoint {
         }
     }
 
-    private void processUrlTemplate(MessageContext synCtx) throws VariableExpansionException {
+    protected void processUrlTemplate(MessageContext synCtx) throws VariableExpansionException {
+
+        String evaluatedUri = resolveUrlTemplate(synCtx);
+        if (evaluatedUri != null) {
+            synCtx.setTo(new EndpointReference(evaluatedUri));
+            if (super.getDefinition() != null) {
+                synCtx.setProperty(EndpointDefinition.DYNAMIC_URL_VALUE, evaluatedUri);
+            }
+        }
+    }
+
+    protected String resolveUrlTemplate(MessageContext synCtx) throws VariableExpansionException {
         Map<String, Object> variables = new HashMap<String, Object>();
 
         /*The properties with uri.var.* are only considered for Outbound REST Endpoints*/
@@ -162,10 +173,10 @@ public class HTTPEndpoint extends AbstractEndpoint {
                     if (objProperty != null) {
                         if (objProperty instanceof String) {
                             variables.put(propertyKey.toString(),
-                                          decodeString((String) synCtx.getProperty(propertyKey.toString())));
+                                    decodeString((String) synCtx.getProperty(propertyKey.toString())));
                         } else {
                             variables.put(propertyKey.toString(),
-                                          decodeString(String.valueOf(synCtx.getProperty(propertyKey.toString()))));
+                                    decodeString(String.valueOf(synCtx.getProperty(propertyKey.toString()))));
                         }
                     }
                 }
@@ -224,14 +235,14 @@ public class HTTPEndpoint extends AbstractEndpoint {
                         (propertyKey.toString().startsWith(RESTConstants.REST_URI_VARIABLE_PREFIX)
                                 || propertyKey.toString().startsWith(RESTConstants.REST_QUERY_PARAM_PREFIX))) {
                     Object objProperty =
-                                         synCtx.getProperty(propertyKey.toString());
+                            synCtx.getProperty(propertyKey.toString());
                     if (objProperty != null) {
                         if (objProperty instanceof String) {
                             variables.put(propertyKey.toString(),
-                                          (String) synCtx.getProperty(propertyKey.toString()));
+                                    (String) synCtx.getProperty(propertyKey.toString()));
                         } else {
                             variables.put(propertyKey.toString(),
-                                          (String) String.valueOf(synCtx.getProperty(propertyKey.toString())));
+                                    (String) String.valueOf(synCtx.getProperty(propertyKey.toString())));
                         }
                     }
                 }
@@ -282,14 +293,7 @@ public class HTTPEndpoint extends AbstractEndpoint {
                 }
             }
         }
-
-
-        if (evaluatedUri != null) {
-            synCtx.setTo(new EndpointReference(evaluatedUri));
-            if (super.getDefinition() != null) {
-                synCtx.setProperty(EndpointDefinition.DYNAMIC_URL_VALUE, evaluatedUri);
-            }
-        }
+        return evaluatedUri;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/OAuthConfiguredHTTPEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/OAuthConfiguredHTTPEndpoint.java
@@ -18,7 +18,9 @@
 
 package org.apache.synapse.endpoints;
 
+import com.damnhandy.uri.template.VariableExpansionException;
 import org.apache.axis2.AxisFault;
+import org.apache.axis2.addressing.EndpointReference;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.endpoints.auth.AuthHandler;
@@ -46,6 +48,7 @@ public class OAuthConfiguredHTTPEndpoint extends HTTPEndpoint {
     public void send(MessageContext synCtx) {
 
         try {
+            setResolvedUrlTemplate(synCtx);
             oAuthHandler.setAuthHeader(synCtx);
 
             // If this a blocking call, add 401 as a non error http status code
@@ -77,17 +80,22 @@ public class OAuthConfiguredHTTPEndpoint extends HTTPEndpoint {
      */
     public MessageContext retryCallWithNewToken(MessageContext synCtx) {
         // remove the existing token from the cache so that a new token is generated
-        oAuthHandler.removeTokenFromCache();
-        // set RETRIED_ON_OAUTH_FAILURE property to true
-        synCtx.setProperty(AuthConstants.RETRIED_ON_OAUTH_FAILURE, true);
-        send(synCtx);
+        try {
+            // set RETRIED_ON_OAUTH_FAILURE property to true
+            synCtx.setProperty(AuthConstants.RETRIED_ON_OAUTH_FAILURE, true);
+            oAuthHandler.removeTokenFromCache(synCtx);
+            send(synCtx);
+        } catch (AuthException e) {
+            handleError(synCtx,
+                    "Error removing access token for oauth configured http endpoint " + this.getName(), e);
+        }
         return synCtx;
     }
 
     @Override
     public void destroy() {
 
-        oAuthHandler.removeTokenFromCache();
+        oAuthHandler.removeTokensFromCache();
         super.destroy();
     }
 
@@ -108,5 +116,22 @@ public class OAuthConfiguredHTTPEndpoint extends HTTPEndpoint {
         String errorMsg = message + " " + exception.getMessage();
         log.error(errorMsg);
         informFailure(synCtx, SynapseConstants.ENDPOINT_AUTH_FAILURE, errorMsg);
+    }
+
+    private void setResolvedUrlTemplate(MessageContext messageContext) {
+        String resolvedUrl = resolveUrlTemplate(messageContext);
+        if (resolvedUrl != null) {
+            messageContext.setTo(new EndpointReference(resolvedUrl));
+            if (super.getDefinition() != null) {
+                messageContext.setProperty(EndpointDefinition.DYNAMIC_URL_VALUE, resolvedUrl);
+            }
+        }
+    }
+
+    @Override
+    protected void processUrlTemplate(MessageContext synCtx) throws VariableExpansionException {
+        // Since we set the resolved URL in the OAuthConfiguredHTTPEndpoint.send method
+        // return the processUrlTemplate to skip re-resolving at HTTPEndpoint.
+        return;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -26,6 +26,8 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
 
+import java.util.Objects;
+
 /**
  * This class is used to handle Authorization code grant oauth.
  */
@@ -72,6 +74,15 @@ public class AuthorizationCodeHandler extends OAuthHandler {
         authCode.addChild(
                 OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.OAUTH_REFRESH_TOKEN, getRefreshToken()));
         return authCode;
+    }
+
+    @Override
+    protected int getHash(MessageContext messageContext) throws AuthException {
+        return Objects.hash(messageContext.getTo().getAddress(), OAuthUtils.resolveExpression(getTokenUrl(), messageContext),
+                OAuthUtils.resolveExpression(getClientId(), messageContext), OAuthUtils.resolveExpression(getClientSecret(),
+                        messageContext), OAuthUtils.resolveExpression(getRefreshToken(), messageContext),
+                getRequestParametersAsString(messageContext), getResolvedCustomHeadersMap(getCustomHeadersMap(),
+                        messageContext));
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -26,6 +26,8 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
 
+import java.util.Objects;
+
 /**
  * This class is used to handle Client Credentials grant oauth.
  */
@@ -59,5 +61,13 @@ public class ClientCredentialsHandler extends OAuthHandler {
     protected OMElement serializeSpecificOAuthConfigs(OMFactory omFactory) {
 
         return omFactory.createOMElement(AuthConstants.CLIENT_CREDENTIALS, SynapseConstants.SYNAPSE_OMNAMESPACE);
+    }
+
+    @Override
+    protected int getHash(MessageContext messageContext) throws AuthException {
+        return Objects.hash(messageContext.getTo().getAddress(), OAuthUtils.resolveExpression(getTokenUrl(), messageContext),
+                OAuthUtils.resolveExpression(getClientId(), messageContext), OAuthUtils.resolveExpression(getClientSecret(),
+                        messageContext), getRequestParametersAsString(messageContext),
+                getResolvedCustomHeadersMap(getCustomHeadersMap(), messageContext));
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -26,6 +26,8 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
 
+import java.util.Objects;
+
 /**
  * This class is used to handle Password Credentials grant oauth.
  */
@@ -76,6 +78,16 @@ public class PasswordCredentialsHandler extends OAuthHandler {
         passwordCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.OAUTH_PASSWORD,
                 password));
         return passwordCredentials;
+    }
+
+    @Override
+    protected int getHash(MessageContext messageContext) throws AuthException {
+        return Objects.hash(messageContext.getTo().getAddress(), OAuthUtils.resolveExpression(getTokenUrl(), messageContext),
+                OAuthUtils.resolveExpression(getClientId(), messageContext), OAuthUtils.resolveExpression(getClientSecret(),
+                        messageContext), OAuthUtils.resolveExpression(getUsername(), messageContext),
+                OAuthUtils.resolveExpression(getPassword(), messageContext),
+                getRequestParametersAsString(messageContext), getResolvedCustomHeadersMap(getCustomHeadersMap(),
+                        messageContext));
     }
 
     public String getUsername() {

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/TokenCache.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/TokenCache.java
@@ -82,7 +82,7 @@ public class TokenCache {
     }
 
     /**
-     * This method is called to remove the token from the cache when the endpoint is destroyed
+     * This method is called to remove the token from the cache when the token is invalid
      *
      * @param id id of the endpoint
      */
@@ -91,4 +91,12 @@ public class TokenCache {
         tokenMap.invalidate(id);
     }
 
+    /**
+     * This method is called to remove the tokens from the cache when the endpoint is destroyed
+     *
+     * @param oauthHandlerId id of the OAuth handler bounded to the endpoint
+     */
+    public void removeTokens(String oauthHandlerId) {
+        tokenMap.asMap().entrySet().removeIf(entry -> entry.getKey().startsWith(oauthHandlerId));
+    }
 }

--- a/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/endpoint/Sample63.java
+++ b/modules/integration/src/test/java/org/apache/synapse/samples/framework/tests/endpoint/Sample63.java
@@ -100,4 +100,27 @@ public class Sample63 extends SynapseTestCase {
         HttpResponse response = client.doGet("http://127.0.0.1:8280/foodapi/list/dynamicValues");
         assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
+
+    public void testOAuthConfiguredDynamicURLEP() throws Exception {
+
+        String payload1 = "<request>\n" +
+                "\t<ep_url>http://localhost:9000/foodservice/food</ep_url>\n" +
+                "\t<token_ep>http://localhost:9000/foodservice/token1</token_ep>\n" +
+                "</request>";
+
+        String payload2 = "<request>\n" +
+                "\t<ep_url>http://localhost:9000/foodservice/apple</ep_url>\n" +
+                "\t<token_ep>http://localhost:9000/foodservice/token2</token_ep>\n" +
+                "</request>";
+
+        BasicHttpClient client = new BasicHttpClient();
+        HttpResponse response = client.doPost("http://127.0.0.1:8280/foodapi/list/dynamicURL", payload1.getBytes(),
+                "text/xml");
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+        HttpResponse response2 = client.doPost("http://127.0.0.1:8280/foodapi/list/dynamicURL", payload2.getBytes(),
+                "text/xml");
+        assertEquals(HttpStatus.SC_OK, response2.getStatus());
+        assertEquals("1", response2.getBodyAsString());
+    }
 }

--- a/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/Constants.java
+++ b/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
 
     static final String refreshToken = "wxyz#9876";
     static final String accessToken = "abcd@1234";
+    static final String accessToken2 = "jklm#6789";
     static final String expiresIn = "3600";
     static final String tokenType = "Bearer";
     static final String clientId = "my_client_id";

--- a/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
+++ b/modules/samples/src/main/java/org/wso2/synapse/samples/jaxrs/foodsample/FoodService.java
@@ -38,6 +38,7 @@ public class FoodService {
 
     private int unauthorizedReqCount = 0;
     private int tokenReqCount = 0;
+    private int appleServiceRequests = 0;
 
     @POST
     @Path("/token")
@@ -52,6 +53,38 @@ public class FoodService {
 
         if (validateBasicAuthHeader(basicHeader)) {
             return Response.status(Response.Status.OK).entity(new Token(Constants.accessToken, Constants.expiresIn,
+                    Constants.tokenType)).build();
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid Credentials").build();
+    }
+
+    @POST
+    @Path("/token1")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAccessToken1(@Context HttpHeaders httpHeaders,
+                                    MultivaluedMap<String, String> tokenRequestParams) {
+
+        String basicHeader = httpHeaders.getHeaderString("Authorization");
+
+        if (validateBasicAuthHeader(basicHeader)) {
+            return Response.status(Response.Status.OK).entity(new Token(Constants.accessToken, Constants.expiresIn,
+                    Constants.tokenType)).build();
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid Credentials").build();
+    }
+
+    @POST
+    @Path("/token2")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAccessToken2(@Context HttpHeaders httpHeaders,
+                                   MultivaluedMap<String, String> tokenRequestParams) {
+
+        String basicHeader = httpHeaders.getHeaderString("Authorization");
+
+        if (validateBasicAuthHeader(basicHeader)) {
+            return Response.status(Response.Status.OK).entity(new Token(Constants.accessToken2, Constants.expiresIn,
                     Constants.tokenType)).build();
         }
         return Response.status(Response.Status.UNAUTHORIZED).entity("Invalid Credentials").build();
@@ -100,6 +133,22 @@ public class FoodService {
             String token = authorizationHeader.split(" ")[1];
             if (token.equals(Constants.accessToken)) {
                 return Response.status(Response.Status.OK).entity(tokenReqCount).build();
+            }
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+
+    @GET
+    @Path("/apple")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getFoodItem2(@Context HttpHeaders httpHeaders) {
+
+        appleServiceRequests++;
+        String authorizationHeader = httpHeaders.getHeaderString("Authorization");
+        if (authorizationHeader != null) {
+            String token = authorizationHeader.split(" ")[1];
+            if (token.equals(Constants.accessToken2)) {
+                return Response.status(Response.Status.OK).entity(appleServiceRequests).build();
             }
         }
         return Response.status(Response.Status.UNAUTHORIZED).build();

--- a/repository/conf/sample/synapse_sample_63.xml
+++ b/repository/conf/sample/synapse_sample_63.xml
@@ -211,5 +211,33 @@
                 <respond/>
             </faultSequence>
         </resource>
+        <resource uri-template="/list/dynamicURL" methods="POST">
+            <inSequence>
+                <property expression="$body//ep_url" name="uri.var.ep" scope="default" type="STRING"/>
+                <property expression="$body//token_ep" name="token_ep" scope="default" type="STRING"/>
+                <send>
+                    <endpoint>
+                        <http method="get" uri-template="{uri.var.ep}">
+                            <authentication>
+                                <oauth>
+                                    <clientCredentials>
+                                        <clientId>my_client_id</clientId>
+                                        <clientSecret>my_client_secret</clientSecret>
+                                        <tokenUrl>{$ctx:token_ep}</tokenUrl>
+                                    </clientCredentials>
+                                </oauth>
+                            </authentication>
+                        </http>
+                    </endpoint>
+                </send>
+            </inSequence>
+            <outSequence>
+                <send/>
+            </outSequence>
+            <faultSequence>
+                <property name="HTTP_SC" value="500" scope="axis2"/>
+                <respond/>
+            </faultSequence>
+        </resource>
     </api>
 </definitions>


### PR DESCRIPTION
## Purpose

Since the cached token was mapped to the synapse endpoint instance previously, the same token was shared even we change the endpoint URL dynamically. With this improvement, we use the endpoint URL and OAuth credentials as the key when caching the token.

Fixes: https://github.com/wso2/api-manager/issues/2381