### PR TITLE
Add option to continue iterations on failure for foreach mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorFactory.java
@@ -54,6 +54,9 @@ public class ForEachMediatorFactory extends AbstractMediatorFactory {
     private static final QName ID_Q
             = new QName(XMLConfigConstants.NULL_NAMESPACE, "id");
 
+    private static final QName CONTINUE_IN_FAULT_Q
+            = new QName(XMLConfigConstants.NULL_NAMESPACE, "continueLoopOnFailure");
+
     public QName getTagQName() {
         return FOREACH_Q;
     }
@@ -67,6 +70,11 @@ public class ForEachMediatorFactory extends AbstractMediatorFactory {
         OMAttribute id = elem.getAttribute(ID_Q);
         if (id != null) {
             mediator.setId(id.getAttributeValue());
+        }
+
+        OMAttribute continueOnFail = elem.getAttribute(CONTINUE_IN_FAULT_Q);
+        if (continueOnFail != null) {
+            mediator.setContinueLoopOnFailure(Boolean.parseBoolean(continueOnFail.getAttributeValue()));
         }
 
         OMAttribute expression = elem.getAttribute(ATT_EXPRN);


### PR DESCRIPTION
## Purpose

Add option to continue iterations on failure for foreach mediator. Set the attribute `continueLoopOnFailure` to true to continue the iterations when an error occurs.

```xml
<foreach expression="json-eval($.info)" id="foreach_1o" continueLoopOnFailure="true">
    <sequence>
        ...
    </sequence>
</foreach>
```

Fixes : https://github.com/wso2/micro-integrator/issues/3318