### PR TITLE
Add correlation_id as a span tagger and handle NPE

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -78,4 +78,5 @@ public class TelemetryConstants {
     public static final String STATUS_CODE_ATTRIBUTE_KEY = "Status code";
     public static final String STATUS_DESCRIPTION_ATTRIBUTE_KEY = "Status description";
     public static final String ENDPOINT_ATTRIBUTE_KEY = "Endpoint";
+    public static final String CORRELATION_ID_ATTRIBUTE_KEY = "CorrelationId";
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
@@ -214,8 +214,10 @@ public class SpanHandler implements OpenTelemetrySpanHandler {
         if (isOuterLevelSpan(statisticDataUnit, spanStore)) {
             // Extract span context from headers
             context = extract(headersMap);
-        } else {
+        } else if (parentSpan != null) {
             context = Context.current().with(parentSpan);
+        } else {
+            context = Context.current();
         }
         span = tracer.spanBuilder(statisticDataUnit.getComponentName()).setParent(context).startSpan();
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
@@ -19,11 +19,13 @@
 package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.helpers;
 
 import io.opentelemetry.api.trace.Span;
+import org.apache.synapse.MessageContext;
 import org.apache.synapse.aspects.flow.statistics.data.raw.StatisticDataUnit;
 import org.apache.synapse.aspects.flow.statistics.data.raw.StatisticsLog;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.OpenTelemetryManagerHolder;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.TelemetryConstants;
 import org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.models.SpanWrapper;
+import org.apache.synapse.commons.CorrelationConstants;
 
 /**
  * Applies tags to Spans.
@@ -39,8 +41,9 @@ public class SpanTagger {
      * Sets tags to the span which is contained in the provided span wrapper, from information acquired from the
      * given basic statistic data unit.
      * @param spanWrapper               Span wrapper that contains the target span.
+     * @param synCtx Synapse message context
      */
-    public static void setSpanTags(SpanWrapper spanWrapper) {
+    public static void setSpanTags(SpanWrapper spanWrapper, MessageContext synCtx) {
         StatisticsLog openStatisticsLog = new StatisticsLog(spanWrapper.getStatisticDataUnit());
         Span span = spanWrapper.getSpan();
         if (OpenTelemetryManagerHolder.isCollectingPayloads() || OpenTelemetryManagerHolder.isCollectingProperties()) {
@@ -112,6 +115,10 @@ public class SpanTagger {
         if (openStatisticsLog.getEndpoint() != null) {
             span.setAttribute(TelemetryConstants.ENDPOINT_ATTRIBUTE_KEY,
                     String.valueOf(openStatisticsLog.getEndpoint().getJsonRepresentation()));
+        }
+        if (synCtx.getProperty(CorrelationConstants.CORRELATION_ID) != null) {
+            span.setAttribute(TelemetryConstants.CORRELATION_ID_ATTRIBUTE_KEY,
+                    synCtx.getProperty(CorrelationConstants.CORRELATION_ID).toString());
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/stores/SpanStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/stores/SpanStore.java
@@ -116,11 +116,12 @@ public class SpanStore {
      * Denotes the end of a span.
      * Adds tags to the span and removes reference to the appropriate span wrapper in activeSpanWrappers.
      * @param spanWrapper   Span wrapper object, which has been already created
+     * @param synCtx Synapse message context
      */
-    public void finishSpan(SpanWrapper spanWrapper) {
+    public void finishSpan(SpanWrapper spanWrapper, MessageContext synCtx) {
         if (spanWrapper != null && spanWrapper.getSpan() != null) {
             if (spanWrapper.getStatisticDataUnit() != null) {
-                SpanTagger.setSpanTags(spanWrapper);
+                SpanTagger.setSpanTags(spanWrapper, synCtx);
             }
             spanWrapper.getSpan().end();
             activeSpanWrappers.remove(spanWrapper);


### PR DESCRIPTION
This PR adds the below improvements.

- Handle possible NPE due to the parentSpan being null intermittently for some scenarios.
- Add CorrelationId as a span tagger so that in case there are dissected traces, the end user can correlate those traces that belong to a single call using the "CorrelationId" span tag.

Fixes: https://github.com/wso2/micro-integrator/issues/3433