### PR TITLE
Add a new method to identify the invoked API

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/api/API.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/API.java
@@ -246,6 +246,10 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
         return resources.values().toArray(new Resource[resources.size()]);
     }
 
+    public Map<String, Resource> getResourcesMap() {
+        return resources;
+    }
+
     public void addHandler(Handler handler) {
         handlers.add(handler);
     }
@@ -443,12 +447,7 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
                     msgCtx.getIncomingTransportName() + "://" + hostHeader);
         }
 
-        Set<Resource> acceptableResources = new LinkedHashSet<Resource>();
-        for (Resource r : resources.values()) {
-            if (isBound(r, synCtx) && r.canProcess(synCtx)) {
-                acceptableResources.add(r);
-            }
-        }
+        Set<Resource> acceptableResources = ApiUtils.getAcceptableResources(resources, synCtx);
 
         boolean processed = false;
         if (!acceptableResources.isEmpty()) {
@@ -530,23 +529,6 @@ public class API extends AbstractRequestProcessor implements ManagedLifecycle, A
 
     }
 
-    /**
-     * Checks whether the provided resource is capable of processing the message from the provided message context.
-     * The resource becomes capable to do this when the it contains either the name of the api caller,
-     * or {@value ApiConstants#DEFAULT_BINDING_ENDPOINT_NAME}, in its binds-to.
-     *
-     * @param resource  Resource object
-     * @param synCtx    MessageContext object
-     * @return          Whether the provided resource is bound to the provided message context
-     */
-    private boolean isBound(Resource resource, MessageContext synCtx) {
-        Collection<String> bindings = resource.getBindsTo();
-        Object apiCaller = synCtx.getProperty(ApiConstants.API_CALLER);
-        if (apiCaller != null) {
-            return bindings.contains(apiCaller.toString());
-        }
-        return bindings.contains(ApiConstants.DEFAULT_BINDING_ENDPOINT_NAME);
-    }
 
     /**
      * Helper method to use when no matching resource found

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -194,7 +194,6 @@ public class ApiUtils {
     }
 
     public static API getSelectedAPI(MessageContext synCtx) {
-        API selectedApi;
         //getting the API collection from the synapse configuration to find the invoked API
         Collection<API> apiSet = synCtx.getEnvironment().getSynapseConfiguration().getAPIs();
         //Since swapping elements are not possible with sets, Collection is converted to a List
@@ -204,8 +203,7 @@ public class ApiUtils {
         //identiy the api using canProcess method
         for (API api : duplicateApiSet) {
             if (identifySelectedAPI(api, synCtx, defaultStrategyApiSet)) {
-                selectedApi = api;
-                return selectedApi;
+                return api;
             }
         }
         for (API api : defaultStrategyApiSet) {
@@ -214,8 +212,7 @@ public class ApiUtils {
                 if (log.isDebugEnabled()) {
                     log.debug("Located specific API: " + api.getName() + " for processing message");
                 }
-                selectedApi = api;
-                return selectedApi;
+                return api;
             }
         }
         return null;

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -42,7 +42,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 public class ApiUtils {
 

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -39,8 +39,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public class ApiUtils {
 
@@ -158,6 +157,34 @@ public class ApiUtils {
         return (String) synCtx.getProperty(RESTConstants.REST_SUB_REQUEST_PATH);
     }
 
+    /**
+     * Checks whether the provided resource is capable of processing the message from the provided message context.
+     * The resource becomes capable to do this when the it contains either the name of the api caller,
+     * or {@value ApiConstants#DEFAULT_BINDING_ENDPOINT_NAME}, in its binds-to.
+     *
+     * @param resource  Resource object
+     * @param synCtx    MessageContext object
+     * @return          Whether the provided resource is bound to the provided message context
+     */
+    public static boolean isBound(Resource resource, MessageContext synCtx) {
+        Collection<String> bindings = resource.getBindsTo();
+        Object apiCaller = synCtx.getProperty(ApiConstants.API_CALLER);
+        if (apiCaller != null) {
+            return bindings.contains(apiCaller.toString());
+        }
+        return bindings.contains(ApiConstants.DEFAULT_BINDING_ENDPOINT_NAME);
+    }
+
+    public static Set<Resource> getAcceptableResources(Map<String, Resource> resources, MessageContext synCtx) {
+        Set<Resource> acceptableResources = new LinkedHashSet<Resource>();
+        for (Resource r : resources.values()) {
+            if (isBound(r, synCtx) && r.canProcess(synCtx)) {
+                acceptableResources.add(r);
+            }
+        }
+        return acceptableResources;
+    }
+
     public static List<RESTDispatcher> getDispatchers() {
         return dispatchers;
     }
