### PR TITLE
Avoid clearing buffer when ProducerError occurs in Passthru pipe

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -672,7 +672,6 @@ public class Pipe {
                         return;
                     } else if (isProducerError()) {
                         writeCondition.signalAll();
-                        buffer.clear();
                         return;
                     }
                 } else if (consumerIoControl instanceof NHttpClientConnection) {


### PR DESCRIPTION
Resolves https://github.com/wso2/micro-integrator/issues/3081

This PR resolves an OOM issue where a loop scenario is created when the backend resets the connection without properly sending the complete payload. When backend closes the connection, the `producerError` flag of the Passthru Pipe is set to true. A previous fix[1] has been introduced to clear the buffer during such scenarios. But when the buffer is cleared, the read position of the buffer is set to 0. Hence IOUtils.copy() method tries to copy the same inputStream to outputStream again and again which leads to the OOM issue.

<img width="520" alt="Screenshot 2024-01-22 at 11 25 56" src="https://github.com/wso2-support/wso2-synapse/assets/17047910/b9ec5661-2a5c-4eb0-a0e1-687486b7faf9">

[1] - https://github.com/wso2/wso2-synapse/pull/1933