### PR TITLE
Improve log mediator to support string templating

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
@@ -32,6 +32,7 @@ import java.util.Properties;
  *
  * <pre>
  * &lt;log [level="simple|headers|full|custom"]&gt;
+ *      &lt;message&gt;String template&lt;/message&gt;
  *      &lt;property&gt; *
  * &lt;/log&gt;
  * </pre>
@@ -52,6 +53,8 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
     private static final QName ATT_LEVEL = new QName("level");
     private static final QName ATT_SEPERATOR = new QName("separator");
     private static final QName ATT_CATEGORY = new QName("category");
+    protected static final QName ELEMENT_MESSAGE_Q
+            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "message");
 
     public QName getTagQName() {
         return LOG_Q;
@@ -64,7 +67,13 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
         // after successfully creating the mediator
         // set its common attributes such as tracing etc
         processAuditStatus(logMediator,elem);
-        
+
+        OMElement messageElement = elem.getFirstChildWithName(ELEMENT_MESSAGE_Q);
+        if (messageElement != null && messageElement.getText() != null) {
+            logMediator.setMessageTemplate(messageElement.getText());
+            logMediator.setLogLevel(LogMediator.MESSAGE_TEMPLATE);
+        }
+
         // Set the high level set of properties to be logged (i.e. log level)
         OMAttribute level = elem.getAttribute(ATT_LEVEL);
         if (level != null) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
@@ -68,10 +68,11 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
         // set its common attributes such as tracing etc
         processAuditStatus(logMediator,elem);
 
+        boolean containMessageTemplate = false;
         OMElement messageElement = elem.getFirstChildWithName(ELEMENT_MESSAGE_Q);
         if (messageElement != null && messageElement.getText() != null) {
             logMediator.setMessageTemplate(messageElement.getText());
-            logMediator.setLogLevel(LogMediator.MESSAGE_TEMPLATE);
+            containMessageTemplate = true;
         }
 
         // Set the high level set of properties to be logged (i.e. log level)
@@ -89,6 +90,10 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
             } else {
                 handleException("Invalid log level. Level has to be one of the following : "
                         + "simple, headers, full, custom");
+            }
+        } else {
+            if (containMessageTemplate) {
+                logMediator.setLogLevel(LogMediator.MESSAGE_TEMPLATE);
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
@@ -126,7 +126,7 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
         }
 
         logMediator.addAllProperties(MediatorPropertyFactory.getMediatorProperties(elem));
-
+        logMediator.processTemplateAndSetContentAware();
         addAllCommentChildrenToList(elem, logMediator.getCommentsList());
 
         return logMediator;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorSerializer.java
@@ -44,7 +44,7 @@ public class LogMediatorSerializer extends AbstractMediatorSerializer {
         OMElement log = fac.createOMElement("log", synNS);
         saveTracingState(log,mediator);
 
-        if (StringUtils.isBlank(mediator.getMessageTemplate()) && mediator.getLogLevel() != LogMediator.SIMPLE) {
+        if (mediator.getLogLevel() != LogMediator.MESSAGE_TEMPLATE) {
             log.addAttribute(fac.createOMAttribute(
                 "level", nullNS,
                     mediator.getLogLevel() == LogMediator.HEADERS ? "headers" :

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorSerializer.java
@@ -20,12 +20,14 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.builtin.LogMediator;
 
 /**
  * <pre>
  * &lt;log [level="simple|headers|full|custom"] [separator="string"] [category="INFO|TRACE|DEBUG|WARN|ERROR|FATAL"]&gt;
+ *      &lt;message&gt;String template&lt;/message&gt;
  *      &lt;property&gt; *
  * &lt;/log&gt;
  * </pre>
@@ -42,7 +44,7 @@ public class LogMediatorSerializer extends AbstractMediatorSerializer {
         OMElement log = fac.createOMElement("log", synNS);
         saveTracingState(log,mediator);
 
-        if (mediator.getLogLevel() != LogMediator.SIMPLE) {
+        if (StringUtils.isBlank(mediator.getMessageTemplate()) && mediator.getLogLevel() != LogMediator.SIMPLE) {
             log.addAttribute(fac.createOMAttribute(
                 "level", nullNS,
                     mediator.getLogLevel() == LogMediator.HEADERS ? "headers" :
@@ -71,6 +73,12 @@ public class LogMediatorSerializer extends AbstractMediatorSerializer {
         if (!LogMediator.DEFAULT_SEP.equals(mediator.getSeparator())) {
             log.addAttribute(fac.createOMAttribute(
                     "separator", nullNS, mediator.getSeparator()));
+        }
+
+        if (StringUtils.isNotBlank(mediator.getMessageTemplate())) {
+            OMElement onCompleteElem = fac.createOMElement("message", synNS);
+            onCompleteElem.setText(mediator.getMessageTemplate());
+            log.addChild(onCompleteElem);
         }
 
         super.serializeProperties(log, mediator.getProperties());

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -79,6 +79,7 @@ public class LogMediator extends AbstractMediator {
     private final List<MediatorProperty> properties = new ArrayList<MediatorProperty>();
 
     private String messageTemplate = "";
+    private boolean isContentAware = false;
 
     /**
      * Logs the current message according to the supplied semantics
@@ -331,14 +332,22 @@ public class LogMediator extends AbstractMediator {
 
     @Override
     public boolean isContentAware() {
+
+        return isContentAware;
+    }
+
+    public void processTemplateAndSetContentAware() {
+
         if (logLevel == MESSAGE_TEMPLATE || logLevel == CUSTOM) {
             for (MediatorProperty property : properties) {
                 if (property.getExpression() != null && property.getExpression().isContentAware()) {
-                    return true;
+                    isContentAware = true;
+                    return;
                 }
             }
-            return InlineExpressionUtil.isInlineSynapseExpressionsContentAware(messageTemplate);
+            isContentAware = InlineExpressionUtil.isInlineSynapseExpressionsContentAware(messageTemplate);
+        } else {
+            isContentAware = true;
         }
-        return true;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/util/InlineExpressionUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/InlineExpressionUtil.java
@@ -204,12 +204,12 @@ public final class InlineExpressionUtil {
     }
 
     /**
-     * Checks whether inline text contains synapse expressions
+     * Checks whether inline template contains content aware synapse expressions.
      * Inline expressions will be denoted inside ${}
      * e.g.: ${var.var1}, ${payload.element.id}
      *
      * @param inlineText Inline text string
-     * @return true if the string contains inline synapse expressions, false otherwise
+     * @return true if the string contains content aware inline synapse expressions, false otherwise
      */
     public static boolean isInlineSynapseExpressionsContentAware(String inlineText) {
 

--- a/modules/core/src/main/java/org/apache/synapse/util/InlineExpressionUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/InlineExpressionUtil.java
@@ -19,7 +19,6 @@ package org.apache.synapse.util;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
@@ -30,8 +29,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.config.xml.SynapsePath;
-import org.apache.synapse.config.xml.SynapsePathFactory;
 import org.apache.synapse.util.xpath.SynapseExpression;
+import org.apache.synapse.util.xpath.SynapseExpressionUtils;
 import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
@@ -216,8 +215,8 @@ public final class InlineExpressionUtil {
         Matcher matcher = SYNAPSE_EXPRESSION_PLACEHOLDER_PATTERN.matcher(inlineText);
         while (matcher.find()) {
             // Extract the expression inside ${...}
-            String placeholder = matcher.group(1);
-            if (placeholder.contains("xpath(") || placeholder.contains("payload.") || placeholder.contains("$.")) {
+            String expression = matcher.group(1);
+            if (SynapseExpressionUtils.isSynapseExpressionContentAware(expression)) {
                 return true;
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseExpression.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseExpression.java
@@ -74,33 +74,7 @@ public class SynapseExpression extends SynapsePath {
             }
             throw new JaxenException(errorMessage.toString());
         }
-
-        // TODO : Need to improve the content aware detection logic
-        if (synapseExpression.equals("payload") || synapseExpression.equals("$")
-                || synapseExpression.contains("payload.") || synapseExpression.contains("$.")) {
-            isContentAware = true;
-        } else if (synapseExpression.contains("xpath(")) {
-            // TODO change the regex to support xpath + variable syntax
-            Pattern pattern = Pattern.compile("xpath\\(['\"](.*?)['\"]\\s*(,\\s*['\"](.*?)['\"])?\\)?");
-            Matcher matcher = pattern.matcher(synapseExpression);
-            // Find all matches
-            while (matcher.find()) {
-                if (matcher.group(2) != null) {
-                    // evaluating xpath on a variable so not content aware
-                    continue;
-                }
-                String xpath = matcher.group(1);
-                try {
-                    SynapseXPath synapseXPath = new SynapseXPath(xpath);
-                    if (synapseXPath.isContentAware()) {
-                        isContentAware = true;
-                        break;
-                    }
-                } catch (JaxenException e) {
-                    // Ignore the exception and continue
-                }
-            }
-        }
+        isContentAware = SynapseExpressionUtils.isSynapseExpressionContentAware(synapseExpression);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseExpressionUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseExpressionUtils.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.util.xpath;
+
+import org.jaxen.JaxenException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for Synapse Expressions
+ */
+public class SynapseExpressionUtils {
+
+    /**
+     * Checks whether the synapse expression is content aware
+     *
+     * @param synapseExpression synapse expression string
+     * @return true if the synapse expression is content aware, false otherwise
+     */
+    public static boolean isSynapseExpressionContentAware(String synapseExpression) {
+
+        // TODO : Need to improve the content aware detection logic
+        if (synapseExpression.equals("payload") || synapseExpression.equals("$")
+                || synapseExpression.contains("payload.") || synapseExpression.contains("$.")) {
+            return true;
+        } else if (synapseExpression.contains("xpath(")) {
+            // TODO change the regex to support xpath + variable syntax
+            Pattern pattern = Pattern.compile("xpath\\(['\"](.*?)['\"]\\s*(,\\s*['\"](.*?)['\"])?\\)?");
+            Matcher matcher = pattern.matcher(synapseExpression);
+            // Find all matches
+            while (matcher.find()) {
+                if (matcher.group(2) != null) {
+                    // evaluating xpath on a variable so not content aware
+                    continue;
+                }
+                String xpath = matcher.group(1);
+                try {
+                    SynapseXPath synapseXPath = new SynapseXPath(xpath);
+                    if (synapseXPath.isContentAware()) {
+                        return true;
+                    }
+                } catch (JaxenException e) {
+                    // Ignore the exception and continue
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/LogMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/LogMediatorSerializationTest.java
@@ -161,7 +161,7 @@ public class LogMediatorSerializationTest extends AbstractTestCase {
     }
 
     private String getXmlOfMediatorScenarioThree(String category) {
-        return "<log xmlns=\"http://ws.apache.org/ns/synapse\" category=\"" +
+        return "<log xmlns=\"http://ws.apache.org/ns/synapse\" level=\"simple\" category=\"" +
                 category + "\"><property name=\"Text\" value=\"Sending quote request\"/></log>";
 
     }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/LogMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/LogMediatorSerializationTest.java
@@ -51,6 +51,12 @@ public class LogMediatorSerializationTest extends AbstractTestCase {
         logMediatorSerializer = new LogMediatorSerializer();
     }
 
+    public void testLogMediatorSerializationWithTemplate() throws Exception {
+
+        assertTrue(serialization(getXmlOfLogMediatorWithTemplate(), logMediatorFactory, logMediatorSerializer));
+        assertTrue(serialization(getXmlOfLogMediatorWithTemplateAndProps(), logMediatorFactory, logMediatorSerializer));
+    }
+
     public void testLogMediatorSerializationSenarioOne() throws Exception {
 
         //    assertTrue(serialization(getXmlOfMediatorScenarioOne(SIMPLE), logMediatorFactory, logMediatorSerializer));
@@ -128,6 +134,17 @@ public class LogMediatorSerializationTest extends AbstractTestCase {
         return "<log xmlns=\"http://ws.apache.org/ns/synapse\" level=\"" +
                 level + "\"><property name=\"Text\" value=\"Sending quote request\"/></log>";
 
+    }
+
+    private String getXmlOfLogMediatorWithTemplate() {
+        return "<log xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<message>Processing message with ID: 123</message></log>";
+    }
+
+    private String getXmlOfLogMediatorWithTemplateAndProps() {
+        return "<log xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<message>Processing message with ID: 123</message>" +
+                "<property name=\"Text\" value=\"Sending quote request\"/></log>";
     }
 
     private String getXmlOfMediatorScenarioOneA(String level) {


### PR DESCRIPTION
## Purpose

In the current log mediator, the user needs to add a property and use XPATH concatenations to define a log message. With this improvement, the user can define a string template for the log message. In addition to the log message, the user can add additional properties to be logged.

```xml
<log category="INFO">
    <message>Test clone path 1 "logging" ${var.var1}</message>
</log>
```

```xml
<log category="INFO">
    <message>Test message "logging" ${var.var1}</message>
    <property name="var2" value="test-prop1"/>
    <property name="server-header" expression="${headers.Server}"/>
</log>
```

To maintain backward compatibility when the user has set a `level`, the message will be printed in addition to the content printed according to `level`