@@ -177,8 +204,8 @@ public class ApiUtils {
      * and false if the two values don't match
      */
     public static boolean matchApiPath(String path, String context) {
-        if (!path.startsWith(context + "/") && !path.startsWith(context + "?") &&
-                !context.equals(path) && !"/".equals(context)) {
+        if (!path.startsWith(context + "/") && !path.startsWith(context + "?")
+                && !context.equals(path) && !"/".equals(context)) {
             return false;
         }
         return true;

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -193,6 +193,12 @@ public class ApiUtils {
         return acceptableResources;
     }
 
+    /**
+     * This method is used to locate the specific API that has been invoked from the collection of all APIs.
+     *
+     * @param synCtx MessageContext of the request
+     * @return Selected API
+     */
     public static API getSelectedAPI(MessageContext synCtx) {
         //getting the API collection from the synapse configuration to find the invoked API
         Collection<API> apiSet = synCtx.getEnvironment().getSynapseConfiguration().getAPIs();
@@ -200,7 +206,7 @@ public class ApiUtils {
         List<API> defaultStrategyApiSet = new ArrayList<API>(apiSet);
         //To avoid apiSet being modified concurrently
         List<API> duplicateApiSet = new ArrayList<>(apiSet);
-        //identiy the api using canProcess method
+        //identify the api using canProcess method
         for (API api : duplicateApiSet) {
             if (identifySelectedAPI(api, synCtx, defaultStrategyApiSet)) {
                 return api;
@@ -218,7 +224,7 @@ public class ApiUtils {
         return null;
     }
 
-    public static boolean identifySelectedAPI(API api, MessageContext synCtx, List defaultStrategyApiSet) {
+    private static boolean identifySelectedAPI(API api, MessageContext synCtx, List defaultStrategyApiSet) {
         API defaultAPI = null;
         api.setLogSetterValue();
         if ("/".equals(api.getContext())) {

--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -195,7 +195,6 @@ public class ApiUtils {
 
     public static API getSelectedAPI(MessageContext synCtx) {
         API selectedApi;
-        API defaultAPI = null;
         //getting the API collection from the synapse configuration to find the invoked API
         Collection<API> apiSet = synCtx.getEnvironment().getSynapseConfiguration().getAPIs();
         //Since swapping elements are not possible with sets, Collection is converted to a List
@@ -218,10 +217,6 @@ public class ApiUtils {
                 selectedApi = api;
                 return selectedApi;
             }
-        }
-        if (defaultAPI != null && defaultAPI.canProcess(synCtx)) {
-            defaultAPI.setLogSetterValue();
-            return defaultAPI;
         }
         return null;
     }

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/DefaultDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/DefaultDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.synapse.api.dispatch;
 
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.api.Resource;
+import org.apache.synapse.rest.RESTConstants;
 
 import java.util.Collection;
 
@@ -28,6 +29,7 @@ public class DefaultDispatcher implements RESTDispatcher {
     public Resource findResource(MessageContext synCtx, Collection<Resource> resources) {
         for (Resource resource : resources) {
             if (resource.getDispatcherHelper() == null) {
+                synCtx.setProperty(RESTConstants.SELECTED_RESOURCE, resource);
                 return resource;
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateBasedDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URITemplateBasedDispatcher.java
@@ -35,12 +35,13 @@ public class URITemplateBasedDispatcher implements RESTDispatcher {
             DispatcherHelper helper = r.getDispatcherHelper();
             if (helper instanceof URITemplateHelper) {
                 URITemplateHelper templateHelper = (URITemplateHelper) helper;
-                Map<String,String> variables = new HashMap<String,String>();
+                Map<String, String> variables = new HashMap<String, String>();
                 if (templateHelper.getUriTemplate().matches(url, variables)) {
-                    for (Map.Entry<String,String> entry : variables.entrySet()) {
+                    for (Map.Entry<String, String> entry : variables.entrySet()) {
                         synCtx.setProperty(RESTConstants.REST_URI_VARIABLE_PREFIX + entry.getKey(),
                                 entry.getValue());
                     }
+                    synCtx.setProperty(RESTConstants.SELECTED_RESOURCE, r);
                     return r;
                 }
             }

--- a/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingBasedDispatcher.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/dispatch/URLMappingBasedDispatcher.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.api.Resource;
+import org.apache.synapse.rest.RESTConstants;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +56,7 @@ public class URLMappingBasedDispatcher implements RESTDispatcher {
                 if (log.isDebugEnabled()) {
                     log.debug("Found exact URL match for: " + url);
                 }
+                synCtx.setProperty(RESTConstants.SELECTED_RESOURCE, filteredResources.get(i));
                 return filteredResources.get(i);
             }
         }
@@ -72,6 +74,7 @@ public class URLMappingBasedDispatcher implements RESTDispatcher {
             if (log.isDebugEnabled()) {
                 log.debug("Found path match for: " + url + " with matching length: " + maxLength);
             }
+            synCtx.setProperty(RESTConstants.SELECTED_RESOURCE, matchedResource);
             return matchedResource;
         }
 
@@ -80,6 +83,7 @@ public class URLMappingBasedDispatcher implements RESTDispatcher {
                 if (log.isDebugEnabled()) {
                     log.debug("Found extension match for: " + url);
                 }
+                synCtx.setProperty(RESTConstants.SELECTED_RESOURCE, filteredResources.get(i));
                 return filteredResources.get(i);
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/rest/RESTConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/rest/RESTConstants.java
@@ -91,5 +91,6 @@ public class RESTConstants {
      */
     public static final String IS_PROMETHEUS_ENGAGED = "IS_PROMETHEUS_ENGAGED";
     public static final String PROCESSED_API = "PROCESSED_API";
+    public static final String SELECTED_RESOURCE = "SELECTED_RESOURCE";
 
 }


### PR DESCRIPTION
## Purpose
This PR adds a new method to identify the invoked API from the collection of all APIs.

The initial change was https://github.com/wso2/wso2-synapse/pull/2083. But as this was a major refactoring, we have ported the changes from https://github.com/wso2/wso2-synapse/pull/2079 only.