### PR TITLE
[APIM] Add Support to Config Java Access Control through JS in Script Mediator

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/AccessControlConstants.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/AccessControlConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control;
+
+/**
+ * Constants related to Script Mediator access control.
+ */
+public class AccessControlConstants {
+    public static String LIMIT_CLASS_ACCESS_PREFIX = "limit_java_class_access_in_scripts.";
+    public static String LIMIT_NATIVE_OBJECT_ACCESS_PREFIX = "limit_java_native_object_access_in_scripts.";
+    public static String ENABLE = "enable";
+    public static String LIST_TYPE = "list_type";
+    public static String CLASS_PREFIXES = "class_prefixes";
+    public static String OBJECT_NAMES = "object_names";
+}

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/AccessControlUtils.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/AccessControlUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control;
+
+import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
+import org.apache.synapse.mediators.bsf.access.control.config.AccessControlListType;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Utility methods related to Script Mediator access control.
+ */
+public class AccessControlUtils {
+
+    /**
+     * Returns whether the provided string which represents a Java class or native object is accessible or not.
+     * The allowing/blocking will be determined by the provided AccessControlConfig, based on the matching/comparing
+     * done as specified in the comparator.
+     * @param string                Java class name or native object name.
+     * @param accessControlConfig   Access control config of the Script Mediator.
+     * @param comparator            The comparator based on which, the provided Java class/native object name is
+     *                              matched against the provided access control config.
+     * @return                      Whether the access is allowed or not.
+     */
+    public static boolean isAccessAllowed(String string, AccessControlConfig accessControlConfig,
+                                          Comparator<String> comparator) {
+        if (accessControlConfig == null || !accessControlConfig.isAccessControlEnabled()) {
+            return true; // Access control is not applicable
+        }
+
+        List<String> accessControlList = accessControlConfig.getAccessControlList();
+        boolean doesMatchExist = false;
+        for (String item : accessControlList) {
+            if (comparator.compare(string, item) > -1) {
+                doesMatchExist = true;
+                break;
+            }
+        }
+
+        if (accessControlConfig.getAccessControlListType() == AccessControlListType.BLOCK_LIST) {
+            return !doesMatchExist;
+        }
+        if (accessControlConfig.getAccessControlListType() == AccessControlListType.ALLOW_LIST) {
+            return doesMatchExist;
+        }
+        return true; // Ideally we won't reach here
+    }
+}
+

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxContextFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxContextFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control;
+
+import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+
+/**
+ * Represents the sandbox context factory - which is used with access control of the Script Mediator.
+ */
+public class SandboxContextFactory extends ContextFactory {
+    private AccessControlConfig nativeObjectAccessControlConfig;
+
+    public SandboxContextFactory(AccessControlConfig nativeObjectAccessControlConfig) {
+        this.nativeObjectAccessControlConfig = nativeObjectAccessControlConfig;
+    }
+
+    @Override
+    protected Context makeContext() {
+        Context cx = super.makeContext();
+        cx.setWrapFactory(new SandboxWrapFactory(nativeObjectAccessControlConfig));
+        return cx;
+    }
+}
+

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxNativeJavaObject.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxNativeJavaObject.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control;
+
+import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
+import org.mozilla.javascript.NativeJavaObject;
+import org.mozilla.javascript.Scriptable;
+
+import java.util.Comparator;
+
+/**
+ * Provides native Java objects to the sandbox, after necessary access control filtering.
+ */
+public class SandboxNativeJavaObject extends NativeJavaObject {
+    private AccessControlConfig nativeObjectAccessControlConfig;
+
+    public SandboxNativeJavaObject(Scriptable scope, Object javaObject, Class staticType,
+                                   AccessControlConfig nativeObjectAccessControlConfig) {
+        super(scope, javaObject, staticType);
+        this.nativeObjectAccessControlConfig = nativeObjectAccessControlConfig;
+    }
+
+    @Override
+    public Object get(String name, Scriptable start) {
+        Comparator<String> equalsComparator = new Comparator<String>() {
+            @Override
+            public int compare(String o1, String o2) {
+                if (o1 != null && o1.equals(o2)) {
+                    return 0;
+                }
+                return -1;
+            }
+        };
+        if (AccessControlUtils.isAccessAllowed(name, nativeObjectAccessControlConfig, equalsComparator)) {
+            return super.get(name, start);
+        }
+        return NOT_FOUND;
+    }
+
+}
+

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxWrapFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/SandboxWrapFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control;
+
+import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.WrapFactory;
+
+/**
+ * Wraps sandbox native Java objects that are used in Script Mediator access control.
+ */
+public class SandboxWrapFactory extends WrapFactory {
+    private AccessControlConfig nativeObjectAccessControlConfig;
+
+    public SandboxWrapFactory(AccessControlConfig nativeObjectAccessControlConfig) {
+        this.nativeObjectAccessControlConfig = nativeObjectAccessControlConfig;
+    }
+
+    @Override
+    public Scriptable wrapAsJavaObject(Context cx, Scriptable scope, Object javaObject, Class staticType) {
+        return new SandboxNativeJavaObject(scope, javaObject, staticType, nativeObjectAccessControlConfig);
+    }
+}
+
+

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/config/AccessControlConfig.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/config/AccessControlConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control.config;
+
+import java.util.List;
+
+/**
+ * Holds the configurations that are used for access control in the Script Mediator.
+ */
+public class AccessControlConfig {
+
+    private boolean isAccessControlEnabled;
+    private AccessControlListType accessControlListType;
+    private List<String> accessControlList;
+
+    public AccessControlConfig(boolean isAccessControlEnabled, AccessControlListType accessControlListType,
+                               List<String> accessControlList) {
+        this.isAccessControlEnabled = isAccessControlEnabled;
+        this.accessControlListType = accessControlListType;
+        this.accessControlList = accessControlList;
+    }
+
+    public boolean isAccessControlEnabled() {
+        return isAccessControlEnabled;
+    }
+
+    public AccessControlListType getAccessControlListType() {
+        return accessControlListType;
+    }
+
+    public List<String> getAccessControlList() {
+        return accessControlList;
+    }
+}
+

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/config/AccessControlListType.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/access/control/config/AccessControlListType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators.bsf.access.control.config;
+
+/**
+
+ * Represents the type of access control list for the Script Mediator.
+
+ */
+
+public enum AccessControlListType {
+    ALLOW_LIST,
+    BLOCK_LIST
+
+}
+

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
@@ -21,6 +21,7 @@ package org.apache.synapse.mediators.bsf.javascript;
 
 import junit.framework.TestCase;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.mediators.bsf.ScriptMediator;
 
