### PR TITLE
Fix CPU spinning issue

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -1064,100 +1064,101 @@ public class TargetHandler implements NHttpClientEventHandler {
     public void exception(NHttpClientConnection conn, Exception ex) {
         ProtocolState state = TargetContext.getState(conn);
         MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
-        Map<String, String> logDetails = getLoggingInfo(conn, state, requestMsgCtx, ex);
-
-        if (state == ProtocolState.REQUEST_HEAD || state == ProtocolState.REQUEST_BODY) {
-            informWriterError(conn);
-            log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
-                    + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
-                    + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
-                    + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
-                    + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
-                    + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
-                    .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
-                    + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
-                    + ", CONNECTION = " + conn);
-        } else if (state == ProtocolState.RESPONSE_HEAD || state == ProtocolState.RESPONSE_BODY) {
-            informReaderError(conn);
-            log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
-                    + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
-                    + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
-                    + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
-                    + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
-                    + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
-                    .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
-                    + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
-                    + ", CONNECTION = " + conn);
-        } else if (state == ProtocolState.REQUEST_DONE) {
-            log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
-                    + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
-                    + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
-                    + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
-                    + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
-                    + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
-                    .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
-                    + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
-                    + ", CONNECTION = " + conn);
-        } else if (state == ProtocolState.REQUEST_READY) {
-            log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
-                    + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
-                    + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
-                    + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
-                    + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
-                    + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
-                    .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
-                    + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
-                    + ", CONNECTION = " + conn);
-        } else if (state == ProtocolState.RESPONSE_DONE) {
-            return;
-        }
-        
-        if (ex instanceof IOException) {
-
-            logIOException(conn, (IOException) ex);
-            if (PassThroughCorrelationConfigDataHolder.isEnable()){
-                logHttpRequestErrorInCorrelationLog(conn, "IO Exception in " + state.name());
+        try {
+            Map<String, String> logDetails = getLoggingInfo(conn, state, requestMsgCtx, ex);
+            if (state == ProtocolState.REQUEST_HEAD || state == ProtocolState.REQUEST_BODY) {
+                informWriterError(conn);
+                log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
+                        + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
+                        + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
+                        + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
+                        + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
+                        + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
+                        .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
+                        + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
+                        + ", CONNECTION = " + conn);
+            } else if (state == ProtocolState.RESPONSE_HEAD || state == ProtocolState.RESPONSE_BODY) {
+                informReaderError(conn);
+                log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
+                        + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
+                        + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
+                        + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
+                        + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
+                        + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
+                        .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
+                        + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
+                        + ", CONNECTION = " + conn);
+            } else if (state == ProtocolState.REQUEST_DONE) {
+                log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
+                        + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
+                        + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
+                        + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
+                        + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
+                        + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
+                        .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
+                        + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
+                        + ", CONNECTION = " + conn);
+            } else if (state == ProtocolState.REQUEST_READY) {
+                log.warn("ERROR_CODE = " + logDetails.get("error_code") + ", STATE_DESCRIPTION = Exception occurred "
+                        + logDetails.get("state_description") + ", INTERNAL_STATE = " + state + ", DIRECTION = "
+                        + logDetails.get("direction") + ", " + "CAUSE_OF_ERROR = " + logDetails.get("cause_of_error")
+                        + ", TARGET_HOST = " + logDetails.get("host") + ", TARGET_PORT = " + logDetails.get("port")
+                        + ", TARGET_CONTEXT = " + logDetails.get("url") + ", " + "HTTP_METHOD = " + logDetails.get("method")
+                        + ", TRIGGER_TYPE = " + logDetails.get("trigger_type") + ", TRIGGER_NAME = " + logDetails
+                        .get("trigger_name") + ", REMOTE_ADDRESS = " + getBackEndConnectionInfo(conn)
+                        + ", CORRELATION_ID" + " = " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID)
+                        + ", CONNECTION = " + conn);
             }
