### PR TITLE
Introducing RequiredFileNamePatterns feature to read files depending on the existence of other files

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/vfs/VFSConstants.java
@@ -40,6 +40,7 @@ public final class VFSConstants {
 
     public static final String TRANSPORT_FILE_FILE_URI = "transport.vfs.FileURI";
     public static final String TRANSPORT_FILE_FILE_NAME_PATTERN = "transport.vfs.FileNamePattern";
+    public static final String TRANSPORT_FILE_REQUIRED_FILE_NAME_PATTERNS = "transport.vfs.RequiredFileNamePatterns";
     public static final String TRANSPORT_FILE_CONTENT_TYPE = "transport.vfs.ContentType";
     public static final String TRANSPORT_FILE_LOCKING = "transport.vfs.Locking";
     public static final String UPDATE_LAST_MODIFIED = "transport.vfs.UpdateLastModified";

--- a/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
+++ b/modules/transports/core/vfs/src/main/java/org/apache/synapse/transport/vfs/PollTableEntry.java
@@ -57,6 +57,8 @@ public class PollTableEntry extends AbstractPollTableEntry {
     private String replyFileURI;
     /** file name pattern for a directory or compressed file entry */
     private String fileNamePattern;
+    /** File name patterns and order of processing the matching files */
+    private String requiredFileNamePatterns;
     /** Content-Type to use for the message */
     private String contentType;
 
@@ -177,6 +179,14 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
     public String getFileNamePattern() {
         return fileNamePattern;
+    }
+
+    public String getRequiredFileNamePatterns() {
+        return requiredFileNamePatterns;
+    }
+
+    public boolean hasRequiredFileNamePatterns() {
+        return requiredFileNamePatterns != null && !requiredFileNamePatterns.isEmpty();
     }
 
     public String getContentType() {
@@ -531,6 +541,9 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
             fileNamePattern = ParamUtils.getOptionalParam(params,
                                                           VFSConstants.TRANSPORT_FILE_FILE_NAME_PATTERN);
+
+            requiredFileNamePatterns = ParamUtils.getOptionalParam(params,
+                                                      VFSConstants.TRANSPORT_FILE_REQUIRED_FILE_NAME_PATTERNS);
 
             contentType = ParamUtils.getRequiredParam(params,
                                                       VFSConstants.TRANSPORT_FILE_CONTENT_TYPE);


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to introduce a feature covering a common use case, which is reading a file depending of the existence of another file.

This feature is particularly useful in cases, where two files are bound together and should be processed nearly at the same time in a given order, once both of them exist in a given location (e.g. receipt and warranty document for the same purchase).

## Release note
Added RequiredFileNamePatterns feature to process files depending on the existence of other files using regular expressions.
