### PR TITLE
Bump okhttp okio and opentel versions to match versions in apimgt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1589,9 +1589,9 @@
        <transport.http.netty.version>6.3.50</transport.http.netty.version>
        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v3</version.org.wso2.orbit.javax.activation>
        <rabbitmq.version>5.8.0</rabbitmq.version>
-       <opentelemetry.all.version>1.11.0.wso2v6</opentelemetry.all.version>
-       <okhttp.wso2.version>4.9.3.wso2v2</okhttp.wso2.version>
-       <okio.wso2.version>2.8.0.wso2v2</okio.wso2.version>
+       <opentelemetry.all.version>1.34.1.wso2v1</opentelemetry.all.version>
+       <okhttp.wso2.version>4.11.0.wso2v1</okhttp.wso2.version>
+       <okio.wso2.version>3.6.0.wso2v1</okio.wso2.version>
        <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>
        <zipkin.version>2.23.2</zipkin.version>
        <zipkin-reporter.version>2.16.3</zipkin-reporter.version>


### PR DESCRIPTION
## Purpose
Fixing : https://github.com/wso2/api-manager/issues/2427