### PR TITLE
Update the json-schema-validator version to 2.2.7

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -343,7 +343,7 @@
         </dependency>
         <!--  JSON Schema validator dependency -->
         <dependency>
-            <groupId>org.wso2.orbit.com.github.fge</groupId>
+            <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator-all</artifactId>
         </dependency>
         <dependency>

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -131,7 +131,7 @@
             <artifactId>synapse-core</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.wso2.orbit.com.github.fge</groupId>
+                    <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
                     <artifactId>json-schema-validator-all</artifactId>
                 </exclusion>
             </exclusions>
@@ -143,7 +143,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.wso2.orbit.com.github.fge</groupId>
+                    <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
                     <artifactId>json-schema-validator-all</artifactId>
                 </exclusion>
             </exclusions>

--- a/modules/features/org.apache.synapse.wso2.feature/pom.xml
+++ b/modules/features/org.apache.synapse.wso2.feature/pom.xml
@@ -76,7 +76,7 @@
             <artifactId>handy-uri-templates</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.github.fge</groupId>
+            <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator-all</artifactId>
         </dependency>
         <dependency>
@@ -155,7 +155,7 @@
                                 <!--<bundleDef>org.wso2.orbit.joda-time:joda-time:${joda-time.version}</bundleDef>-->
                                 <bundleDef>com.google.guava:guava:${google.guava.version}</bundleDef>
                                 <bundleDef>com.google.guava:failureaccess:${failureaccess.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.com.github.fge:json-schema-validator-all</bundleDef>
+                                <bundleDef>org.wso2.orbit.com.github.java-json-tools:json-schema-validator-all</bundleDef>
                                 <bundleDef>
                                     org.wso2.orbit.io.opentelemetry:opentelemetry-all:${opentelemetry.all.version}
                                 </bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1067,9 +1067,9 @@
               <version>${version.org.wso2.orbit.javax.activation}</version>
           </dependency>
          <dependency>
-            <groupId>org.wso2.orbit.com.github.fge</groupId>
+            <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator-all</artifactId>
-            <version>${fge.json.schema.validator.version}</version>
+            <version>${java-json-tools.json.schema.validator.version}</version>
          </dependency>
          <dependency>
               <groupId>com.fasterxml.jackson.core</groupId>
@@ -1565,7 +1565,7 @@
       <javax.servlet.version>3.0.1</javax.servlet.version>
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
-      <fge.json.schema.validator.version>2.2.6.wso2v10</fge.json.schema.validator.version>
+      <java-json-tools.json.schema.validator.version>2.2.7.wso2v1</java-json-tools.json.schema.validator.version>
       <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
       <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
       <google.guava.version>33.0.0-jre</google.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1565,7 +1565,7 @@
       <javax.servlet.version>3.0.1</javax.servlet.version>
       <powermock.version>2.0.9</powermock.version>
       <mockito.version>3.0.0</mockito.version>
-      <java-json-tools.json.schema.validator.version>2.2.7.wso2v1</java-json-tools.json.schema.validator.version>
+      <java-json-tools.json.schema.validator.version>2.2.7.wso2v2</java-json-tools.json.schema.validator.version>
       <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
       <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
       <google.guava.version>33.0.0-jre</google.guava.version>


### PR DESCRIPTION
## Purpose
Update the json-schema-validator version to 2.2.7. 

Fixes: https://github.com/wso2/micro-integrator/issues/3311

