### PR TITLE
Add a configuration parameter to enable/disable graceful TLS connection termination

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -759,8 +759,13 @@ public class SourceHandler implements NHttpServerEventHandler {
         }
 
         SourceContext.updateState(conn, ProtocolState.CLOSED);
-   
-        sourceConfiguration.getSourceConnections().closeConnection(conn, true);
+
+        if (conf.isTLSGracefulConnectionTerminationEnabled()) {
+            sourceConfiguration.getSourceConnections().closeConnection(conn, true);
+        } else {
+            sourceConfiguration.getSourceConnections().shutDownConnection(conn, true);
+        }
+
         if (isTimeoutOccurred) {
             rollbackTransaction(conn);
         }
@@ -845,7 +850,13 @@ public class SourceHandler implements NHttpServerEventHandler {
         metrics.disconnected();
 
         SourceContext.updateState(conn, ProtocolState.CLOSED);
-        sourceConfiguration.getSourceConnections().closeConnection(conn, isFault);
+        
+        if (conf.isTLSGracefulConnectionTerminationEnabled()) {
+            sourceConfiguration.getSourceConnections().closeConnection(conn, isFault);
+        } else {
+            sourceConfiguration.getSourceConnections().shutDownConnection(conn, isFault);
+        }
+
         if (isFault) {
             rollbackTransaction(conn);
             metrics.exceptionOccured();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -827,7 +827,12 @@ public class TargetHandler implements NHttpClientEventHandler {
         metrics.disconnected();
 
         TargetContext.updateState(conn, ProtocolState.CLOSED);
-        targetConfiguration.getConnections().closeConnection(conn, isFault);
+        
+        if (conf.isTLSGracefulConnectionTerminationEnabled()) {
+            targetConfiguration.getConnections().closeConnection(conn, isFault);
+        } else {
+            targetConfiguration.getConnections().shutdownConnection(conn, isFault);
+        }
 
     }
 
@@ -937,7 +942,12 @@ public class TargetHandler implements NHttpClientEventHandler {
         }
 
         TargetContext.updateState(conn, ProtocolState.CLOSED);
-        targetConfiguration.getConnections().closeConnection(conn, true);
+        
+        if (conf.isTLSGracefulConnectionTerminationEnabled()) {
+            targetConfiguration.getConnections().closeConnection(conn, true);
+        } else {
+            targetConfiguration.getConnections().shutdownConnection(conn, true);
+        }
     }
 
     private String workerPoolExhaustedErrorMessage(Object clientWorker

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfigPNames.java
@@ -182,4 +182,10 @@ public interface PassThroughConfigPNames {
      * Defines whether to ignore case-sensitive headers from excess headers map
      */
     public String IGNORE_CASE_SENSITIVE_HEADERS = "ignore_case_sensitive_headers";
+
+    /**
+     * Defines whether TransportHandler and SourceHandler has to enable/disable TLS graceful connection termination
+     */
+    public String TLS_GRACEFUL_CONNECTION_TERMINATION = "tls_graceful_connection_termination";
+
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -70,6 +70,9 @@ public class PassThroughConfiguration {
     /** Reverse proxy mode is enabled or not */
     private Boolean reverseProxyMode = null;
 
+    /** Enables graceful termination for TLS connection */
+    private Boolean isTLSGracefulConnectionTerminationEnabled = null;
+
     /** Default Synapse service name */
     private String passThroughDefaultServiceName = null;
 
@@ -149,6 +152,14 @@ public class PassThroughConfiguration {
     public boolean isCloseSocketOnEndpointTimeout() {
         return ConfigurationBuilderUtil.getBooleanProperty(PassThroughConfigPNames.CLOSE_SOCKET_ON_ENDPOINT_TIMEOUT
                 , CLOSE_SOCKET_ON_ENDPOINT_TIMEOUT, props);
+    }
+
+    public boolean isTLSGracefulConnectionTerminationEnabled() {
+        if (isTLSGracefulConnectionTerminationEnabled == null) {
+            isTLSGracefulConnectionTerminationEnabled = getBooleanProperty(
+                    PassThroughConfigPNames.TLS_GRACEFUL_CONNECTION_TERMINATION, true);
+        }
+        return isTLSGracefulConnectionTerminationEnabled;
     }
 
     public boolean isConsumeAndDiscard() {


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/2420
- Port https://github.com/wso2-support/wso2-synapse/pull/2253
- Add a new configuration to enable/ disable the functionality of gracefully closing the TLS connection
- Users can add following configuration to `deployment.toml` to disable the above functionality which is enabled by default

> [passthru_http]
tls_graceful_connection_termination = false