### PR TITLE
Fix analytics data of template endpoints publishing twice

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
@@ -51,23 +51,7 @@ public class TemplateEndpoint extends AbstractEndpoint {
 
     @Override
     public void send(MessageContext synCtx) {
-        if (RuntimeStatisticCollector.isStatisticsEnabled()) {
-            Integer currentIndex = null;
-            if (getDefinition() != null) {
-                currentIndex = OpenEventCollector.reportChildEntryEvent(synCtx, getReportingName(),
-                        ComponentType.ENDPOINT, getDefinition().getAspectConfiguration(), true);
-            }
-            try {
-                sendMessage(synCtx);
-            } finally {
-                if (currentIndex != null) {
-                    CloseEventCollector.closeEntryEvent(synCtx, getReportingName(), ComponentType.MEDIATOR,
-                            currentIndex, false);
-                }
-            }
-        } else {
-            sendMessage(synCtx);
-        }
+        sendMessage(synCtx);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/TemplateEndpoint.java
@@ -51,7 +51,15 @@ public class TemplateEndpoint extends AbstractEndpoint {
 
     @Override
     public void send(MessageContext synCtx) {
-        sendMessage(synCtx);
+        reLoadAndInitEndpoint(synCtx.getEnvironment());
+
+        if (realEndpoint != null) {
+            realEndpoint.send(synCtx);
+        } else {
+            informFailure(synCtx, SynapseConstants.ENDPOINT_IN_DIRECT_NOT_READY,
+                    "Couldn't find the endpoint with the name " + getName() +
+                            " & template : " + template);
+        }
     }
 
     @Override
@@ -62,18 +70,6 @@ public class TemplateEndpoint extends AbstractEndpoint {
         endpointJson.put(TYPE_JSON_ATT, "Template Endpoint");
         endpointJson.put("parameters", getParameters());
         endpointJson.put("template", getTemplate());
-    }
-
-    public void sendMessage(MessageContext synCtx) {
-        reLoadAndInitEndpoint(synCtx.getEnvironment());
-
-        if (realEndpoint != null) {
-            realEndpoint.send(synCtx);
-        } else {
-            informFailure(synCtx, SynapseConstants.ENDPOINT_IN_DIRECT_NOT_READY,
-                    "Couldn't find the endpoint with the name " + getName() +
-                            " & template : " + template);
-        }
     }
 
     public Map<String, String> getParameters() {


### PR DESCRIPTION
When invoking a template endpoint, two endpoint events are added to the event queue through the AbstractEndpoint and TemplateEndpoint, which results in publishing the same endpoint analytics data twice.

As a fix, this PR removes the event added through the TemplateEndpoint.

Fixes: https://github.com/wso2/micro-integrator/issues/3119