### PR TITLE
Upgrade json schema validator to 2.2.6.wso2v10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1565,7 +1565,7 @@
       <javax.servlet.version>3.0.1</javax.servlet.version>
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
-      <fge.json.schema.validator.version>2.2.6.wso2v9</fge.json.schema.validator.version>
+      <fge.json.schema.validator.version>2.2.6.wso2v10</fge.json.schema.validator.version>
       <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
       <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
       <google.guava.version>33.0.0-jre</google.guava.version>


### PR DESCRIPTION
## Purpose
Upgrade json schema validator with upgraded guava version range to support 33.0