### PR TITLE
Upgrade opentelemetry version to 1.11.0.wso2v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1589,7 +1589,7 @@
        <transport.http.netty.version>6.3.50</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <opentelemetry.all.version>1.34.1.wso2v1</opentelemetry.all.version>
+       <opentelemetry.all.version>1.11.0.wso2v6</opentelemetry.all.version>
        <okhttp.wso2.version>4.9.3.wso2v2</okhttp.wso2.version>
        <okio.wso2.version>2.8.0.wso2v2</okio.wso2.version>
        <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1569,7 +1569,7 @@
       <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
       <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
       <google.guava.version>33.0.0-jre</google.guava.version>
-      <failureaccess.version>1.0.1</failureaccess.version>
+      <failureaccess.version>1.0.2</failureaccess.version>
       <joda-time.version>2.9.4.wso2v1</joda-time.version>
       <com.googlecode.libphonenumber.version>7.4.2.wso2v1</com.googlecode.libphonenumber.version>
       <jacoco.agent.version>0.8.6</jacoco.agent.version>
@@ -1589,7 +1589,7 @@
        <transport.http.netty.version>6.3.50</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <opentelemetry.all.version>1.11.0.wso2v5</opentelemetry.all.version>
+       <opentelemetry.all.version>1.34.1.wso2v1</opentelemetry.all.version>
        <okhttp.wso2.version>4.9.3.wso2v2</okhttp.wso2.version>
        <okio.wso2.version>2.8.0.wso2v2</okio.wso2.version>
        <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>


### PR DESCRIPTION
## Purpose
Upgrade open telemetry dependency with the guava range to support 33.0.0-jre