### PR TITLE
Create new synapse property to change default js engine for script mediator

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -61,6 +61,13 @@ import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.JAVA_SCRIPT;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.MC_VAR_NAME;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.NASHORN;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.NASHORN_JAVA_SCRIPT;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.ORACLE_NASHORN_NAME;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.POOL_SIZE_PROPERTY;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.RHINO_JAVA_SCRIPT;
 import static org.apache.synapse.mediators.bsf.access.control.AccessControlConstants.CLASS_PREFIXES;
 import static org.apache.synapse.mediators.bsf.access.control.AccessControlConstants.ENABLE;
 import static org.apache.synapse.mediators.bsf.access.control.AccessControlConstants.LIMIT_CLASS_ACCESS_PREFIX;
@@ -88,41 +95,6 @@ import static org.apache.synapse.mediators.bsf.access.control.AccessControlConst
 public class ScriptMediator extends AbstractMediator {
 
     private static final Log logger = LogFactory.getLog(ScriptMediator.class.getName());
-
-    /**
-     * The name of the variable made available to the scripting language to access the message
-     */
-    private static final String MC_VAR_NAME = "mc";
-
-    /**
-     * Name of the java script language
-     */
-    private static final String JAVA_SCRIPT = "js";
-
-    /**
-     * Name of the java script language with usage of nashorn engine.
-     */
-    private static final String NASHORN_JAVA_SCRIPT = "nashornJs";
-
-    /**
-     *
-     */
-    private static final String RHINO_JAVA_SCRIPT = "rhinoJs";
-
-    /**
-     * Name of the nashorn java script engine.
-     */
-    private static final String NASHORN = "nashorn";
-
-    /**
-     * Name of the graalvm js engine.
-     */
-    private static final String GRAALVM = "graal.js";
-
-    /**
-     * Factory Name for Oracle Nashorn Engine. Built-in Nashorn engine in JDK 8 to JDK 11
-     */
-    private static final String ORACLE_NASHORN_NAME = "Oracle Nashorn";
 
     /**
      * The registry entry key for a script loaded from the registry
@@ -178,10 +150,6 @@ public class ScriptMediator extends AbstractMediator {
      * Pool size
      */
     private int poolSize = DEFAULT_POOL_SIZE;
-    /**
-     * Pool size property name
-     */
-    private static String POOL_SIZE_PROPERTY = "synapse.script.mediator.pool.size";
     /**
      * Pool ScriptEngine Resources
      */

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorConstants.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorConstants.java
@@ -1,0 +1,54 @@
+package org.apache.synapse.mediators.bsf;
+
+public class ScriptMediatorConstants {
+
+    /**
+     * The name of the variable made available to the scripting language to access the message
+     */
+    public static final String MC_VAR_NAME = "mc";
+
+    /**
+     * Name of the java script language
+     */
+    public static final String JAVA_SCRIPT = "js";
+
+    /**
+     * Name of the java script language with usage of nashorn engine.
+     */
+    public static final String NASHORN_JAVA_SCRIPT = "nashornJs";
+
+    /**
+     * Name of the java script language with usage of rhino engine.
+     */
+    public static final String RHINO_JAVA_SCRIPT = "rhinoJs";
+
+    /**
+     * Name of the java script language with usage of rhino engine.
+     */
+    public static final String GRAAL_JAVA_SCRIPT = "graalJs";
+
+    /**
+     * Name of the nashorn java script engine.
+     */
+    public static final String NASHORN = "nashorn";
+
+    /**
+     * Name of the graalvm js engine.
+     */
+    public static final String GRAALVM = "graal.js";
+
+    /**
+     * Factory Name for Oracle Nashorn Engine. Built-in Nashorn engine in JDK 8 to JDK 11
+     */
+    public static final String ORACLE_NASHORN_NAME = "Oracle Nashorn";
+
+    /**
+     * Pool size property name
+     */
+    public static String POOL_SIZE_PROPERTY = "synapse.script.mediator.pool.size";
+
+    /**
+     * Default Script Engine
+     */
+    public static String DEFAULT_SCRIPT_ENGINE = "synapse.script.mediator.default.engine";
+}

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorConstants.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorConstants.java
@@ -1,3 +1,21 @@
+/**
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.synapse.mediators.bsf;
 
 public class ScriptMediatorConstants {

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
@@ -24,6 +24,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.AbstractMediatorFactory;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.mediators.Value;
@@ -36,6 +37,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 import java.util.*;
+
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.DEFAULT_SCRIPT_ENGINE;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.GRAAL_JAVA_SCRIPT;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.JAVA_SCRIPT;
+import static org.apache.synapse.mediators.bsf.ScriptMediatorConstants.RHINO_JAVA_SCRIPT;
 
 /**
  * Creates an instance of a Script mediator for inline or external script mediation for BSF
@@ -106,7 +112,13 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
             mediator = new ScriptMediator(langAtt.getAttributeValue(),
                     includeKeysMap, generatedKey, functionName,classLoader);
         } else {
-            mediator = new ScriptMediator(langAtt.getAttributeValue(), elem.getText(),classLoader);
+            String language = langAtt.getAttributeValue();
+            if (language.equals(JAVA_SCRIPT) &&
+                    (RHINO_JAVA_SCRIPT.equals(SynapsePropertiesLoader.getPropertyValue(
+                            DEFAULT_SCRIPT_ENGINE, GRAAL_JAVA_SCRIPT)))) {
+                language = RHINO_JAVA_SCRIPT;
+            }
+            mediator = new ScriptMediator(language, elem.getText(),classLoader);
         }
 
         processAuditStatus(mediator, elem);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

In a [recent change](https://github.com/wso2/wso2-synapse/pull/2196), default engine for script mediator was set to GraalVM js. With this improvement, a synapse property has been introduced to change the default engine.

```
Eg:
[synapse_properties]
'synapse.script.mediator.default.engine' = "rhinoJs"  # rhinoJs or graalJs
```

