### PR TITLE
Fix enrich mediator failing continuously when a parse error happens

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Source.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Source.java
@@ -321,24 +321,27 @@ public class Source {
             case EnrichMediator.INLINE: {
                 assert inlineOMNode != null
                         || inlineKey != null : "inlineJSONNode or key shouldn't be null when type is INLINE";
-                if (inlineOMNode instanceof OMText) {
-                    object = JsonPath.parse(((OMTextImpl) inlineOMNode).getText()).json();
-                } else if (inlineKey != null && !inlineKey.trim().equals("")) {
-                    Object inlineObj = synCtx.getEntry(inlineKey);
-                    if ((inlineObj instanceof String) && !(((String) inlineObj).trim().equals(""))) {
-                        object = JsonPath.parse(((String) inlineObj)).json();
+                try {
+                    if (inlineOMNode instanceof OMText) {
+                        object = JsonPath.parse(((OMTextImpl) inlineOMNode).getText()).json();
+                    } else if (inlineKey != null && !inlineKey.trim().equals("")) {
+                        Object inlineObj = synCtx.getEntry(inlineKey);
+                        if ((inlineObj instanceof String) && !(((String) inlineObj).trim().equals(""))) {
+                            object = JsonPath.parse(((String) inlineObj)).json();
+                        } else {
+                            synLog.error("Source failed to get inline JSON" + "inlineKey=" + inlineKey);
+                        }
                     } else {
-                        synLog.error("Source failed to get inline JSON" + "inlineKey=" + inlineKey);
+                        synLog.error("Source failed to get inline JSON" + "inlineJSONNode=" + inlineOMNode + ", inlineKey="
+                                + inlineKey);
                     }
-                } else {
-                    synLog.error("Source failed to get inline JSON" + "inlineJSONNode=" + inlineOMNode + ", inlineKey="
-                            + inlineKey);
-                }
-                // If the initialInlineOMNode is not null, it means that inline OM Node has been overridden with the
-                // inline string containing resolved dynamic values. Therefore, we should set the initial OM Node back
-                // which contains the original inline value
-                if (initialInlineOMNode != null) {
-                    this.inlineOMNode = initialInlineOMNode;
+                } finally {
+                    // If the initialInlineOMNode is not null, it means that inline OM Node has been overridden with the
+                    // inline string containing resolved dynamic values. Therefore, we should set the initial OM Node back
+                    // which contains the original inline value
+                    if (initialInlineOMNode != null) {
+                        this.inlineOMNode = initialInlineOMNode;
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
## Purpose

When a JSON parse error happens, the enrich mediator will fail continuously even for valid JSON inputs. To fix this we need to reset the inlineOMNode when an error happens.

Fixes: https://github.com/wso2/micro-integrator/issues/3272