@@ -62,5 +63,46 @@ public class JavaScriptMediatorTest extends TestCase {
 
         boolean response = mediator.mediate(mc);
         assertTrue(response);
+    }
+
+    /**
+     * Test controlling access to java classes through JS
+     * @throws Exception
+     */
+    public void testJavaClassAccessControl() throws Exception {
+        String scriptSourceCode =  "var s = new java.util.ArrayList();\n";
+
+
+        MessageContext mc = TestUtils.getTestContext("<foo/>", null);
+        ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
+
+        System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
+
+        try {
+            mediator.mediate(mc);
+            fail("Failed to enforce Java class access control configuration during mediation");
+        } catch(SynapseException e) {}
+
+    }
+
+    /**
+     * Test controlling access to java methods through JS
+     * @throws Exception
+     */
+    public void testJavaMethodAccessControl() throws Exception {
+        String scriptSourceCode =  "var c = this.context.getClass();\n" +
+                "var hashmapConstructors = c.getClassLoader().loadClass(\"java.util.HashMap\").getDeclaredConstructors();\n";
+
+
+        MessageContext mc = TestUtils.getTestContext("<foo/>", null);
+        ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
+
+        System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
+
+        try {
+            mediator.mediate(mc);
+            fail("Failed to enforce Java method access control configuration during mediation");
+        } catch(SynapseException e) {}
+
     }
 }

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
@@ -72,16 +72,20 @@ public class JavaScriptMediatorTest extends TestCase {
     public void testJavaClassAccessControl() throws Exception {
         String scriptSourceCode =  "var s = new java.util.ArrayList();\n";
 
-
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
         ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
 
         System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
 
+        boolean synapseExceptionThrown = false;
         try {
             mediator.mediate(mc);
-            fail("Failed to enforce Java class access control configuration during mediation");
-        } catch(SynapseException e) {}
+        } catch(SynapseException e) {
+            synapseExceptionThrown = true;
+        }
+
+        assertTrue("As Java class access control is configured " +
+                "SynapseException should be thrown during mediation", synapseExceptionThrown);
 
     }
 
@@ -93,16 +97,20 @@ public class JavaScriptMediatorTest extends TestCase {
         String scriptSourceCode =  "var c = this.context.getClass();\n" +
                 "var hashmapConstructors = c.getClassLoader().loadClass(\"java.util.HashMap\").getDeclaredConstructors();\n";
 
-
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
         ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
 
         System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
 
+        boolean synapseExceptionThrown = false;
         try {
             mediator.mediate(mc);
-            fail("Failed to enforce Java method access control configuration during mediation");
-        } catch(SynapseException e) {}
+        } catch(SynapseException e) {
+            synapseExceptionThrown = true;
+        }
+
+        assertTrue("As Java method access control is configured " +
+                "SynapseException should be thrown during mediation", synapseExceptionThrown);
 
     }
 }

--- a/modules/extensions/src/test/resources/synapse.properties
+++ b/modules/extensions/src/test/resources/synapse.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+limit_java_class_access_in_scripts.enable=true
+limit_java_class_access_in_scripts.list_type = BLOCK_LIST
+limit_java_class_access_in_scripts.class_prefixes = java.util.ArrayList
+limit_java_native_object_access_in_scripts.enable = true
+limit_java_native_object_access_in_scripts.list_type = BLOCK_LIST
+limit_java_native_object_access_in_scripts.object_names = getClassLoader,loadClass


### PR DESCRIPTION
## Purpose
The access to java classes though JS in script mediator can be controlled through following synapse propeties
```
limit_java_class_access_in_scripts.enable= true
limit_java_class_access_in_scripts.list_type = BLOCK_LIST # or ALLOW_LIST
limit_java_class_access_in_scripts.class_prefixes = java.util # Prefixes of class names, to be allowed or blocked
limit_java_native_object_access_in_scripts.enable = true
limit_java_native_object_access_in_scripts.list_type = BLOCK_LIST # or ALLOW_LIST
limit_java_native_object_access_in_scripts.object_names = getClassLoader,loadClass # Native method names, to be allowed or blocked
```