-            if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
-                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
-                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
-                targetErrorHandler.handleError(requestMsgCtx,
-                        ErrorCodes.SND_IO_ERROR,
-                        "Error in Sender",
-                        ex,
-                        state);
-            }
+        } finally {
+            if (ex instanceof IOException) {
 
-            TargetContext.updateState(conn, ProtocolState.CLOSING);
-        } else if (ex instanceof HttpException) {
-            String message = getErrorMessage("HTTP protocol violation : " + ex.getMessage(), conn);
-            log.error(message, ex);
-            if (PassThroughCorrelationConfigDataHolder.isEnable()){
-                logHttpRequestErrorInCorrelationLog(conn, "HTTP Exception in " + state.name());
-            }
-            if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
-                requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
-                        PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
-                targetErrorHandler.handleError(requestMsgCtx,
-                        ErrorCodes.PROTOCOL_VIOLATION,
-                        "Error in Sender",
-                        null,
-                        state);
-            }
+                logIOException(conn, (IOException) ex);
+                if (PassThroughCorrelationConfigDataHolder.isEnable()){
+                    logHttpRequestErrorInCorrelationLog(conn, "IO Exception in " + state.name());
+                }
+                if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
+                    requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                            PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
+                    targetErrorHandler.handleError(requestMsgCtx,
+                            ErrorCodes.SND_IO_ERROR,
+                            "Error in Sender",
+                            ex,
+                            state);
+                }
 
-            TargetContext.updateState(conn, ProtocolState.CLOSED);
-        } else {
-            if(null != ex && null != ex.getMessage()) {
-                log.error("Unexpected error: " + ex.getMessage(), ex);
+                TargetContext.updateState(conn, ProtocolState.CLOSING);
+            } else if (ex instanceof HttpException) {
+                String message = getErrorMessage("HTTP protocol violation : " + ex.getMessage(), conn);
+                log.error(message, ex);
+                if (PassThroughCorrelationConfigDataHolder.isEnable()){
+                    logHttpRequestErrorInCorrelationLog(conn, "HTTP Exception in " + state.name());
+                }
+                if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
+                    requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                            PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
+                    targetErrorHandler.handleError(requestMsgCtx,
+                            ErrorCodes.PROTOCOL_VIOLATION,
+                            "Error in Sender",
+                            null,
+                            state);
+                }
+
+                TargetContext.updateState(conn, ProtocolState.CLOSED);
             } else {
-                log.error("Unexpected error.");
+                if (null != ex && null != ex.getMessage()) {
+                    log.error("Unexpected error: " + ex.getMessage(), ex);
+                } else {
+                    log.error("Unexpected error.");
+                }
+                if (PassThroughCorrelationConfigDataHolder.isEnable()) {
+                    logHttpRequestErrorInCorrelationLog(conn, "Unexpected error");
+                }
+                TargetContext.updateState(conn, ProtocolState.CLOSED);
             }
-            if (PassThroughCorrelationConfigDataHolder.isEnable()) {
-                logHttpRequestErrorInCorrelationLog(conn, "Unexpected error");
-            }
-            TargetContext.updateState(conn, ProtocolState.CLOSED);
+
+            targetConfiguration.getConnections().shutdownConnection(conn, true);
         }
-        targetConfiguration.getConnections().shutdownConnection(conn, true);
+
     }
 
     public void setConnFactory(ClientConnFactory connFactory) {


### PR DESCRIPTION


## Purpose
When back-end connection is closed (RST sent) while handling the response if the protocol state is already marked as RESPONSE_DONE in the TargetHandler exception patch we have omitted to close the connection so the connection remain intact and it will continue to hit the inputReady method and when trying to read from the SSLIOSession it will throws a I/O Exception but since in the exception patch we are omitting the error this will loop.
Fixed this issue by moving the connection close logic to finally block.

Fixes: https://github.com/wso2/micro-integrator/issues/3363