### PR TITLE
Integrate GraalVM JS to script mediator

### DIFF
--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -341,6 +341,35 @@
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.regex</groupId>
+            <artifactId>regex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.bsf.wso2</groupId>
+            <artifactId>bsf-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+        </dependency>
+
     </dependencies>
     
     <properties />

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ExtendedJavaScriptXmlHelper.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ExtendedJavaScriptXmlHelper.java
@@ -32,7 +32,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * This class will provide the operations to convert between xml elements of scripts and OMElements.
  */
-public class NashornJavaScriptXmlHelper extends DefaultXMLHelper {
+public class ExtendedJavaScriptXmlHelper extends DefaultXMLHelper {
 
     /**
      * This method will convert the message payload in to xml.

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/JavaScriptXmlHelper.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/JavaScriptXmlHelper.java
@@ -36,7 +36,7 @@ import javax.xml.stream.XMLStreamException;
  * since there is an api change in rhino17,This class is provided instead of getting Helper class by
  * XMLHelper.getArgHelper(engine) in bsf
  */
-
+@Deprecated
 public class JavaScriptXmlHelper extends DefaultXMLHelper {
     private final Scriptable scope;
 

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/OpenJDKNashornFactoryWrapper.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/OpenJDKNashornFactoryWrapper.java
@@ -21,6 +21,7 @@ import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
 import javax.script.ScriptEngineFactory;
 
+@Deprecated
 public class OpenJDKNashornFactoryWrapper {
     public static ScriptEngineFactory getOpenJDKNashornFactory() {
         return new NashornScriptEngineFactory();

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/OpenJDKNashornJavaScriptMessageContext.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/OpenJDKNashornJavaScriptMessageContext.java
@@ -55,6 +55,7 @@ import java.util.*;
  * NashornJavaScriptMessageContext implements the ScriptMessageContext specific to Nashorn java script engine.
  */
 @SuppressWarnings({"UnusedDeclaration"})
+@Deprecated
 public class OpenJDKNashornJavaScriptMessageContext implements ScriptMessageContext {
     private static final Log logger = LogFactory.getLog(OpenJDKNashornJavaScriptMessageContext.class.getName());
 

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -684,6 +684,8 @@ public class ScriptMediator extends AbstractMediator {
             ScriptEngineWrapper sew;
             if (language.equals(NASHORN_JAVA_SCRIPT)) {
                 sew = new ScriptEngineWrapper(engineManager.getEngineByName(NASHORN));
+            } else if (language.equals(RHINO_JAVA_SCRIPT)) {
+                sew = new ScriptEngineWrapper(engineManager.getEngineByExtension("jsEngine"));
             } else {
                 sew = new ScriptEngineWrapper(engineManager.getEngineByExtension(language));
             }
@@ -708,6 +710,9 @@ public class ScriptMediator extends AbstractMediator {
 
 
         this.multiThreadedEngine = scriptEngine.getFactory().getParameter("THREADING") != null;
+        if (language.equals(JAVA_SCRIPT)) {
+            this.multiThreadedEngine = true;
+        }
         log.debug("Script mediator for language : " + language +
                 " supports multithreading? : " + multiThreadedEngine);
 
@@ -759,8 +764,10 @@ public class ScriptMediator extends AbstractMediator {
         if (scriptEngineWrapper == null) {
             if (language.equals(NASHORN_JAVA_SCRIPT)) {
                 scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByName(NASHORN));
+            } else if (language.equals(RHINO_JAVA_SCRIPT)) {
+                scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByExtension("jsEngine"));
             } else {
-                scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByExtension(GRAALVM));
+                scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByExtension(language));
             }
         }
         // fall back

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -19,6 +19,7 @@
 package org.apache.synapse.mediators.bsf;
 
 import com.google.gson.JsonParser;
+import com.oracle.truffle.js.scriptengine.GraalJSEngineFactory;
 import com.sun.phobos.script.javascript.RhinoScriptEngineFactory;
 import com.sun.script.groovy.GroovyScriptEngineFactory;
 import com.sun.script.jruby.JRubyScriptEngineFactory;
@@ -42,8 +43,8 @@ import org.apache.synapse.mediators.bsf.access.control.SandboxContextFactory;
 import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
 import org.apache.synapse.mediators.bsf.access.control.config.AccessControlListType;
 import org.apache.synapse.mediators.eip.EIPUtils;
+import org.graalvm.polyglot.Context;
 import org.mozilla.javascript.ClassShutter;
-import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 
 import javax.activation.DataHandler;
@@ -104,9 +105,19 @@ public class ScriptMediator extends AbstractMediator {
     private static final String NASHORN_JAVA_SCRIPT = "nashornJs";
 
     /**
+     *
+     */
+    private static final String RHINO_JAVA_SCRIPT = "rhinoJs";
+
+    /**
      * Name of the nashorn java script engine.
      */
     private static final String NASHORN = "nashorn";
+
+    /**
+     * Name of the graalvm js engine.
+     */
+    private static final String GRAALVM = "graal.js";
 
     /**
      * Factory Name for Oracle Nashorn Engine. Built-in Nashorn engine in JDK 8 to JDK 11
@@ -296,22 +307,26 @@ public class ScriptMediator extends AbstractMediator {
 
     private boolean invokeScript(MessageContext synCtx) {
         boolean returnValue;
+        Context context = null;
         try {
             //if the engine is Rhino then needs to set the class loader specifically
-            if (language.equals("js")) {
-                Context cx = Context.enter();
+            if (language.equals(RHINO_JAVA_SCRIPT)) {
+                org.mozilla.javascript.Context cx = org.mozilla.javascript.Context.enter();
                 if (classAccessControlConfig != null && classAccessControlConfig.isAccessControlEnabled()) {
                     cx.setClassShutter(createClassShutter());
                 }
                 cx.setApplicationClassLoader(this.loader);
-
+            }
+            if (language.equals(JAVA_SCRIPT)) {
+                context = Context.newBuilder("js").allowExperimentalOptions(true).build();
+                context.enter();
             }
 
             Object returnObject;
             if (key != null) {
-                returnObject = mediateWithExternalScript(synCtx);
+                returnObject = mediateWithExternalScript(synCtx, context);
             } else {
-                returnObject = mediateForInlineScript(synCtx);
+                returnObject = mediateForInlineScript(synCtx, context);
             }
             returnValue = !(returnObject != null && returnObject instanceof Boolean) || (Boolean) returnObject;
 
@@ -332,8 +347,13 @@ public class ScriptMediator extends AbstractMediator {
                     (function != null ? " function " + function : ""), e, synCtx);
             returnValue = false;
         } finally {
+            if (language.equals(RHINO_JAVA_SCRIPT)) {
+                org.mozilla.javascript.Context.exit();
+            }
             if (language.equals("js")) {
-                Context.exit();
+                if (context != null) {
+                    context.leave();
+                }
             }
         }
 
@@ -344,24 +364,26 @@ public class ScriptMediator extends AbstractMediator {
      * Mediation implementation when the script to be executed should be loaded from the registry
      *
      * @param synCtx the message context
+     * @param context the context of script engine
      * @return script result
      * @throws ScriptException       For any errors , when compile, run the script
      * @throws NoSuchMethodException If the function is not defined in the script
      */
-    private Object mediateWithExternalScript(MessageContext synCtx)
+    private Object mediateWithExternalScript(MessageContext synCtx, Context context)
             throws ScriptException, NoSuchMethodException {
         ScriptEngineWrapper sew = null;
         Object obj;
         try {
             sew = prepareExternalScript(synCtx);
             XMLHelper helper;
-            if (language.equalsIgnoreCase(JAVA_SCRIPT) || language.equals(NASHORN_JAVA_SCRIPT)) {
+            if (language.equalsIgnoreCase(JAVA_SCRIPT) || language.equals(NASHORN_JAVA_SCRIPT) ||
+                    language.equals(RHINO_JAVA_SCRIPT)) {
                 helper = xmlHelper;
             } else {
                 helper = XMLHelper.getArgHelper(sew.getEngine());
             }
             ScriptMessageContext scriptMC;
-            scriptMC = getScriptMessageContext(synCtx, helper);
+            scriptMC = getScriptMessageContext(synCtx, helper, context);
             processJSONPayload(synCtx, scriptMC);
             Invocable invocableScript = (Invocable) sew.getEngine();
 
@@ -384,9 +406,11 @@ public class ScriptMediator extends AbstractMediator {
      * @param helper Object which help to convert xml into OMelemnt
      * @return Nashorn or Common script message context according to language attribute
      */
-    private ScriptMessageContext getScriptMessageContext(MessageContext synCtx, XMLHelper helper) {
+    private ScriptMessageContext getScriptMessageContext(MessageContext synCtx, XMLHelper helper,
+                                                         Context context) {
         ScriptMessageContext scriptMC;
         if (language.equals(NASHORN_JAVA_SCRIPT)) {
+            // nashorn is deprecated and will be removed in the future in favor of graal.js
             try {
                 if(isJDKContainNashorn()) {
                     scriptMC = new NashornJavaScriptMessageContext(synCtx, helper, jsEngine);
@@ -397,6 +421,12 @@ public class ScriptMediator extends AbstractMediator {
                 throw new SynapseException("Error occurred while evaluating empty json object", e);
             }
 
+        } else if (language.equals(JAVA_SCRIPT)) {
+            try {
+                scriptMC = new GraalVMJavaScriptMessageContext(synCtx, helper, context);
+            } catch (ScriptException e) {
+                throw new SynapseException("Error occurred while evaluating empty json object", e);
+            }
         } else {
             scriptMC = new CommonScriptMessageContext(synCtx, helper);
         }
@@ -410,9 +440,9 @@ public class ScriptMediator extends AbstractMediator {
      * @return true, or the script return value
      * @throws ScriptException For any errors , when compile , run the script
      */
-    private Object mediateForInlineScript(MessageContext synCtx) throws ScriptException {
+    private Object mediateForInlineScript(MessageContext synCtx, Context context) throws ScriptException {
         ScriptMessageContext scriptMC;
-        scriptMC = getScriptMessageContext(synCtx, xmlHelper);
+        scriptMC = getScriptMessageContext(synCtx, xmlHelper, context);
         processJSONPayload(synCtx, scriptMC);
         Bindings bindings = scriptEngine.createBindings();
         bindings.put(MC_VAR_NAME, scriptMC);
@@ -443,6 +473,8 @@ public class ScriptMediator extends AbstractMediator {
                     } else {
                         jsonObject = ((OpenJDKNashornJavaScriptMessageContext) scriptMC).jsonSerializerCallMember("parse", jsonPayload);
                     }
+                } else if (JAVA_SCRIPT.equals(language)) {
+                    jsonObject = ((GraalVMJavaScriptMessageContext) scriptMC).jsonSerializerCallMember("parse", jsonPayload);
                 } else {
                     String scriptWithJsonParser = "JSON.parse(JSON.stringify(" + jsonPayload + "))";
                     jsonObject = this.jsEngine.eval('(' + scriptWithJsonParser + ')');
@@ -618,13 +650,15 @@ public class ScriptMediator extends AbstractMediator {
         if (log.isDebugEnabled()) {
             log.debug("Initializing script mediator for language : " + language);
         }
-
+        System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+        System.setProperty("polyglot.js.nashorn-compat", "true");
         engineManager = new ScriptEngineManager();
-        if (!language.equals(NASHORN_JAVA_SCRIPT)) {
+        if (language.equals(JAVA_SCRIPT)) {
+            engineManager.registerEngineExtension("jsEngine", new GraalJSEngineFactory());
+        }
+        if (language.equals(RHINO_JAVA_SCRIPT)) {
             engineManager.registerEngineExtension("jsEngine", new RhinoScriptEngineFactory());
         }
-
-        engineManager.registerEngineExtension("js", new RhinoScriptEngineFactory());
         engineManager.registerEngineExtension("groovy", new GroovyScriptEngineFactory());
         engineManager.registerEngineExtension("rb", new JRubyScriptEngineFactory());
         engineManager.registerEngineExtension("py", new JythonScriptEngineFactory());
@@ -638,6 +672,8 @@ public class ScriptMediator extends AbstractMediator {
         }
         if (language.equals(NASHORN_JAVA_SCRIPT)) {
             this.scriptEngine = engineManager.getEngineByName(NASHORN);
+        } else if (language.equals(RHINO_JAVA_SCRIPT)) {
+            this.scriptEngine = engineManager.getEngineByExtension("jsEngine");
         } else {
             this.scriptEngine = engineManager.getEngineByExtension(language);
         }
@@ -661,11 +697,11 @@ public class ScriptMediator extends AbstractMediator {
         if (scriptEngine == null) {
             handleException("No script engine found for language: " + language);
         }
-        //Invoking a custom Helper class for api change in rhino17 and also for Nashorn engine based implimentation
-        if (language.equalsIgnoreCase(JAVA_SCRIPT)) {
+        if (language.equalsIgnoreCase(JAVA_SCRIPT) || language.equals(NASHORN_JAVA_SCRIPT)) {
+            xmlHelper = new ExtendedJavaScriptXmlHelper();
+        } else if (language.equals(RHINO_JAVA_SCRIPT)) {
+            // this will be removed in the future in favor of graal.js
             xmlHelper = new JavaScriptXmlHelper();
-        } else if (language.equals(NASHORN_JAVA_SCRIPT)) {
-            xmlHelper = new NashornJavaScriptXmlHelper();
         } else {
             xmlHelper = XMLHelper.getArgHelper(scriptEngine);
         }
@@ -675,10 +711,12 @@ public class ScriptMediator extends AbstractMediator {
         log.debug("Script mediator for language : " + language +
                 " supports multithreading? : " + multiThreadedEngine);
 
-        readAccessControlConfigurations(MiscellaneousUtil.loadProperties("synapse.properties"));
-        if (nativeObjectAccessControlConfig != null && nativeObjectAccessControlConfig.isAccessControlEnabled() &&
-                !ContextFactory.hasExplicitGlobal()) {
-            ContextFactory.initGlobal(new SandboxContextFactory(nativeObjectAccessControlConfig));
+        if (language.equals(RHINO_JAVA_SCRIPT)) {
+            readAccessControlConfigurations(MiscellaneousUtil.loadProperties("synapse.properties"));
+            if (nativeObjectAccessControlConfig != null && nativeObjectAccessControlConfig.isAccessControlEnabled() &&
+                    !ContextFactory.hasExplicitGlobal()) {
+                ContextFactory.initGlobal(new SandboxContextFactory(nativeObjectAccessControlConfig));
+            }
         }
     }
 
@@ -722,7 +760,7 @@ public class ScriptMediator extends AbstractMediator {
             if (language.equals(NASHORN_JAVA_SCRIPT)) {
                 scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByName(NASHORN));
             } else {
-                scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByExtension(language));
+                scriptEngineWrapper = new ScriptEngineWrapper(engineManager.getEngineByExtension(GRAALVM));
             }
         }
         // fall back
@@ -752,11 +790,13 @@ public class ScriptMediator extends AbstractMediator {
     }
 
     /**
+     * @deprecated This method is deprecated and will be removed in a future release in favour of GraalVM JS engine.
      * Creates a class shutter, which will be used inside the context that executes the script.
      * This class shutter will be used to control the visibility of classes specified in the access control config,
      * to the script.
      * @return
      */
+    @Deprecated
     private ClassShutter createClassShutter() {
         return new ClassShutter() {
             public boolean visibleToScripts(String className) {

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializationTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializationTest.java
@@ -44,7 +44,7 @@ public class ScriptMediatorSerializationTest extends AbstractTestCase {
     }
 
     public void testInlineScriptMediatorSerializationScenarioOne() throws XMLComparisonException {
-        String inputXml = "<syn:script xmlns:syn=\"http://ws.apache.org/ns/synapse\" language='js'>" +
+        String inputXml = "<syn:script xmlns:syn=\"http://ws.apache.org/ns/synapse\" language='rhinoJs'>" +
                 "<![CDATA[var symbol = mc.getPayloadXML()..*::Code.toString();mc.setPayloadXML(<m:getQuote xmlns:m=\"http://services.samples/xsd\">\n" +
                 "<m:request><m:symbol>{symbol}</m:symbol></m:request></m:getQuote>);]]></syn:script> ";
         assertTrue(serialization(inputXml, mediatorFactory, scriptMediatorSerializer));

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorTest.java
@@ -43,10 +43,10 @@ public class ScriptMediatorTest extends TestCase {
 
     private static final String inlinescript = "var state=5;";
 
-    private String threadsafetyscript = "var rno = mc.getPayloadXML().toString(); rno=rno*2; mc.setPayloadXML"
+    private String threadsafetyscriptForRhinoJS = "var rno = mc.getPayloadXML().toString(); rno=rno*2; mc.setPayloadXML"
             + "(<randomNo>{rno}</randomNo>)";
 
-    private String threadSafetyScriptForNashorn = "var rno = mc.getPayloadXML().toString(); var st1 = mc.getEnvelope"
+    private String threadSafetyScript = "var rno = mc.getPayloadXML().toString(); var st1 = mc.getEnvelope"
             + "().getBody().getFirstElement().getText();mc.getEnvelope().getBody().getFirstElement().setText"
             + "(st1 * 2);";
 
@@ -58,13 +58,13 @@ public class ScriptMediatorTest extends TestCase {
     }
 
     /**
-     * Test functionality of mediate with inline script in nashornJS.
+     * Test functionality of mediate with inline script in rhinoJs.
      *
      * @throws Exception
      */
     public void testInlineMediatorOnNashornEngine() throws Exception {
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
-        ScriptMediator mediator = new ScriptMediator("nashornJs", inlinescript,null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", inlinescript,null);
         boolean responese = mediator.mediate(mc);
         assertTrue(responese);
     }
@@ -74,23 +74,23 @@ public class ScriptMediatorTest extends TestCase {
         Random rand = new Random();
         String randomno = Integer.toString(rand.nextInt(200));
         mc.getEnvelope().getBody().getFirstElement().setText(randomno);
-        ScriptMediator mediator = new ScriptMediator("js", threadsafetyscript,null);
+        ScriptMediator mediator = new ScriptMediator("js", threadSafetyScript,null);
         mediator.mediate(mc);
         assertEquals(Integer.parseInt(mc.getEnvelope().getBody().getFirstElement().getText()),
                 Integer.parseInt(randomno) * 2);
     }
 
     /**
-     * Test functionality of mediate with multiple threads in nashornJS.
+     * Test functionality of mediate with multiple threads in rhinoJS.
      *
      * @throws Exception
      */
-    public void testThreadSafetyOnNashornEngine() throws Exception {
+    public void testThreadSafetyOnRhinoEngine() throws Exception {
         MessageContext mc = TestUtils.getTestContext("<randomNo/>", null);
         Random rand = new Random();
         String randomno = Integer.toString(rand.nextInt(200));
         mc.getEnvelope().getBody().getFirstElement().setText(randomno);
-        ScriptMediator mediator = new ScriptMediator("nashornJs", threadSafetyScriptForNashorn,null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", threadsafetyscriptForRhinoJS,null);
         mediator.mediate(mc);
         assertEquals(Integer.parseInt(mc.getEnvelope().getBody().getFirstElement().getText()),
                 Integer.parseInt(randomno) * 2);
@@ -191,9 +191,9 @@ public class ScriptMediatorTest extends TestCase {
         ScriptMediator mediator = new ScriptMediator("js", new LinkedHashMap<Value, Object>(), v, "transform", null);
         boolean result = mediator.mediate(mc);
         String response = JsonUtil.jsonPayloadToString(((Axis2MessageContext) mc).getAxis2MessageContext());
-        String expectedResponse = "[{\"name\":\"Biaggio Cafe\", \"tags\":[\"bar\", \"restaurant\", \"food\","
-                + " \"establishment\"], \"id\":\"ID:7eaf7\"}, {\"name\":\"Doltone House\", \"tags\":[\"food\","
-                + " \"establishment\"], \"id\":\"ID:3ef98\"}]";
+        String expectedResponse = "[{\"name\":\"Biaggio Cafe\",\"tags\":[\"bar\",\"restaurant\",\"food\","
+                + "\"establishment\"],\"id\":\"ID:7eaf7\"},{\"name\":\"Doltone House\",\"tags\":[\"food\","
+                + "\"establishment\"],\"id\":\"ID:3ef98\"}]";
 
         assertEquals(expectedResponse, response);
         assertEquals(true, result);

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/GraalVMJavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/GraalVMJavaScriptMediatorTest.java
@@ -35,18 +35,18 @@ import javax.activation.DataSource;
 import java.util.LinkedHashMap;
 
 /**
- * Test functions of Nashorn Java Script Mediator
+ * Test functions of GraalVM Java Script Mediator
  */
-public class NashornJavaScriptMediatorTest extends TestCase {
+public class GraalVMJavaScriptMediatorTest extends TestCase {
 
     private static final String INLINE_SCRIPT = "var state=5;";
 
     /**
-     * Test functionality of mediate with external script in nashornJS.
+     * Test functionality of mediate with external script in graalVMJs.
      *
      * @throws Exception
      */
-    public void testExternalScriptWithCommentsOnNashornEngine() throws Exception {
+    public void testExternalScriptWithCommentsOnGraalVMEngine() throws Exception {
         String request = "{\n"
                 + "    \"results\": [\n"
                 + "        {\n"
@@ -133,7 +133,7 @@ public class NashornJavaScriptMediatorTest extends TestCase {
         e.setValue(text);
         mc.getConfiguration().addEntry(scriptSrcKey, e);
         Value v = new Value(scriptSrcKey);
-        ScriptMediator mediator = new ScriptMediator("nashornJs", new LinkedHashMap<Value, Object>(), v, "transform",
+        ScriptMediator mediator = new ScriptMediator("js", new LinkedHashMap<Value, Object>(), v, "transform",
                 null);
         boolean result = mediator.mediate(mc);
         String response = JsonUtil.jsonPayloadToString(((Axis2MessageContext) mc).getAxis2MessageContext());
@@ -146,13 +146,13 @@ public class NashornJavaScriptMediatorTest extends TestCase {
     }
 
     /**
-     * Test functionality of mediate with inline script in nashornJS.
+     * Test functionality of mediate with inline script in graalVMJs.
      *
      * @throws Exception
      */
-    public void testInlineMediatorOnNashornEngine() throws Exception {
+    public void testInlineMediatorOnGraalVMEngine() throws Exception {
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
-        ScriptMediator mediator = new ScriptMediator("nashornJs", INLINE_SCRIPT,null);
+        ScriptMediator mediator = new ScriptMediator("js", INLINE_SCRIPT,null);
         boolean responese = mediator.mediate(mc);
         assertTrue(responese);
     }

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/JavaScriptMediatorTest.java
@@ -28,7 +28,7 @@ import org.apache.synapse.mediators.bsf.ScriptMediator;
 public class JavaScriptMediatorTest extends TestCase {
 
     public void testInlineMediator() throws Exception {
-        ScriptMediator mediator = new ScriptMediator("js", "mc.getPayloadXML().b == 'petra';",null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", "mc.getPayloadXML().b == 'petra';",null);
 
         MessageContext mc = TestUtils.getTestContext("<a><b>petra</b></a>", null);
         assertTrue(mediator.mediate(mc));
@@ -41,7 +41,7 @@ public class JavaScriptMediatorTest extends TestCase {
     }
 
     public void testInlineMediator2() throws Exception {
-        ScriptMediator mediator = new ScriptMediator("js", "mc.getPayloadXML().b == 'petra';",null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", "mc.getPayloadXML().b == 'petra';",null);
 
         MessageContext mc = TestUtils.getTestContext("<a><b>petra</b></a>", null);
         assertTrue(mediator.mediate(mc));
@@ -55,8 +55,7 @@ public class JavaScriptMediatorTest extends TestCase {
 
     public void testInlineMediatorWithImports() throws Exception {
 
-        String scriptSourceCode = "importClass(Packages.java.util.UUID);\n" +
-                "var uuid = java.util.UUID.randomUUID().toString().replace('-','');\n";
+        String scriptSourceCode = "var uuid = java.util.UUID.randomUUID().toString().replace('-','');\n";
 
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
         ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
@@ -73,7 +72,7 @@ public class JavaScriptMediatorTest extends TestCase {
         String scriptSourceCode =  "var s = new java.util.ArrayList();\n";
 
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
-        ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", scriptSourceCode, null);
 
         System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
 
@@ -98,7 +97,7 @@ public class JavaScriptMediatorTest extends TestCase {
                 "var hashmapConstructors = c.getClassLoader().loadClass(\"java.util.HashMap\").getDeclaredConstructors();\n";
 
         MessageContext mc = TestUtils.getTestContext("<foo/>", null);
-        ScriptMediator mediator = new ScriptMediator("js", scriptSourceCode, null);
+        ScriptMediator mediator = new ScriptMediator("rhinoJs", scriptSourceCode, null);
 
         System.setProperty("properties.file.path", System.getProperty("user.dir") + "/src/test/resources/file.properties");
 

--- a/pom.xml
+++ b/pom.xml
@@ -1391,6 +1391,36 @@
               <artifactId>nashorn-core</artifactId>
               <version>${nashorn.core.version}</version>
           </dependency>
+          <dependency>
+              <groupId>org.graalvm.sdk</groupId>
+              <artifactId>graal-sdk</artifactId>
+              <version>${graalvm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.graalvm.js</groupId>
+              <artifactId>js-scriptengine</artifactId>
+              <version>${graalvm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.graalvm.js</groupId>
+              <artifactId>js</artifactId>
+              <version>${graalvm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.graalvm.truffle</groupId>
+              <artifactId>truffle-api</artifactId>
+              <version>${graalvm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>org.graalvm.regex</groupId>
+              <artifactId>regex</artifactId>
+              <version>${graalvm.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.ibm.icu</groupId>
+              <artifactId>icu4j</artifactId>
+              <version>${icu.version}</version>
+          </dependency>
       </dependencies>
    </dependencyManagement>
     <reporting>
@@ -1610,6 +1640,8 @@
        <awaitility.version>3.1.2</awaitility.version>
        <jaxb.version>2.3.0</jaxb.version>
        <nashorn.core.version>15.4</nashorn.core.version>
+       <graalvm.version>22.3.4</graalvm.version>
+       <icu.version>72.1</icu.version>
    </properties>
    <developers>
       <!-- If you are a committer and your name is not listed here, please include/edit -->

--- a/repository/conf/mediator/scriptInlineFunctionSynapseConfig.xml
+++ b/repository/conf/mediator/scriptInlineFunctionSynapseConfig.xml
@@ -22,7 +22,7 @@
     <proxy name="scriptMediatorJSInlineTestProxy" transports="http">
         <target>
             <inSequence>
-                <script language="js">var symbol = mc.getPayloadXML()..*::Code.toString();
+                <script language="rhinoJs">var symbol = mc.getPayloadXML()..*::Code.toString();
                     mc.setPayloadXML(
                     &lt;m:getQuote xmlns:m="http://services.samples"&gt;
                     &lt;m:request&gt;
@@ -36,7 +36,7 @@
                 </send>
             </inSequence>
             <outSequence>
-                <script language="js" key="stockQuoteJsScript" function="transformResponse"/>
+                <script language="rhinoJs" key="stockQuoteJsScript" function="transformResponse"/>
                 <send/>
             </outSequence>
         </target>

--- a/repository/conf/sample/synapse_sample_252.xml
+++ b/repository/conf/sample/synapse_sample_252.xml
@@ -24,7 +24,7 @@
     <sequence name="text_proxy">
         <log level="full"/>
         <header name="Action" value="urn:placeOrder"/>
-        <script language="js">
+        <script language="rhinoJs">
             var args = mc.getPayloadXML().toString().split(" ");
             mc.setPayloadXML(
             &lt;placeOrder xmlns="http://services.samples"&gt;

--- a/repository/conf/sample/synapse_sample_350.xml
+++ b/repository/conf/sample/synapse_sample_350.xml
@@ -34,7 +34,7 @@
     <sequence name="main">
         <in>
             <!-- transform the custom quote request into a standard quote request expected by the service -->
-            <script language="js" key="stockquoteScript" function="transformRequest"/>
+            <script language="rhinoJs" key="stockquoteScript" function="transformRequest"/>
             <send>
                 <endpoint>
                     <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
@@ -43,7 +43,7 @@
         </in>
         <out>
             <!-- transform the standard response back into the custom format the client expects -->
-            <script language="js" key="script/stockquoteTransformResponse.js"
+            <script language="rhinoJs" key="script/stockquoteTransformResponse.js"
                     function="transformResponse"/>
             <send/>
         </out>

--- a/repository/conf/sample/synapse_sample_351.xml
+++ b/repository/conf/sample/synapse_sample_351.xml
@@ -24,7 +24,7 @@
     <sequence name="main">
         <in>
             <!-- transform the custom quote request into a standard quote requst expected by the service -->
-            <script language="js">
+            <script language="rhinoJs">
                 var symbol = mc.getPayloadXML()..*::Code.toString();
                 mc.setPayloadXML(
                 &lt;m:getQuote xmlns:m="http://services.samples"&gt;
@@ -41,7 +41,7 @@
         </in>
         <out>
             <!-- transform the standard response back into the custom format the client expects -->
-            <script language="js">
+            <script language="rhinoJs">
                 var symbol = mc.getPayloadXML()..*::symbol.toString();
                 var price = mc.getPayloadXML()..*::last.toString();
                 mc.setPayloadXML(

--- a/repository/conf/sample/synapse_sample_352.xml
+++ b/repository/conf/sample/synapse_sample_352.xml
@@ -24,7 +24,7 @@
     <sequence name="main">
         <in>
             <!-- change the MessageContext into a response and set a response payload -->
-            <script language="js">
+            <script language="rhinoJs">
                 mc.setTo(mc.getReplyTo());
                 mc.setProperty("RESPONSE", "true");
                 mc.setPayloadXML(


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject 
This will replace existing rhinoJS and be an alternative to deprecated nashornJs. 

Note:  E4X is deprecated and it is not supported by GraalVM JS engine. To overcome this when using GraalJS, DOMparser can be used to parse XML strings rather than using XML objects. But then the users who are using
script mediator with the new GraalVM JS engine will not be able to use XML objects in javascript but they will be able to use  setPayloadXML and getPayloadXML methods in script mediator by using string representations of XML. 

To maintain backward compatibility, the existing rhinoJs engine is kept and it can be used by setting the language as "rhinoJs" in the script mediator syntax.

Example
```
<script language="rhinoJs">
     var bNode = mc.getPayloadXML().b;
</script>
```

Default "js" language will be utilizing the graalVM JS engine.

Example
```
<script language="js">
     var rno = mc.getPayloadXML().toString(); 
      var st1 = mc.getEnvelope().getBody().getFirstElement().getText();
     mc.getEnvelope().getBody().getFirstElement().setText(st1 * 2);
</script>
```

