### PR TITLE
Fix source payload not preserving in call mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
@@ -109,6 +109,11 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
 
         OMElement targetEle = elem.getFirstChildWithName(TARGET_Q);
         if (targetEle != null) {
+            if (sourceEle == null) {
+                Source source = CallMediatorEnrichUtil.createSourceWithBody();
+                callMediator.setSourceAvailable(true);
+                callMediator.setSourceForOutboundPayload(source);
+            }
             Target target = new Target();
             populateTarget(callMediator, target, targetEle);
             callMediator.setTargetForInboundPayload(target);


### PR DESCRIPTION

## Purpose
When there isn't a defined source when using source and target with call mediator the source supposed to be the body and after mediation the original payload in this case source should be preserved but in this case there isn't a define source it was not happening and I have fixed it by adding a dummy source.

Fixes: https://github.com/wso2/micro-integrator/issues/3086
