### PR TITLE
Change the log level error to warn for the un-deploy errors where user is not required to do anything

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/LibraryArtifactDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/LibraryArtifactDeployer.java
@@ -205,7 +205,7 @@ public class LibraryArtifactDeployer extends AbstractSynapseArtifactDeployer {
 	} else {
 	    String msg = "Artifact representing the filename " + fileName
 		    + " is not deployed on Synapse";
-	    log.error(msg);
+	    log.warn(msg);
 	    throw new DeploymentException(msg);
 	}
 


### PR DESCRIPTION
## Purpose
Public issue: https://github.com/wso2/micro-integrator/issues/3610

As given in the issue, the following log levels will be changed to warn

```
[2024-09-05 15:05:03,082] ERROR {LibraryArtifactDeployer} - Artifact representing the filename /Users/sajithmadhusanka/Documents/CS/SETUP/APIM4.1.0/wso2mi-4.1.0/tmp/carbonapps/-1234/1725528812990file_connector_5CompositeExporter_1.0.0-SNAPSHOT.car/file-connector_4.0.30/file-connector-4.0.30.zip is not deployed on Synapse
```