### PR TITLE
Improve StartupController to delete pending tasks

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
@@ -76,7 +76,7 @@ public class StartUpController extends AbstractStartup {
         }        
         if (synapseTaskManager.isInitialized()) {
             TaskScheduler taskScheduler = synapseTaskManager.getTaskScheduler();
-            if (taskScheduler != null && taskScheduler.isInitialized() && removeTask) {
+            if (taskScheduler != null && taskScheduler.isTaskSchedulerInitialized() && removeTask) {
                 taskScheduler.deleteTask(taskDescription.getName(), taskDescription.getTaskGroup());
             }
             TaskDescriptionRepository repository = synapseTaskManager.getTaskDescriptionRepository();

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskScheduler.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskScheduler.java
@@ -159,6 +159,12 @@ public class TaskScheduler {
         }
     }
 
+    public boolean isTaskSchedulerInitialized() {
+        synchronized (lock) {
+            return initialized;
+        }
+    }
+
     public void deleteTask(String name, String group) {
         synchronized (lock) {
             if (!initialized) {


### PR DESCRIPTION
$subject

When the TaskScheduler is initialized but TaskManager is not initialized, the task will be added to taskQueue. But when the task gets destroyed before the tTaskManager is not initialized, the taskQueue is not cleared. 

Resolves https://github.com/wso2/api-manager/issues/2525