### PR TITLE
Fix connection close during endpoint timeout when reusing a connection

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/DeliveryAgent.java
@@ -259,9 +259,6 @@ public class DeliveryAgent {
                 MessageContext messageContext = queue.poll();
 
                 if (messageContext != null) {
-                    messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONNECTION, conn);
-                    messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONFIGURATION,
-                            targetConfiguration);
                     tryNextMessage(messageContext, route, conn);
                     conn = null;
                 }
@@ -279,6 +276,8 @@ public class DeliveryAgent {
     private void tryNextMessage(MessageContext messageContext, HttpRoute route, NHttpClientConnection conn) {
         if (conn != null) {
             try {
+                messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONNECTION, conn);
+                messageContext.setProperty(PassThroughConstants.PASS_THROUGH_TARGET_CONFIGURATION, targetConfiguration);
                 HttpContext ctx = conn.getContext();
                 /*
                 * If the flow is SSE we need to set references to target connection and targetConnections


### PR DESCRIPTION
## Purpose
$Subject, by setting `PASS_THROUGH_TARGET_CONNECTION` and `PASS_THROUGH_TARGET_CONFIGURATION` in tryNextMessage method.
Resolves https://github.com/wso2/api-manager/issues/3003

## Approach
`PASS_THROUGH_TARGET_CONNECTION` and `PASS_THROUGH_TARGET_CONFIGURATION` properties are only set during a new connection. When endpoint timeout occurs in a **re-used connection,** the `PassThroughHttpSender#onAppError` method gets hit, and the above properties are not present. Therefore, the connection won't get closed, and the following error is printed:
```
WARN - PassThroughHttpSender Unable to update target connection state to CLOSED upon endpoint timeout.
```

This PR adds the above properties within the `DeliveryAgent#tryNextMessage` method. This method gets called during a new connection, as well as a re-used connection. Due to this, when `PassThroughHttpSender#onAppError` method is called, we will be able to close the connection successfully.