### PR TITLE
Make connection reset error log a debug log

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServiceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServiceHandler.java
@@ -70,7 +70,7 @@ class LoggingNHttpServiceHandler implements NHttpServerEventHandler {
             msg = "";
         }
         if (ex instanceof ConnectionClosedException ||
-                msg.contains("Connection reset by peer") ||
+                msg.contains("Connection reset") ||
                 msg.contains("forcibly closed")) {
             if (this.log.isDebugEnabled()) {
                 this.log.debug(conn + ": " + msg +

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerHandler.java
@@ -619,7 +619,7 @@ public class ServerHandler implements NHttpServerEventHandler {
                 commitResponseHideExceptions(conn, response);
             } catch (Exception ignore) {}
         } else if (e instanceof ConnectionClosedException || (e.getMessage() != null &&
-                (e.getMessage().contains("Connection reset by peer") ||
+                (e.getMessage().contains("Connection reset") ||
                 e.getMessage().contains("forcibly closed")))) {
             if (log.isDebugEnabled()) {
                 errMsg = "I/O error (Probably the keepalive connection " +
@@ -658,7 +658,7 @@ public class ServerHandler implements NHttpServerEventHandler {
         String errMsg = "I/O error : " + e.getMessage();
 
         if (e instanceof ConnectionClosedException || (e.getMessage() != null &&
-                (e.getMessage().contains("Connection reset by peer") ||
+                (e.getMessage().contains("Connection reset") ||
                         e.getMessage().contains("forcibly closed")))) {
             if (log.isDebugEnabled()) {
                 errMsg = "I/O error (Probably the keepalive connection " +

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -645,7 +645,7 @@ public class SourceHandler implements NHttpServerEventHandler {
             return;
         }
         if (e instanceof ConnectionClosedException || (e.getMessage() != null && (
-                e.getMessage().toLowerCase().contains("connection reset by peer") ||
+                e.getMessage().toLowerCase().contains("connection reset") ||
                 e.getMessage().toLowerCase().contains("forcibly closed")))) {
             if (log.isDebugEnabled()) {
                 log.debug(conn + ": I/O error (Probably the keepalive connection "

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -840,7 +840,7 @@ public class TargetHandler implements NHttpClientEventHandler {
         String message = getErrorMessage("I/O error : " + e.getMessage(), conn);
 
         if (e.getMessage() != null && (e instanceof ConnectionClosedException
-                || e.getMessage().toLowerCase().contains("connection reset by peer")
+                || e.getMessage().toLowerCase().contains("connection reset")
                 || e.getMessage().toLowerCase().contains("forcibly closed"))) {
             if (log.isDebugEnabled()) {
                 log.debug(conn + ": I/O error (Probably the keep-alive connection "


### PR DESCRIPTION
## Purpose
From JDK 17 onward, the Connection Reset by peer error log has been replaced by Connection Reset. Hence contains check has to be changed to check the string as in this commit