### PR TITLE
Add Scatter Gather mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -626,4 +626,6 @@ public final class SynapseConstants {
 
     public static final String ANALYTICS_METADATA = "ANALYTICS_METADATA";
 
+    public static final String SCATTER_MESSAGES = "SCATTER_MESSAGES";
+    public static final String CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER = "CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER";
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CloseEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/CloseEventCollector.java
@@ -148,4 +148,17 @@ public class CloseEventCollector extends RuntimeStatisticCollector {
 //			closeFlowForcefully(messageContext);
 		}
 	}
+
+	/**
+	 * This method will close the event collector and finish the flow when a Scatter Gather mediator is used.
+	 *
+	 * @param messageContext synapse message context.
+	 */
+	public static void closeEventsAfterScatterGather(MessageContext messageContext) {
+
+		if (isOpenTelemetryEnabled()) {
+			OpenTelemetryManagerHolder.getOpenTelemetryManager().getHandler()
+					.handleScatterGatherFinishEvent(messageContext);
+		}
+	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/event/CloseEventHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/event/CloseEventHandler.java
@@ -45,4 +45,11 @@ public interface CloseEventHandler {
      * @param synCtx                    Message context.
      */
     void handleTryEndFlow(BasicStatisticDataUnit basicStatisticDataUnit, MessageContext synCtx);
+
+    /**
+     * Handles a close flow event.
+     *
+     * @param synCtx Message context.
+     */
+    void handleScatterGatherFinishEvent(MessageContext synCtx);
 }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
@@ -430,6 +430,16 @@ public class SpanHandler implements OpenTelemetrySpanHandler {
         }
     }
 
+    public void handleScatterGatherFinishEvent(MessageContext messageContext) {
+        TracingScope tracingScope = tracingScopeManager.getTracingScope(messageContext);
+            synchronized (tracingScope.getSpanStore()) {
+                cleanupContinuationStateSequences(tracingScope.getSpanStore(), messageContext);
+                SpanWrapper outerLevelSpanWrapper = tracingScope.getSpanStore().getOuterLevelSpanWrapper();
+                tracingScope.getSpanStore().finishSpan(outerLevelSpanWrapper, messageContext);
+                tracingScopeManager.cleanupTracingScope(tracingScope.getTracingScopeId());
+            }
+    }
+
     @Override
     public void handleStateStackInsertion(MessageContext synCtx, String seqName, SequenceType seqType) {
         TracingScope tracingScope = tracingScopeManager.getTracingScope(synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/handling/span/SpanHandler.java
@@ -432,12 +432,21 @@ public class SpanHandler implements OpenTelemetrySpanHandler {
 
     public void handleScatterGatherFinishEvent(MessageContext messageContext) {
         TracingScope tracingScope = tracingScopeManager.getTracingScope(messageContext);
-            synchronized (tracingScope.getSpanStore()) {
-                cleanupContinuationStateSequences(tracingScope.getSpanStore(), messageContext);
-                SpanWrapper outerLevelSpanWrapper = tracingScope.getSpanStore().getOuterLevelSpanWrapper();
-                tracingScope.getSpanStore().finishSpan(outerLevelSpanWrapper, messageContext);
-                tracingScopeManager.cleanupTracingScope(tracingScope.getTracingScopeId());
-            }
+        synchronized (tracingScope.getSpanStore()) {
+            cleanupContinuationStateSequences(tracingScope.getSpanStore(), messageContext);
+            cleanUpActiveSpans(tracingScope.getSpanStore(), messageContext);
+            SpanWrapper outerLevelSpanWrapper = tracingScope.getSpanStore().getOuterLevelSpanWrapper();
+            tracingScope.getSpanStore().finishSpan(outerLevelSpanWrapper, messageContext);
+            tracingScopeManager.cleanupTracingScope(tracingScope.getTracingScopeId());
+        }
+    }
+
+    private void cleanUpActiveSpans(SpanStore spanStore, MessageContext messageContext) {
+        List<SpanWrapper> activeSpanWrappers = spanStore.getActiveSpanWrappers();
+        for (int i = activeSpanWrappers.size() - 1; i > 0; i--) {
+            SpanWrapper spanWrapper = activeSpanWrappers.get(i);
+            spanStore.finishSpan(spanWrapper, messageContext);
+        }
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorFactoryFinder.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorFactoryFinder.java
@@ -103,7 +103,8 @@ public class MediatorFactoryFinder implements XMLToObjectMapper {
             ForEachMediatorFactory.class,
             JSONTransformMediatorFactory.class,
             NTLMMediatorFactory.class,
-            VariableMediatorFactory.class
+            VariableMediatorFactory.class,
+            ScatterGatherMediatorFactory.class
     };
 
     private final static MediatorFactoryFinder instance  = new MediatorFactoryFinder();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorSerializerFinder.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorSerializerFinder.java
@@ -77,7 +77,8 @@ public class MediatorSerializerFinder {
             ForEachMediatorSerializer.class,
             JSONTransformMediatorSerializer.class,
             NTLMMediatorSerializer.class,
-            VariableMediatorSerializer.class
+            VariableMediatorSerializer.class,
+            ScatterGatherMediatorSerializer.class
     };
 
     private final static MediatorSerializerFinder instance = new MediatorSerializerFinder();

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorFactory.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.mediators.eip.Target;
+import org.apache.synapse.mediators.v2.ScatterGather;
+import org.jaxen.JaxenException;
+
+import java.util.Iterator;
+import java.util.Properties;
+import javax.xml.namespace.QName;
+
+/**
+ * The &lt;scatter-gather&gt; mediator is used to copy messages in Synapse to similar messages but with
+ * different message contexts and aggregate the responses back.
+ *
+ * <pre>
+ * &lt;scatter-gather parallel-execution=(true | false)&gt;
+ *   &lt;aggregation value-to-aggregate="expression" condition="expression" timeout="long"
+ *     min-messages="expression" max-messages="expression"/&gt;
+ *   &lt;target&gt;
+ *     &lt;sequence&gt;
+ *       (mediator)+
+ *     &lt;/sequence&gt;
+ *   &lt;/target&gt;+
+ * &lt;/scatter-gather&gt;
+ * </pre>
+ */
+public class ScatterGatherMediatorFactory extends AbstractMediatorFactory {
+
+    /**
+     * This will hold the QName of the clone mediator element in the xml configuration
+     */
+    private static final QName SCATTER_GATHER_Q
+            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "scatter-gather");
+    private static final QName ELEMENT_AGGREGATE_Q
+            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "aggregation");
+    private static final QName ATT_VALUE_TO_AGGREGATE = new QName("value-to-aggregate");
+    private static final QName ATT_CONDITION = new QName("condition");
+    private static final QName ATT_TIMEOUT = new QName("timeout");
+    private static final QName ATT_MIN_MESSAGES = new QName("min-messages");
+    private static final QName ATT_MAX_MESSAGES = new QName("max-messages");
+    private static final QName TARGET_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "target");
+    private static final QName PARALLEL_EXEC_Q = new QName("parallel-execution");
+
+    public Mediator createSpecificMediator(OMElement elem, Properties properties) {
+
+        boolean asynchronousExe = true;
+
+        ScatterGather mediator = new ScatterGather();
+        processAuditStatus(mediator, elem);
+
+        OMAttribute parallelExecAttr = elem.getAttribute(PARALLEL_EXEC_Q);
+        if (parallelExecAttr != null && parallelExecAttr.getAttributeValue().equals("false")) {
+            asynchronousExe = false;
+        }
+
+        mediator.setParallelExecution(asynchronousExe);
+
+        Iterator targetElements = elem.getChildrenWithName(TARGET_Q);
+        while (targetElements.hasNext()) {
+            Target target = TargetFactory.createTarget((OMElement) targetElements.next(), properties);
+            target.setAsynchronous(asynchronousExe);
+            mediator.addTarget(target);
+        }
+
+        OMElement aggregateElement = elem.getFirstChildWithName(ELEMENT_AGGREGATE_Q);
+        if (aggregateElement != null) {
+            OMAttribute aggregateExpr = aggregateElement.getAttribute(ATT_VALUE_TO_AGGREGATE);
+            if (aggregateExpr != null) {
+                try {
+                    mediator.setAggregationExpression(
+                            SynapsePathFactory.getSynapsePath(aggregateElement, ATT_VALUE_TO_AGGREGATE));
+                } catch (JaxenException e) {
+                    handleException("Unable to load the aggregating expression", e);
+                }
+            }
+
+            OMAttribute conditionExpr = aggregateElement.getAttribute(ATT_CONDITION);
+            if (conditionExpr != null) {
+                try {
+                    mediator.setCorrelateExpression(
+                            SynapsePathFactory.getSynapsePath(aggregateElement, ATT_CONDITION));
+                } catch (JaxenException e) {
+                    handleException("Unable to load the condition expression", e);
+                }
+            }
+
+            OMAttribute completeTimeout = aggregateElement.getAttribute(ATT_TIMEOUT);
+            if (completeTimeout != null) {
+                mediator.setCompletionTimeoutMillis(Long.parseLong(completeTimeout.getAttributeValue()));
+            }
+
+            OMAttribute minMessages = aggregateElement.getAttribute(ATT_MIN_MESSAGES);
+            if (minMessages != null) {
+                mediator.setMinMessagesToComplete(new ValueFactory().createValue("min-messages", aggregateElement));
+            }
+
+            OMAttribute maxMessages = aggregateElement.getAttribute(ATT_MAX_MESSAGES);
+            if (maxMessages != null) {
+                mediator.setMaxMessagesToComplete(new ValueFactory().createValue("max-messages", aggregateElement));
+            }
+        }
+        addAllCommentChildrenToList(elem, mediator.getCommentsList());
+        return mediator;
+    }
+
+    /**
+     * This method will implement the getTagQName method of the MediatorFactory interface
+     *
+     * @return QName of the clone element in xml configuration
+     */
+    public QName getTagQName() {
+
+        return SCATTER_GATHER_Q;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
@@ -43,6 +43,11 @@ public class ScatterGatherMediatorSerializer extends AbstractMediatorSerializer 
 
         scatterGatherElement.addAttribute(fac.createOMAttribute(
                 "parallel-execution", nullNS, Boolean.toString(scatterGatherMediator.getParallelExecution())));
+        scatterGatherElement.addAttribute(fac.createOMAttribute(
+                "result-target", nullNS, scatterGatherMediator.getResultTarget()));
+        scatterGatherElement.addAttribute(fac.createOMAttribute(
+                "content-type", nullNS, scatterGatherMediator.getContentType()));
+
         OMElement aggregationElement = fac.createOMElement("aggregation", synNS);
 
         SynapsePathSerializer.serializePath(

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.eip.Target;
 import org.apache.synapse.mediators.v2.ScatterGather;
@@ -47,11 +48,15 @@ public class ScatterGatherMediatorSerializer extends AbstractMediatorSerializer 
                 "result-target", nullNS, scatterGatherMediator.getResultTarget()));
         scatterGatherElement.addAttribute(fac.createOMAttribute(
                 "content-type", nullNS, scatterGatherMediator.getContentType()));
+        if (StringUtils.isNotBlank(scatterGatherMediator.getRootElementName())) {
+            scatterGatherElement.addAttribute(fac.createOMAttribute(
+                    "root-element", nullNS, scatterGatherMediator.getRootElementName()));
+        }
 
         OMElement aggregationElement = fac.createOMElement("aggregation", synNS);
 
         SynapsePathSerializer.serializePath(
-                scatterGatherMediator.getAggregationExpression(), aggregationElement, "value");
+                scatterGatherMediator.getAggregationExpression(), aggregationElement, "expression");
 
         if (scatterGatherMediator.getCorrelateExpression() != null) {
             SynapsePathSerializer.serializePath(

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.mediators.eip.Target;
+import org.apache.synapse.mediators.v2.ScatterGather;
+
+/**
+ * Serializer for {@link ScatterGather} instances.
+ */
+public class ScatterGatherMediatorSerializer extends AbstractMediatorSerializer {
+
+    public OMElement serializeSpecificMediator(Mediator m) {
+
+        ScatterGather scatterGatherMediator = null;
+        if (!(m instanceof ScatterGather)) {
+            handleException("Unsupported mediator passed in for serialization : " + m.getType());
+        } else {
+            scatterGatherMediator = (ScatterGather) m;
+        }
+
+        assert scatterGatherMediator != null;
+        OMElement scatterGatherElement = fac.createOMElement("scatter-gather", synNS);
+        saveTracingState(scatterGatherElement, scatterGatherMediator);
+
+        scatterGatherElement.addAttribute(fac.createOMAttribute(
+                "parallel-execution", nullNS, Boolean.toString(scatterGatherMediator.getParallelExecution())));
+        OMElement aggregationElement = fac.createOMElement("aggregation", synNS);
+
+        SynapsePathSerializer.serializePath(
+                scatterGatherMediator.getAggregationExpression(), aggregationElement, "value-to-aggregate");
+
+        if (scatterGatherMediator.getCorrelateExpression() != null) {
+            SynapsePathSerializer.serializePath(
+                    scatterGatherMediator.getAggregationExpression(), aggregationElement, "condition");
+        }
+
+        if (scatterGatherMediator.getCompletionTimeoutMillis() != 0) {
+            aggregationElement.addAttribute(fac.createOMAttribute(
+                    "timeout", nullNS, Long.toString(scatterGatherMediator.getCompletionTimeoutMillis())));
+        }
+        if (scatterGatherMediator.getMinMessagesToComplete() != null) {
+            new ValueSerializer().serializeValue(
+                    scatterGatherMediator.getMinMessagesToComplete(), "min-messages", aggregationElement);
+        }
+        if (scatterGatherMediator.getMaxMessagesToComplete() != null) {
+            new ValueSerializer().serializeValue(
+                    scatterGatherMediator.getMaxMessagesToComplete(), "max-messages", aggregationElement);
+        }
+        scatterGatherElement.addChild(aggregationElement);
+
+        for (Target target : scatterGatherMediator.getTargets()) {
+            if (target != null) {
+                scatterGatherElement.addChild(TargetSerializer.serializeTarget(target));
+            }
+        }
+        serializeComments(scatterGatherElement, scatterGatherMediator.getCommentsList());
+
+        return scatterGatherElement;
+    }
+
+    public String getMediatorClassName() {
+
+        return ScatterGather.class.getName();
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializer.java
@@ -46,7 +46,7 @@ public class ScatterGatherMediatorSerializer extends AbstractMediatorSerializer 
         OMElement aggregationElement = fac.createOMElement("aggregation", synNS);
 
         SynapsePathSerializer.serializePath(
-                scatterGatherMediator.getAggregationExpression(), aggregationElement, "value-to-aggregate");
+                scatterGatherMediator.getAggregationExpression(), aggregationElement, "value");
 
         if (scatterGatherMediator.getCorrelateExpression() != null) {
             SynapsePathSerializer.serializePath(
@@ -68,8 +68,9 @@ public class ScatterGatherMediatorSerializer extends AbstractMediatorSerializer 
         scatterGatherElement.addChild(aggregationElement);
 
         for (Target target : scatterGatherMediator.getTargets()) {
-            if (target != null) {
-                scatterGatherElement.addChild(TargetSerializer.serializeTarget(target));
+            if (target != null && target.getSequence() != null) {
+                SequenceMediatorSerializer serializer = new SequenceMediatorSerializer();
+                serializer.serializeAnonymousSequence(scatterGatherElement, target.getSequence());
             }
         }
         serializeComments(scatterGatherElement, scatterGatherMediator.getCommentsList());

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -154,7 +154,7 @@ public class MediatorWorker implements Runnable {
                 debugManager.advertiseMediationFlowTerminatePoint(synCtx);
                 debugManager.releaseMediationFlowLock();
             }
-            if (RuntimeStatisticCollector.isStatisticsEnabled()) {
+            if (RuntimeStatisticCollector.isStatisticsEnabled() && !isScatterMessage(synCtx)) {
                 this.statisticsCloseEventListener.invokeCloseEventEntry(synCtx);
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -97,24 +97,20 @@ public class MediatorWorker implements Runnable {
                 debugManager.advertiseMediationFlowStartPoint(synCtx);
             }
 
+            boolean result = seq.mediate(synCtx);
             // If this is a scatter message, then we need to use the continuation state and continue the mediation
-            if (isScatterMessage(synCtx)) {
-                boolean result = seq.mediate(synCtx);
-                if (result) {
-                    SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(synCtx);
-                    if (seqContinuationState == null) {
-                        return;
-                    }
-                    SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(synCtx, seqContinuationState);
-
-                    FlowContinuableMediator mediator =
-                            (FlowContinuableMediator) sequenceMediator.getChild(seqContinuationState.getPosition());
-
-                    synCtx.setProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER, true);
-                    mediator.mediate(synCtx, seqContinuationState);
+            if (isScatterMessage(synCtx) && result) {
+                SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(synCtx);
+                if (seqContinuationState == null) {
+                    return;
                 }
-            } else {
-                seq.mediate(synCtx);
+                SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(synCtx, seqContinuationState);
+
+                FlowContinuableMediator mediator =
+                        (FlowContinuableMediator) sequenceMediator.getChild(seqContinuationState.getPosition());
+
+                synCtx.setProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER, true);
+                mediator.mediate(synCtx, seqContinuationState);
             }
             //((Axis2MessageContext)synCtx).getAxis2MessageContext().getEnvelope().discard();
 
@@ -188,7 +184,7 @@ public class MediatorWorker implements Runnable {
      */
     private static boolean isScatterMessage(MessageContext synCtx) {
 
-        Boolean isSkipContinuationState = (Boolean) synCtx.getProperty(SynapseConstants.SCATTER_MESSAGES);
-        return isSkipContinuationState != null && isSkipContinuationState;
+        Boolean isScatterMessage = (Boolean) synCtx.getProperty(SynapseConstants.SCATTER_MESSAGES);
+        return isScatterMessage != null && isScatterMessage;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -19,13 +19,24 @@
 
 package org.apache.synapse.mediators;
 
-import org.apache.synapse.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.FaultHandler;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.aspects.ComponentType;
 import org.apache.synapse.aspects.flow.statistics.StatisticsCloseEventListener;
+import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
+import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
 import org.apache.synapse.carbonext.TenantInfoConfigurator;
+import org.apache.synapse.continuation.ContinuationStackManager;
+import org.apache.synapse.continuation.SeqContinuationState;
 import org.apache.synapse.debug.SynapseDebugManager;
+import org.apache.synapse.mediators.base.SequenceMediator;
 import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
@@ -86,7 +97,25 @@ public class MediatorWorker implements Runnable {
                 debugManager.advertiseMediationFlowStartPoint(synCtx);
             }
 
-            seq.mediate(synCtx);
+            // If this is a scatter message, then we need to use the continuation state and continue the mediation
+            if (isScatterMessage(synCtx)) {
+                boolean result = seq.mediate(synCtx);
+                if (result) {
+                    SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(synCtx);
+                    if (seqContinuationState == null) {
+                        return;
+                    }
+                    SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(synCtx, seqContinuationState);
+
+                    FlowContinuableMediator mediator =
+                            (FlowContinuableMediator) sequenceMediator.getChild(seqContinuationState.getPosition());
+
+                    synCtx.setProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER, true);
+                    mediator.mediate(synCtx, seqContinuationState);
+                }
+            } else {
+                seq.mediate(synCtx);
+            }
             //((Axis2MessageContext)synCtx).getAxis2MessageContext().getEnvelope().discard();
 
         } catch (SynapseException syne) {
@@ -149,5 +178,17 @@ public class MediatorWorker implements Runnable {
 
     public void setStatisticsCloseEventListener(StatisticsCloseEventListener statisticsCloseEventListener) {
         this.statisticsCloseEventListener = statisticsCloseEventListener;
+    }
+
+    /**
+     * Check whether the message is a scatter message or not
+     *
+     * @param synCtx MessageContext
+     * @return true if the message is a scatter message
+     */
+    private static boolean isScatterMessage(MessageContext synCtx) {
+
+        Boolean isSkipContinuationState = (Boolean) synCtx.getProperty(SynapseConstants.SCATTER_MESSAGES);
+        return isSkipContinuationState != null && isSkipContinuationState;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
@@ -521,4 +521,16 @@ public class SequenceMediator extends AbstractListMediator implements Nameable,
             StatisticIdentityGenerator.reportingFlowContinuableEndEvent(sequenceId, ComponentType.SEQUENCE, holder);
         }
     }
+
+    /**
+     * Check whether the message is a scatter message or not
+     *
+     * @param synCtx MessageContext
+     * @return true if the message is a scatter message
+     */
+    private static boolean isScatterMessage(MessageContext synCtx) {
+
+        Boolean isSkipContinuationState = (Boolean) synCtx.getProperty(SynapseConstants.SCATTER_MESSAGES);
+        return isSkipContinuationState != null && isSkipContinuationState;
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
@@ -521,16 +521,4 @@ public class SequenceMediator extends AbstractListMediator implements Nameable,
             StatisticIdentityGenerator.reportingFlowContinuableEndEvent(sequenceId, ComponentType.SEQUENCE, holder);
         }
     }
-
-    /**
-     * Check whether the message is a scatter message or not
-     *
-     * @param synCtx MessageContext
-     * @return true if the message is a scatter message
-     */
-    private static boolean isScatterMessage(MessageContext synCtx) {
-
-        Boolean isSkipContinuationState = (Boolean) synCtx.getProperty(SynapseConstants.SCATTER_MESSAGES);
-        return isSkipContinuationState != null && isSkipContinuationState;
-    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
@@ -189,7 +189,7 @@ public class EIPUtils {
         }
     }
 
-    private static boolean isBody(OMElement body, OMElement enrichingElement) {
+    public static boolean isBody(OMElement body, OMElement enrichingElement) {
         try {
             return (body.getLocalName().equals(enrichingElement.getLocalName()) &&
                     body.getNamespace().getNamespaceURI().equals(enrichingElement.getNamespace().getNamespaceURI()));
@@ -198,7 +198,7 @@ public class EIPUtils {
         }
     }
 
-    private static boolean checkNotEmpty(List list) {
+    public static boolean checkNotEmpty(List list) {
         return list != null && !list.isEmpty();
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/SharedDataHolder.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/SharedDataHolder.java
@@ -18,6 +18,8 @@
 
 package org.apache.synapse.mediators.eip;
 
+import org.apache.synapse.MessageContext;
+
 /**
  * This class is used to hold the shared data for a particular message set
  * For an example we can use this to share some data across all the spawned spilt messages in iterate mediator
@@ -28,6 +30,17 @@ public class SharedDataHolder {
      * Variable to track whether aggregation is completed.
      */
     private boolean isAggregationCompleted = false;
+
+    private MessageContext synCtx;
+
+    public SharedDataHolder() {
+
+    }
+
+    public SharedDataHolder(MessageContext synCtx) {
+
+        this.synCtx = synCtx;
+    }
 
     /**
      * Check whether aggregation has been completed.
@@ -45,4 +58,8 @@ public class SharedDataHolder {
         isAggregationCompleted = true;
     }
 
+    public MessageContext getSynCtx() {
+
+        return synCtx;
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/Aggregate.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/Aggregate.java
@@ -115,6 +115,9 @@ public class Aggregate extends TimerTask {
      */
     public synchronized boolean addMessage(MessageContext synCtx) {
         if (maxCount <= 0 || (maxCount > 0 && messages.size() < maxCount)) {
+            if (messages == null) {
+                return false;
+            }
             messages.add(synCtx);
             return true;
         } else {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/Aggregate.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/Aggregate.java
@@ -31,6 +31,7 @@ import org.apache.synapse.mediators.v2.ScatterGather;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * An instance of this class is created to manage each aggregation group, and it holds
@@ -53,7 +54,7 @@ public class Aggregate extends TimerTask {
     private AggregateMediator aggregateMediator = null;
     private ScatterGather scatterGatherMediator = null;
     private List<MessageContext> messages = new ArrayList<MessageContext>();
-    private boolean locked = false;
+    private ReentrantLock lock = new ReentrantLock();
     private boolean completed = false;
     private SynapseEnvironment synEnv = null;
 
@@ -313,15 +314,15 @@ public class Aggregate extends TimerTask {
     }
 
     public synchronized boolean getLock() {
-        if (!locked) {
-            locked = true;
-            return true;
-        }
-        return false;
+
+        return lock.tryLock();
     }
 
     public synchronized void releaseLock() {
-        locked = false;
+
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
     }
 
     public boolean isCompleted() {
@@ -331,5 +332,4 @@ public class Aggregate extends TimerTask {
     public void setCompleted(boolean completed) {
         this.completed = completed;
     }
-
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
@@ -20,11 +20,18 @@ package org.apache.synapse.mediators.v2;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.context.OperationContext;
+import org.apache.http.protocol.HTTP;
 import org.apache.synapse.ContinuationState;
+import org.apache.synapse.JSONObjectExtensionException;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
@@ -39,6 +46,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
 import org.apache.synapse.aspects.flow.statistics.util.StatisticDataCollectionHelper;
+import org.apache.synapse.aspects.flow.statistics.util.StatisticsConstants;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.continuation.ContinuationStackManager;
@@ -56,10 +64,8 @@ import org.apache.synapse.mediators.eip.SharedDataHolder;
 import org.apache.synapse.mediators.eip.Target;
 import org.apache.synapse.mediators.eip.aggregator.Aggregate;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.apache.synapse.util.JSONMergeUtils;
 import org.apache.synapse.util.MessageHelper;
-import org.apache.synapse.util.xpath.SynapseJsonPath;
-import org.apache.synapse.util.xpath.SynapseXPath;
-import org.jaxen.JaxenException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -69,12 +75,19 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Timer;
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
+
+import static org.apache.synapse.SynapseConstants.XML_CONTENT_TYPE;
+import static org.apache.synapse.transport.passthru.PassThroughConstants.JSON_CONTENT_TYPE;
 
 public class ScatterGather extends AbstractMediator implements ManagedLifecycle, FlowContinuableMediator {
 
+    public static final String JSON_TYPE = "JSON";
+    public static final String XML_TYPE = "XML";
     private final Object lock = new Object();
     private final Map<String, Aggregate> activeAggregates = Collections.synchronizedMap(new HashMap<>());
     private String id;
@@ -86,6 +99,9 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
     private SynapsePath aggregationExpression = null;
     private boolean parallelExecution = true;
     private Integer statisticReportingIndex;
+    private String contentType;
+    private String resultTarget;
+    private SynapseEnvironment synapseEnv;
 
     public ScatterGather() {
 
@@ -122,8 +138,18 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             }
         }
 
-        synCtx.setProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
-                EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
+        MessageContext orginalMessageContext = null;
+        if (!isTargetBody()) {
+            try {
+                // Clone the original MessageContext and save it to continue the flow using it when the scatter gather
+                // output is set to a variable
+                orginalMessageContext = MessageHelper.cloneMessageContext(synCtx);
+            } catch (AxisFault e) {
+                handleException("Error cloning the message context", e, synCtx);
+            }
+        }
+
+        synCtx.setProperty(EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id, new SharedDataHolder(orginalMessageContext));
         Iterator<Target> iter = targets.iterator();
         int i = 0;
         while (iter.hasNext()) {
@@ -144,17 +170,21 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
         if (opCtx != null) {
             opCtx.setProperty(Constants.RESPONSE_WRITTEN, "SKIP");
         }
+        synCtx.setProperty(StatisticsConstants.CONTINUE_STATISTICS_FLOW, true);
         return aggregationResult;
     }
 
-    public void init(SynapseEnvironment se) {
+    public void init(SynapseEnvironment synapseEnv) {
 
+        this.synapseEnv = synapseEnv;
         for (Target target : targets) {
             ManagedLifecycle seq = target.getSequence();
             if (seq != null) {
-                seq.init(se);
+                seq.init(synapseEnv);
             }
         }
+        // Registering the mediator for enabling continuation
+        synapseEnv.updateCallMediatorCount(true);
     }
 
     public void destroy() {
@@ -165,6 +195,8 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
                 seq.destroy();
             }
         }
+        // Unregistering the mediator for continuation
+        synapseEnv.updateCallMediatorCount(false);
     }
 
     /**
@@ -186,14 +218,9 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             // Set the SCATTER_MESSAGES property to the cloned message context which will be used by the MediatorWorker
             // to continue the mediation from the continuation state
             newCtx.setProperty(SynapseConstants.SCATTER_MESSAGES, true);
-            if (id != null) {
-                newCtx.setProperty(EIPConstants.AGGREGATE_CORRELATION + "." + id, synCtx.getMessageID());
-                newCtx.setProperty(EIPConstants.MESSAGE_SEQUENCE + "." + id, messageSequence +
-                        EIPConstants.MESSAGE_SEQUENCE_DELEMITER + messageCount);
-            } else {
-                newCtx.setProperty(EIPConstants.MESSAGE_SEQUENCE, messageSequence +
-                        EIPConstants.MESSAGE_SEQUENCE_DELEMITER + messageCount);
-            }
+            newCtx.setProperty(EIPConstants.AGGREGATE_CORRELATION + "." + id, synCtx.getMessageID());
+            newCtx.setProperty(EIPConstants.MESSAGE_SEQUENCE + "." + id, messageSequence +
+                    EIPConstants.MESSAGE_SEQUENCE_DELEMITER + messageCount);
         } catch (AxisFault axisFault) {
             handleException("Error cloning the message context", axisFault, synCtx);
         }
@@ -282,28 +309,35 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
     private boolean aggregateMessages(MessageContext synCtx, SynapseLog synLog) {
 
         Aggregate aggregate = null;
-        String correlationIdName = (id != null ? EIPConstants.AGGREGATE_CORRELATION + "." + id :
-                EIPConstants.AGGREGATE_CORRELATION);
+        String correlationIdName = EIPConstants.AGGREGATE_CORRELATION + "." + id;
 
         Object correlationID = synCtx.getProperty(correlationIdName);
         String correlation;
 
         Object result = null;
+        // When the target sequences are not content aware, the message builder wont get triggered.
+        // Therefore, we need to build the message to do the aggregation.
+        try {
+            RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
+        } catch (IOException | XMLStreamException e) {
+            handleException("Error building the message", e, synCtx);
+        }
+
         if (correlateExpression != null) {
-            try {
-                result = correlateExpression instanceof SynapseXPath ? correlateExpression.evaluate(synCtx) :
-                        ((SynapseJsonPath) correlateExpression).evaluate(synCtx);
-            } catch (JaxenException e) {
-                handleException("Unable to execute the XPATH over the message", e, synCtx);
-            }
+            result = correlateExpression.objectValueOf(synCtx);
             if (result instanceof List) {
                 if (((List) result).isEmpty()) {
                     handleException("Failed to evaluate correlate expression: " + correlateExpression.toString(), synCtx);
                 }
             }
+            if (result instanceof JsonPrimitive) {
+                if (!((JsonPrimitive) result).getAsBoolean()) {
+                    return false;
+                }
+            }
             if (result instanceof Boolean) {
                 if (!(Boolean) result) {
-                    return true;
+                    return false;
                 }
             }
         }
@@ -444,9 +478,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
 
     private boolean isAggregationCompleted(MessageContext synCtx) {
 
-        Object aggregateTimeoutHolderObj =
-                synCtx.getProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
-                        EIPConstants.EIP_SHARED_DATA_HOLDER);
+        Object aggregateTimeoutHolderObj = synCtx.getProperty(EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id);
 
         if (aggregateTimeoutHolderObj != null) {
             SharedDataHolder sharedDataHolder = (SharedDataHolder) aggregateTimeoutHolderObj;
@@ -481,8 +513,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
                 MessageContext lastMessage = aggregate.getLastMessage();
                 if (lastMessage != null) {
                     Object aggregateTimeoutHolderObj =
-                            lastMessage.getProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
-                                    EIPConstants.EIP_SHARED_DATA_HOLDER);
+                            lastMessage.getProperty(EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id);
 
                     if (aggregateTimeoutHolderObj != null) {
                         SharedDataHolder sharedDataHolder = (SharedDataHolder) aggregateTimeoutHolderObj;
@@ -497,40 +528,222 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             return false;
         }
 
-        MessageContext newSynCtx = getAggregatedMessage(aggregate);
+        if (isTargetBody()) {
+            MessageContext newSynCtx = getAggregatedMessage(aggregate);
+            return processAggregation(newSynCtx, aggregate);
+        } else {
+            MessageContext originalMessageContext = getOriginalMessageContext(aggregate);
+            if (originalMessageContext != null) {
+                setAggregatedMessageAsVariable(originalMessageContext, aggregate);
+                return processAggregation(originalMessageContext, aggregate);
+            } else {
+                handleException(aggregate, "Error retrieving the original message context", null, aggregate.getLastMessage());
+                return false;
+            }
+        }
+    }
 
-        if (newSynCtx == null) {
+    private boolean processAggregation(MessageContext messageContext, Aggregate aggregate) {
+
+        if (messageContext == null) {
             log.warn("An aggregation of messages timed out with no aggregated messages", null);
             return false;
         }
         aggregate.clear();
         activeAggregates.remove(aggregate.getCorrelation());
-        newSynCtx.setProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER, false);
-        SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(newSynCtx);
-        boolean result = false;
+
+        if (isTargetBody()) {
+            // Set content type to the aggregated message
+            setContentType(messageContext);
+        } else {
+            // Update the continuation state to current mediator position as we are using the original message context
+            ContinuationStackManager.updateSeqContinuationState(messageContext, getMediatorPosition());
+        }
+
+        SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(messageContext);
+        messageContext.setProperty(StatisticsConstants.CONTINUE_STATISTICS_FLOW, true);
 
         if (RuntimeStatisticCollector.isStatisticsEnabled()) {
-            CloseEventCollector.closeEntryEvent(newSynCtx, getMediatorName(), ComponentType.MEDIATOR,
+            CloseEventCollector.closeEntryEvent(messageContext, getMediatorName(), ComponentType.MEDIATOR,
                     statisticReportingIndex, isContentAltering());
         }
 
+        boolean result = false;
         if (seqContinuationState != null) {
-            SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(newSynCtx, seqContinuationState);
-            result = sequenceMediator.mediate(newSynCtx, seqContinuationState);
+            SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(messageContext, seqContinuationState);
+            result = sequenceMediator.mediate(messageContext, seqContinuationState);
             if (RuntimeStatisticCollector.isStatisticsEnabled()) {
-                sequenceMediator.reportCloseStatistics(newSynCtx, null);
+                sequenceMediator.reportCloseStatistics(messageContext, null);
             }
         }
-        CloseEventCollector.closeEventsAfterScatterGather(newSynCtx);
+        CloseEventCollector.closeEventsAfterScatterGather(messageContext);
         return result;
+    }
+
+    /**
+     * Return the original message context using the SharedDataHolder.
+     *
+     * @param aggregate Aggregate object
+     * @return original message context
+     */
+    private MessageContext getOriginalMessageContext(Aggregate aggregate) {
+
+        MessageContext lastMessage = aggregate.getLastMessage();
+        if (lastMessage != null) {
+            Object aggregateHolderObj = lastMessage.getProperty(EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id);
+            if (aggregateHolderObj != null) {
+                SharedDataHolder sharedDataHolder = (SharedDataHolder) aggregateHolderObj;
+                return sharedDataHolder.getSynCtx();
+            }
+        }
+        return null;
+    }
+
+    private void setContentType(MessageContext synCtx) {
+
+        org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        if (Objects.equals(contentType, JSON_TYPE)) {
+            a2mc.setProperty(Constants.Configuration.MESSAGE_TYPE, JSON_CONTENT_TYPE);
+            a2mc.setProperty(Constants.Configuration.CONTENT_TYPE, JSON_CONTENT_TYPE);
+            setContentTypeHeader(JSON_CONTENT_TYPE, a2mc);
+        } else {
+            a2mc.setProperty(Constants.Configuration.MESSAGE_TYPE, XML_CONTENT_TYPE);
+            a2mc.setProperty(Constants.Configuration.CONTENT_TYPE, XML_CONTENT_TYPE);
+            setContentTypeHeader(XML_CONTENT_TYPE, a2mc);
+        }
+        a2mc.removeProperty("NO_ENTITY_BODY");
+    }
+
+    private void setContentTypeHeader(Object resultValue, org.apache.axis2.context.MessageContext axis2MessageCtx) {
+
+        axis2MessageCtx.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, resultValue);
+        Object o = axis2MessageCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+        Map headers = (Map) o;
+        if (headers != null) {
+            headers.put(HTTP.CONTENT_TYPE, resultValue);
+        }
+    }
+
+    private static void addChildren(List list, OMElement element) {
+
+        for (Object item : list) {
+            if (item instanceof OMElement) {
+                element.addChild((OMElement) item);
+            }
+        }
+    }
+
+    private static List getMatchingElements(MessageContext messageContext, SynapsePath expression) {
+
+        Object o = expression.objectValueOf(messageContext);
+        if (o instanceof OMNode) {
+            List list = new ArrayList();
+            list.add(o);
+            return list;
+        } else if (o instanceof List) {
+            return (List) o;
+        } else {
+            return new ArrayList();
+        }
+    }
+
+    private static void enrichEnvelope(MessageContext messageContext, SynapsePath expression) {
+
+        OMElement enrichingElement;
+        List elementList = getMatchingElements(messageContext, expression);
+        if (EIPUtils.checkNotEmpty(elementList)) {
+            // attach at parent of the first result from the XPath, or to the SOAPBody
+            Object o = elementList.get(0);
+            if (o instanceof OMElement &&
+                    ((OMElement) o).getParent() != null &&
+                    ((OMElement) o).getParent() instanceof OMElement) {
+                enrichingElement = (OMElement) ((OMElement) o).getParent();
+                OMElement body = messageContext.getEnvelope().getBody();
+                if (!EIPUtils.isBody(body, enrichingElement)) {
+                    OMElement nonBodyElem = enrichingElement;
+                    enrichingElement = messageContext.getEnvelope().getBody();
+                    addChildren(elementList, enrichingElement);
+                    while (!EIPUtils.isBody(body, (OMElement) nonBodyElem.getParent())) {
+                        nonBodyElem = (OMElement) nonBodyElem.getParent();
+                    }
+                    nonBodyElem.detach();
+                }
+            }
+        }
+    }
+
+    private void setAggregatedMessageAsVariable(MessageContext originalMessageContext, Aggregate aggregate) {
+
+        Object variable = originalMessageContext.getVariable(resultTarget);
+        if (variable == null) {
+            variable = createNewVariable(originalMessageContext, aggregate);
+            originalMessageContext.setVariable(resultTarget, variable);
+        }
+        if (Objects.equals(contentType, JSON_TYPE)) {
+            setJSONResultToVariable((JsonElement) variable, aggregate);
+        } else if (Objects.equals(contentType, XML_TYPE) && variable instanceof OMElement) {
+            setXMLResultToVariable((OMElement) variable, aggregate);
+        } else {
+            handleInvalidVariableType(variable, aggregate, originalMessageContext);
+        }
+        StatisticDataCollectionHelper.collectAggregatedParents(aggregate.getMessages(), originalMessageContext);
+    }
+
+    private void handleInvalidVariableType(Object variable, Aggregate aggregate, MessageContext synCtx) {
+
+        String expectedType = Objects.equals(contentType, JSON_TYPE) ? "JSON" : "OMElement";
+        String actualType = variable != null ? variable.getClass().getName() : "null";
+        handleException(aggregate, "Error merging aggregation results to variable: " + resultTarget +
+                " expected a " + expectedType + " but found " + actualType, null, synCtx);
+    }
+
+    private void setJSONResultToVariable(JsonElement variable, Aggregate aggregate) {
+
+        try {
+            for (MessageContext synCtx : aggregate.getMessages()) {
+                Object evaluatedResult = aggregationExpression.objectValueOf(synCtx);
+                if (variable instanceof JsonArray) {
+                    variable.getAsJsonArray().add((JsonElement) evaluatedResult);
+                } else if (variable instanceof JsonObject) {
+                    JSONMergeUtils.extendJSONObject((JsonObject) variable,
+                            JSONMergeUtils.ConflictStrategy.MERGE_INTO_ARRAY,
+                            ((JsonObject) evaluatedResult).getAsJsonObject());
+                } else {
+                    handleException(aggregate, "Error merging aggregation results to variable : " + resultTarget +
+                            " expected a JSON type variable but found " + variable.getClass().getName(), null, synCtx);
+                }
+            }
+        } catch (JSONObjectExtensionException e) {
+            handleException(aggregate, "Error merging aggregation results to JSON Object : " +
+                    aggregationExpression.toString(), e, aggregate.getLastMessage());
+        }
+    }
+
+    private void setXMLResultToVariable(OMElement variable, Aggregate aggregate) {
+
+        for (MessageContext synCtx : aggregate.getMessages()) {
+            List list = getMatchingElements(synCtx, aggregationExpression);
+            addChildren(list, variable);
+        }
+    }
+
+    private Object createNewVariable(MessageContext synCtx, Aggregate aggregate) {
+
+        if (Objects.equals(contentType, JSON_TYPE)) {
+            return new JsonArray();
+        } else if (Objects.equals(contentType, XML_TYPE)) {
+            return OMAbstractFactory.getOMFactory().createOMElement(new QName(resultTarget));
+        } else {
+            handleException(aggregate, "Error merging aggregation results to variable : " + resultTarget +
+                    " unknown content type : " + contentType, null, synCtx);
+            return null;
+        }
     }
 
     private MessageContext getAggregatedMessage(Aggregate aggregate) {
 
         MessageContext newCtx = null;
         JsonArray jsonArray = new JsonArray();
-        JsonElement result;
-        boolean isJSONAggregation = aggregationExpression instanceof SynapseJsonPath;
 
         for (MessageContext synCtx : aggregate.getMessages()) {
             if (newCtx == null) {
@@ -543,58 +756,51 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
                 if (log.isDebugEnabled()) {
                     log.debug("Generating Aggregated message from : " + newCtx.getEnvelope());
                 }
-                if (isJSONAggregation) {
-                    jsonArray.add(EIPUtils.getJSONElement(synCtx, (SynapseJsonPath) aggregationExpression));
-                } else {
-                    try {
-                        EIPUtils.enrichEnvelope(newCtx.getEnvelope(), synCtx, (SynapseXPath) aggregationExpression);
-                    } catch (JaxenException e) {
-                        handleException(aggregate, "Error merging aggregation results using XPath : " +
-                                aggregationExpression.toString(), e, synCtx);
+                if (Objects.equals(contentType, JSON_TYPE)) {
+                    Object evaluatedResult = aggregationExpression.objectValueOf(synCtx);
+                    if (evaluatedResult instanceof JsonElement) {
+                        jsonArray.add((JsonElement) evaluatedResult);
+                    } else {
+                        handleException(aggregate, "Error merging aggregation results as expression : " +
+                                aggregationExpression.toString() + " did not resolve to a JSON value", null, synCtx);
                     }
+                } else {
+                    enrichEnvelope(synCtx, aggregationExpression);
                 }
             } else {
                 try {
                     if (log.isDebugEnabled()) {
-                        log.debug("Merging message : " + synCtx.getEnvelope() + " using XPath : " +
+                        log.debug("Merging message : " + synCtx.getEnvelope() + " using expression : " +
                                 aggregationExpression);
                     }
-                    // When the target sequences are not content aware, the message builder wont get triggered.
-                    // Therefore, we need to build the message to do the aggregation.
-                    RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
-                    if (isJSONAggregation) {
-                        jsonArray.add(EIPUtils.getJSONElement(synCtx, (SynapseJsonPath) aggregationExpression));
+                    if (Objects.equals(contentType, JSON_TYPE)) {
+                        Object evaluatedResult = aggregationExpression.objectValueOf(synCtx);
+                        if (evaluatedResult instanceof JsonElement) {
+                            jsonArray.add((JsonElement) evaluatedResult);
+                        } else {
+                            jsonArray.add(evaluatedResult.toString());
+                        }
                     } else {
-                        EIPUtils.enrichEnvelope(newCtx.getEnvelope(), synCtx.getEnvelope(), synCtx, (SynapseXPath)
-                                aggregationExpression);
+                        enrichEnvelope(synCtx, aggregationExpression);
                     }
 
                     if (log.isDebugEnabled()) {
                         log.debug("Merged result : " + newCtx.getEnvelope());
                     }
-                } catch (JaxenException e) {
-                    handleException(aggregate, "Error merging aggregation results using XPath : " +
-                            aggregationExpression.toString(), e, synCtx);
                 } catch (SynapseException e) {
                     handleException(aggregate, "Error evaluating expression: " + aggregationExpression.toString(), e, synCtx);
                 } catch (JsonSyntaxException e) {
                     handleException(aggregate, "Error reading JSON element: " + aggregationExpression.toString(), e, synCtx);
-                } catch (IOException e) {
-                    handleException(aggregate, "IO Error occurred while building the message", e, synCtx);
-                } catch (XMLStreamException e) {
-                    handleException(aggregate, "XML Error occurred while building the message", e, synCtx);
                 }
             }
         }
 
-        result = jsonArray;
-
         StatisticDataCollectionHelper.collectAggregatedParents(aggregate.getMessages(), newCtx);
-        if (isJSONAggregation) {
+        if (Objects.equals(contentType, JSON_TYPE)) {
             // setting the new JSON payload to the messageContext
             try {
                 JsonUtil.getNewJsonPayload(((Axis2MessageContext) newCtx).getAxis2MessageContext(), new
-                        ByteArrayInputStream(result.toString().getBytes()), true, true);
+                        ByteArrayInputStream(jsonArray.toString().getBytes()), true, true);
             } catch (AxisFault axisFault) {
                 log.error("Error occurred while setting the new JSON payload to the msg context", axisFault);
             }
@@ -615,7 +821,6 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
     public void setCorrelateExpression(SynapsePath correlateExpression) {
 
         this.correlateExpression = correlateExpression;
-        this.id = null;
     }
 
     public long getCompletionTimeoutMillis() {
@@ -700,11 +905,36 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
     private void handleException(Aggregate aggregate, String msg, Exception exception, MessageContext msgContext) {
 
         aggregate.clear();
-        activeAggregates.clear();
+        activeAggregates.remove(aggregate.getCorrelation());
         if (exception != null) {
             super.handleException(msg, exception, msgContext);
         } else {
             super.handleException(msg, msgContext);
         }
+    }
+
+    public String getContentType() {
+
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+
+        this.contentType = contentType;
+    }
+
+    public String getResultTarget() {
+
+        return resultTarget;
+    }
+
+    public void setResultTarget(String resultTarget) {
+
+        this.resultTarget = resultTarget;
+    }
+
+    private boolean isTargetBody() {
+
+        return "body".equalsIgnoreCase(resultTarget);
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
@@ -1,0 +1,710 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.v2;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.Constants;
+import org.apache.axis2.context.OperationContext;
+import org.apache.synapse.ContinuationState;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.SynapseLog;
+import org.apache.synapse.aspects.AspectConfiguration;
+import org.apache.synapse.aspects.ComponentType;
+import org.apache.synapse.aspects.flow.statistics.StatisticIdentityGenerator;
+import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector;
+import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
+import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
+import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
+import org.apache.synapse.aspects.flow.statistics.util.StatisticDataCollectionHelper;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.continuation.ContinuationStackManager;
+import org.apache.synapse.continuation.ReliantContinuationState;
+import org.apache.synapse.continuation.SeqContinuationState;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+import org.apache.synapse.mediators.FlowContinuableMediator;
+import org.apache.synapse.mediators.Value;
+import org.apache.synapse.mediators.base.SequenceMediator;
+import org.apache.synapse.mediators.eip.EIPConstants;
+import org.apache.synapse.mediators.eip.EIPUtils;
+import org.apache.synapse.mediators.eip.SharedDataHolder;
+import org.apache.synapse.mediators.eip.Target;
+import org.apache.synapse.mediators.eip.aggregator.Aggregate;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.apache.synapse.util.MessageHelper;
+import org.apache.synapse.util.xpath.SynapseJsonPath;
+import org.apache.synapse.util.xpath.SynapseXPath;
+import org.jaxen.JaxenException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Timer;
+import javax.xml.stream.XMLStreamException;
+
+public class ScatterGather extends AbstractMediator implements ManagedLifecycle, FlowContinuableMediator {
+
+    private final Object lock = new Object();
+    private final Map<String, Aggregate> activeAggregates = Collections.synchronizedMap(new HashMap<>());
+    private String id;
+    private List<Target> targets = new ArrayList<>();
+    private long completionTimeoutMillis = 0;
+    private Value maxMessagesToComplete;
+    private Value minMessagesToComplete;
+    private SynapsePath correlateExpression = null;
+    private SynapsePath aggregationExpression = null;
+    private boolean parallelExecution = true;
+    private Integer statisticReportingIndex;
+
+    public ScatterGather() {
+
+        id = String.valueOf(new Random().nextLong());
+    }
+
+    public void setParallelExecution(boolean parallelExecution) {
+
+        this.parallelExecution = parallelExecution;
+    }
+
+    public boolean getParallelExecution() {
+
+        return this.parallelExecution;
+    }
+
+    public String getId() {
+
+        return id;
+    }
+
+    @Override
+    public boolean mediate(MessageContext synCtx) {
+
+        boolean aggregationResult = false;
+
+        SynapseLog synLog = getLog(synCtx);
+
+        if (synLog.isTraceOrDebugEnabled()) {
+            synLog.traceOrDebug("Start : Scatter Gather mediator");
+
+            if (synLog.isTraceTraceEnabled()) {
+                synLog.traceTrace("Message : " + synCtx.getEnvelope());
+            }
+        }
+
+        synCtx.setProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
+                EIPConstants.EIP_SHARED_DATA_HOLDER, new SharedDataHolder());
+        Iterator<Target> iter = targets.iterator();
+        int i = 0;
+        while (iter.hasNext()) {
+            if (synLog.isTraceOrDebugEnabled()) {
+                synLog.traceOrDebug("Submitting " + (i + 1) + " of " + targets.size() +
+                        " messages for " + (parallelExecution ? "parallel processing" : "sequential processing"));
+            }
+
+            MessageContext clonedMsgCtx = getClonedMessageContext(synCtx, i++, targets.size());
+            ContinuationStackManager.addReliantContinuationState(clonedMsgCtx, i - 1, getMediatorPosition());
+            boolean result = iter.next().mediate(clonedMsgCtx);
+            if (!parallelExecution && result) {
+                aggregationResult = aggregateMessages(clonedMsgCtx, synLog);
+            }
+        }
+        OperationContext opCtx
+                = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getOperationContext();
+        if (opCtx != null) {
+            opCtx.setProperty(Constants.RESPONSE_WRITTEN, "SKIP");
+        }
+        return aggregationResult;
+    }
+
+    public void init(SynapseEnvironment se) {
+
+        for (Target target : targets) {
+            ManagedLifecycle seq = target.getSequence();
+            if (seq != null) {
+                seq.init(se);
+            }
+        }
+    }
+
+    public void destroy() {
+
+        for (Target target : targets) {
+            ManagedLifecycle seq = target.getSequence();
+            if (seq != null) {
+                seq.destroy();
+            }
+        }
+    }
+
+    /**
+     * Clone the provided message context as a new message, and set the aggregation ID and the message sequence count
+     *
+     * @param synCtx          - MessageContext which is subjected to the cloning
+     * @param messageSequence - the position of this message of the cloned set
+     * @param messageCount    - total of cloned copies
+     * @return MessageContext the cloned message context
+     */
+    private MessageContext getClonedMessageContext(MessageContext synCtx, int messageSequence, int messageCount) {
+
+        MessageContext newCtx = null;
+        try {
+            newCtx = MessageHelper.cloneMessageContext(synCtx);
+            // Set isServerSide property in the cloned message context
+            ((Axis2MessageContext) newCtx).getAxis2MessageContext().setServerSide(
+                    ((Axis2MessageContext) synCtx).getAxis2MessageContext().isServerSide());
+            // Set the SCATTER_MESSAGES property to the cloned message context which will be used by the MediatorWorker
+            // to continue the mediation from the continuation state
+            newCtx.setProperty(SynapseConstants.SCATTER_MESSAGES, true);
+            if (id != null) {
+                newCtx.setProperty(EIPConstants.AGGREGATE_CORRELATION + "." + id, synCtx.getMessageID());
+                newCtx.setProperty(EIPConstants.MESSAGE_SEQUENCE + "." + id, messageSequence +
+                        EIPConstants.MESSAGE_SEQUENCE_DELEMITER + messageCount);
+            } else {
+                newCtx.setProperty(EIPConstants.MESSAGE_SEQUENCE, messageSequence +
+                        EIPConstants.MESSAGE_SEQUENCE_DELEMITER + messageCount);
+            }
+        } catch (AxisFault axisFault) {
+            handleException("Error cloning the message context", axisFault, synCtx);
+        }
+        return newCtx;
+    }
+
+    public List<Target> getTargets() {
+
+        return targets;
+    }
+
+    public void setTargets(List<Target> targets) {
+
+        this.targets = targets;
+    }
+
+    public void addTarget(Target target) {
+
+        this.targets.add(target);
+    }
+
+    public SynapsePath getAggregationExpression() {
+
+        return aggregationExpression;
+    }
+
+    public void setAggregationExpression(SynapsePath aggregationExpression) {
+
+        this.aggregationExpression = aggregationExpression;
+    }
+
+    @Override
+    public boolean mediate(MessageContext synCtx, ContinuationState continuationState) {
+
+        SynapseLog synLog = getLog(synCtx);
+
+        if (synLog.isTraceOrDebugEnabled()) {
+            synLog.traceOrDebug("Scatter Gather mediator : Mediating from ContinuationState");
+        }
+
+        boolean result;
+        // If the continuation is triggered from a mediator worker and has children, then mediate through the sub branch
+        // otherwise start aggregation
+        if (isContinuationTriggeredFromMediatorWorker(synCtx)) {
+            if (continuationState.hasChild()) {
+                int subBranch = ((ReliantContinuationState) continuationState.getChildContState()).getSubBranch();
+                SequenceMediator branchSequence = targets.get(subBranch).getSequence();
+                boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
+                FlowContinuableMediator mediator =
+                        (FlowContinuableMediator) branchSequence.getChild(continuationState.getChildContState().getPosition());
+
+                result = mediator.mediate(synCtx, continuationState.getChildContState());
+                if (isStatisticsEnabled) {
+                    ((Mediator) mediator).reportCloseStatistics(synCtx, null);
+                }
+            } else {
+                result = true;
+            }
+        } else {
+            // If the continuation is triggered from a callback, continue the mediation from the continuation state
+            int subBranch = ((ReliantContinuationState) continuationState).getSubBranch();
+
+            SequenceMediator branchSequence = targets.get(subBranch).getSequence();
+            boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
+            if (!continuationState.hasChild()) {
+                result = branchSequence.mediate(synCtx, continuationState.getPosition() + 1);
+            } else {
+                FlowContinuableMediator mediator =
+                        (FlowContinuableMediator) branchSequence.getChild(continuationState.getPosition());
+
+                result = mediator.mediate(synCtx, continuationState.getChildContState());
+                if (isStatisticsEnabled) {
+                    ((Mediator) mediator).reportCloseStatistics(synCtx, null);
+                }
+            }
+            // If the mediation is completed, remove the child continuation state from the stack, so the aggregation
+            // will continue the mediation from the parent continuation state
+            ContinuationStackManager.removeReliantContinuationState(synCtx);
+        }
+        if (result) {
+            return aggregateMessages(synCtx, synLog);
+        }
+        return false;
+    }
+
+    private boolean aggregateMessages(MessageContext synCtx, SynapseLog synLog) {
+
+        Aggregate aggregate = null;
+        String correlationIdName = (id != null ? EIPConstants.AGGREGATE_CORRELATION + "." + id :
+                EIPConstants.AGGREGATE_CORRELATION);
+
+        Object correlationID = synCtx.getProperty(correlationIdName);
+        String correlation;
+
+        Object result = null;
+        if (correlateExpression != null) {
+            try {
+                result = correlateExpression instanceof SynapseXPath ? correlateExpression.evaluate(synCtx) :
+                        ((SynapseJsonPath) correlateExpression).evaluate(synCtx);
+            } catch (JaxenException e) {
+                handleException("Unable to execute the XPATH over the message", e, synCtx);
+            }
+            if (result instanceof List) {
+                if (((List) result).isEmpty()) {
+                    handleException("Failed to evaluate correlate expression: " + correlateExpression.toString(), synCtx);
+                }
+            }
+            if (result instanceof Boolean) {
+                if (!(Boolean) result) {
+                    return true;
+                }
+            }
+        }
+        if (result != null) {
+            while (aggregate == null) {
+                synchronized (lock) {
+                    if (activeAggregates.containsKey(correlateExpression.toString())) {
+                        aggregate = activeAggregates.get(correlateExpression.toString());
+                        if (aggregate != null) {
+                            if (!aggregate.getLock()) {
+                                aggregate = null;
+                            }
+                        }
+                    } else {
+                        if (synLog.isTraceOrDebugEnabled()) {
+                            synLog.traceOrDebug("Creating new Aggregator - " +
+                                    (completionTimeoutMillis > 0 ? "expires in : "
+                                            + (completionTimeoutMillis / 1000) + "secs" :
+                                            "without expiry time"));
+                        }
+                        if (isAggregationCompleted(synCtx)) {
+                            return false;
+                        }
+
+                        Double minMsg = -1.0;
+                        if (minMessagesToComplete != null) {
+                            minMsg = Double.parseDouble(minMessagesToComplete.evaluateValue(synCtx));
+                        }
+                        Double maxMsg = -1.0;
+                        if (maxMessagesToComplete != null) {
+                            maxMsg = Double.parseDouble(maxMessagesToComplete.evaluateValue(synCtx));
+                        }
+
+                        aggregate = new Aggregate(
+                                synCtx.getEnvironment(),
+                                correlateExpression.toString(),
+                                completionTimeoutMillis,
+                                minMsg.intValue(),
+                                maxMsg.intValue(), this, synCtx.getFaultStack().peek());
+
+                        if (completionTimeoutMillis > 0) {
+                            synCtx.getConfiguration().getSynapseTimer().
+                                    schedule(aggregate, completionTimeoutMillis);
+                        }
+                        aggregate.getLock();
+                        activeAggregates.put(correlateExpression.toString(), aggregate);
+                    }
+                }
+            }
+        } else if (correlationID instanceof String) {
+            correlation = (String) correlationID;
+            while (aggregate == null) {
+                synchronized (lock) {
+                    if (activeAggregates.containsKey(correlation)) {
+                        aggregate = activeAggregates.get(correlation);
+                        if (aggregate != null) {
+                            if (!aggregate.getLock()) {
+                                aggregate = null;
+                            }
+                        } else {
+                            break;
+                        }
+                    } else {
+                        if (synLog.isTraceOrDebugEnabled()) {
+                            synLog.traceOrDebug("Creating new Aggregator - " +
+                                    (completionTimeoutMillis > 0 ? "expires in : "
+                                            + (completionTimeoutMillis / 1000) + "secs" :
+                                            "without expiry time"));
+                        }
+                        if (isAggregationCompleted(synCtx)) {
+                            return false;
+                        }
+
+                        Double minMsg = -1.0;
+                        if (minMessagesToComplete != null) {
+                            minMsg = Double.parseDouble(minMessagesToComplete.evaluateValue(synCtx));
+                        }
+                        Double maxMsg = -1.0;
+                        if (maxMessagesToComplete != null) {
+                            maxMsg = Double.parseDouble(maxMessagesToComplete.evaluateValue(synCtx));
+                        }
+                        aggregate = new Aggregate(
+                                synCtx.getEnvironment(),
+                                correlation,
+                                completionTimeoutMillis,
+                                minMsg.intValue(),
+                                maxMsg.intValue(), this, synCtx.getFaultStack().peek());
+
+                        if (completionTimeoutMillis > 0) {
+                            synchronized (aggregate) {
+                                if (!aggregate.isCompleted()) {
+                                    try {
+                                        synCtx.getConfiguration().getSynapseTimer().
+                                                schedule(aggregate, completionTimeoutMillis);
+                                    } catch (IllegalStateException e) {
+                                        log.warn("Synapse timer already cancelled. Resetting Synapse timer");
+                                        synCtx.getConfiguration().setSynapseTimer(new Timer(true));
+                                        synCtx.getConfiguration().getSynapseTimer().
+                                                schedule(aggregate, completionTimeoutMillis);
+                                    }
+                                }
+                            }
+                        }
+                        aggregate.getLock();
+                        activeAggregates.put(correlation, aggregate);
+                    }
+                }
+            }
+        } else {
+            synLog.traceOrDebug("Unable to find aggregation correlation property");
+            return true;
+        }
+        // if there is an aggregate continue on aggregation
+        if (aggregate != null) {
+            boolean collected = aggregate.addMessage(synCtx);
+            if (synLog.isTraceOrDebugEnabled()) {
+                if (collected) {
+                    synLog.traceOrDebug("Collected a message during aggregation");
+                    if (synLog.isTraceTraceEnabled()) {
+                        synLog.traceTrace("Collected message : " + synCtx);
+                    }
+                }
+            }
+            if (aggregate.isComplete(synLog)) {
+                synLog.traceOrDebug("Aggregation completed");
+                boolean onCompleteSeqResult = completeAggregate(aggregate);
+                synLog.traceOrDebug("End : Scatter Gather mediator");
+                return onCompleteSeqResult;
+            } else {
+                aggregate.releaseLock();
+            }
+        } else {
+            synLog.traceOrDebug("Unable to find an aggregate for this message - skip");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isAggregationCompleted(MessageContext synCtx) {
+
+        Object aggregateTimeoutHolderObj =
+                synCtx.getProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
+                        EIPConstants.EIP_SHARED_DATA_HOLDER);
+
+        if (aggregateTimeoutHolderObj != null) {
+            SharedDataHolder sharedDataHolder = (SharedDataHolder) aggregateTimeoutHolderObj;
+            if (sharedDataHolder.isAggregationCompleted()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Received a response for already completed Aggregate");
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean completeAggregate(Aggregate aggregate) {
+
+        boolean markedCompletedNow = false;
+        boolean wasComplete = aggregate.isCompleted();
+        if (wasComplete) {
+            return false;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Aggregation completed or timed out");
+        }
+
+        // cancel the timer
+        synchronized (this) {
+            if (!aggregate.isCompleted()) {
+                aggregate.cancel();
+                aggregate.setCompleted(true);
+
+                MessageContext lastMessage = aggregate.getLastMessage();
+                if (lastMessage != null) {
+                    Object aggregateTimeoutHolderObj =
+                            lastMessage.getProperty(id != null ? EIPConstants.EIP_SHARED_DATA_HOLDER + "." + id :
+                                    EIPConstants.EIP_SHARED_DATA_HOLDER);
+
+                    if (aggregateTimeoutHolderObj != null) {
+                        SharedDataHolder sharedDataHolder = (SharedDataHolder) aggregateTimeoutHolderObj;
+                        sharedDataHolder.markAggregationCompletion();
+                    }
+                }
+                markedCompletedNow = true;
+            }
+        }
+
+        if (!markedCompletedNow) {
+            return false;
+        }
+
+        MessageContext newSynCtx = getAggregatedMessage(aggregate);
+
+        if (newSynCtx == null) {
+            log.warn("An aggregation of messages timed out with no aggregated messages", null);
+            return false;
+        }
+        aggregate.clear();
+        activeAggregates.remove(aggregate.getCorrelation());
+        newSynCtx.setProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER, false);
+        SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(newSynCtx);
+        boolean result = false;
+
+        if (RuntimeStatisticCollector.isStatisticsEnabled()) {
+            CloseEventCollector.closeEntryEvent(newSynCtx, getMediatorName(), ComponentType.MEDIATOR,
+                    statisticReportingIndex, isContentAltering());
+        }
+
+        if (seqContinuationState != null) {
+            SequenceMediator sequenceMediator = ContinuationStackManager.retrieveSequence(newSynCtx, seqContinuationState);
+            result = sequenceMediator.mediate(newSynCtx, seqContinuationState);
+            if (RuntimeStatisticCollector.isStatisticsEnabled()) {
+                sequenceMediator.reportCloseStatistics(newSynCtx, null);
+            }
+        }
+        CloseEventCollector.closeEventsAfterScatterGather(newSynCtx);
+        return result;
+    }
+
+    private MessageContext getAggregatedMessage(Aggregate aggregate) {
+
+        MessageContext newCtx = null;
+        JsonArray jsonArray = new JsonArray();
+        JsonElement result;
+        boolean isJSONAggregation = aggregationExpression instanceof SynapseJsonPath;
+
+        for (MessageContext synCtx : aggregate.getMessages()) {
+            if (newCtx == null) {
+                try {
+                    newCtx = MessageHelper.cloneMessageContext(synCtx, true, false, true);
+                } catch (AxisFault axisFault) {
+                    handleException(aggregate, "Error creating a copy of the message", axisFault, synCtx);
+                }
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Generating Aggregated message from : " + newCtx.getEnvelope());
+                }
+                if (isJSONAggregation) {
+                    jsonArray.add(EIPUtils.getJSONElement(synCtx, (SynapseJsonPath) aggregationExpression));
+                } else {
+                    try {
+                        EIPUtils.enrichEnvelope(newCtx.getEnvelope(), synCtx, (SynapseXPath) aggregationExpression);
+                    } catch (JaxenException e) {
+                        handleException(aggregate, "Error merging aggregation results using XPath : " +
+                                aggregationExpression.toString(), e, synCtx);
+                    }
+                }
+            } else {
+                try {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Merging message : " + synCtx.getEnvelope() + " using XPath : " +
+                                aggregationExpression);
+                    }
+                    // When the target sequences are not content aware, the message builder wont get triggered.
+                    // Therefore, we need to build the message to do the aggregation.
+                    RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext());
+                    if (isJSONAggregation) {
+                        jsonArray.add(EIPUtils.getJSONElement(synCtx, (SynapseJsonPath) aggregationExpression));
+                    } else {
+                        EIPUtils.enrichEnvelope(newCtx.getEnvelope(), synCtx.getEnvelope(), synCtx, (SynapseXPath)
+                                aggregationExpression);
+                    }
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("Merged result : " + newCtx.getEnvelope());
+                    }
+                } catch (JaxenException e) {
+                    handleException(aggregate, "Error merging aggregation results using XPath : " +
+                            aggregationExpression.toString(), e, synCtx);
+                } catch (SynapseException e) {
+                    handleException(aggregate, "Error evaluating expression: " + aggregationExpression.toString(), e, synCtx);
+                } catch (JsonSyntaxException e) {
+                    handleException(aggregate, "Error reading JSON element: " + aggregationExpression.toString(), e, synCtx);
+                } catch (IOException e) {
+                    handleException(aggregate, "IO Error occurred while building the message", e, synCtx);
+                } catch (XMLStreamException e) {
+                    handleException(aggregate, "XML Error occurred while building the message", e, synCtx);
+                }
+            }
+        }
+
+        result = jsonArray;
+
+        StatisticDataCollectionHelper.collectAggregatedParents(aggregate.getMessages(), newCtx);
+        if (isJSONAggregation) {
+            // setting the new JSON payload to the messageContext
+            try {
+                JsonUtil.getNewJsonPayload(((Axis2MessageContext) newCtx).getAxis2MessageContext(), new
+                        ByteArrayInputStream(result.toString().getBytes()), true, true);
+            } catch (AxisFault axisFault) {
+                log.error("Error occurred while setting the new JSON payload to the msg context", axisFault);
+            }
+        } else {
+            // Removing the JSON stream after aggregated using XML path.
+            // This will fix inconsistent behaviour in logging the payload.
+            ((Axis2MessageContext) newCtx).getAxis2MessageContext()
+                    .removeProperty(org.apache.synapse.commons.json.Constants.ORG_APACHE_SYNAPSE_COMMONS_JSON_JSON_INPUT_STREAM);
+        }
+        return newCtx;
+    }
+
+    public SynapsePath getCorrelateExpression() {
+
+        return correlateExpression;
+    }
+
+    public void setCorrelateExpression(SynapsePath correlateExpression) {
+
+        this.correlateExpression = correlateExpression;
+        this.id = null;
+    }
+
+    public long getCompletionTimeoutMillis() {
+
+        return completionTimeoutMillis;
+    }
+
+    public void setCompletionTimeoutMillis(long completionTimeoutMillis) {
+
+        this.completionTimeoutMillis = completionTimeoutMillis;
+    }
+
+    public Value getMinMessagesToComplete() {
+
+        return minMessagesToComplete;
+    }
+
+    public void setMinMessagesToComplete(Value minMessagesToComplete) {
+
+        this.minMessagesToComplete = minMessagesToComplete;
+    }
+
+    public Value getMaxMessagesToComplete() {
+
+        return maxMessagesToComplete;
+    }
+
+    public void setMaxMessagesToComplete(Value maxMessagesToComplete) {
+
+        this.maxMessagesToComplete = maxMessagesToComplete;
+    }
+
+    /**
+     * Check whether the message is a scatter message or not
+     *
+     * @param synCtx MessageContext
+     * @return true if the message is a scatter message
+     */
+    private static boolean isContinuationTriggeredFromMediatorWorker(MessageContext synCtx) {
+
+        Boolean isContinuationTriggeredMediatorWorker =
+                (Boolean) synCtx.getProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER);
+        return isContinuationTriggeredMediatorWorker != null && isContinuationTriggeredMediatorWorker;
+    }
+
+    @Override
+    public Integer reportOpenStatistics(MessageContext messageContext, boolean isContentAltering) {
+
+        statisticReportingIndex = OpenEventCollector.reportFlowContinuableEvent(messageContext, getMediatorName(),
+                ComponentType.MEDIATOR, getAspectConfiguration(), isContentAltering() || isContentAltering);
+        return statisticReportingIndex;
+    }
+
+    @Override
+    public void reportCloseStatistics(MessageContext messageContext, Integer currentIndex) {
+
+        // Do nothing here as the close event is reported in the completeAggregate method
+    }
+
+    @Override
+    public void setComponentStatisticsId(ArtifactHolder holder) {
+
+        if (getAspectConfiguration() == null) {
+            configure(new AspectConfiguration(getMediatorName()));
+        }
+        String sequenceId =
+                StatisticIdentityGenerator.getIdForFlowContinuableMediator(getMediatorName(), ComponentType.MEDIATOR, holder);
+        getAspectConfiguration().setUniqueId(sequenceId);
+        for (Target target : targets) {
+            target.setStatisticIdForMediators(holder);
+        }
+
+        StatisticIdentityGenerator.reportingFlowContinuableEndEvent(sequenceId, ComponentType.MEDIATOR, holder);
+    }
+
+    @Override
+    public boolean isContentAltering() {
+
+        return true;
+    }
+
+    private void handleException(Aggregate aggregate, String msg, Exception exception, MessageContext msgContext) {
+
+        aggregate.clear();
+        activeAggregates.clear();
+        if (exception != null) {
+            super.handleException(msg, exception, msgContext);
+        } else {
+            super.handleException(msg, msgContext);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
@@ -448,7 +448,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             }
         } else {
             synLog.traceOrDebug("Unable to find aggregation correlation property");
-            return true;
+            return false;
         }
         // if there is an aggregate continue on aggregation
         if (aggregate != null) {
@@ -471,7 +471,6 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             }
         } else {
             synLog.traceOrDebug("Unable to find an aggregate for this message - skip");
-            return true;
         }
         return false;
     }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.config.xml;
+
+/**
+ * Factory and Serializer tests for the ScatterGatherMediator
+ */
+
+public class ScatterGatherMediatorSerializationTest extends AbstractTestCase {
+
+    private ScatterGatherMediatorFactory scatterGatherMediatorFactory;
+    private ScatterGatherMediatorSerializer scatterGatherMediatorSerializer;
+
+    public ScatterGatherMediatorSerializationTest() {
+
+        super(ScatterGatherMediatorSerializer.class.getName());
+        scatterGatherMediatorFactory = new ScatterGatherMediatorFactory();
+        scatterGatherMediatorSerializer = new ScatterGatherMediatorSerializer();
+    }
+
+    public void testScatterGatherSerialization() {
+
+        String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" parallel-execution=\"true\">" +
+                "<aggregation value-to-aggregate=\"json-eval($)\" /><target><sequence>" +
+                "<payloadFactory media-type=\"json\"><format>{                    \"pet\": {                        " +
+                "\"name\": \"pet1\",                        \"type\": \"dog\"                    },                    " +
+                "\"status\": \"success\"                    }</format><args/></payloadFactory><log level=\"custom\">" +
+                "<property name=\"Message\" value=\"==== DONE scatter target 1 ====\"/></log></sequence></target>" +
+                "<target><sequence><call><endpoint><http method=\"GET\" uri-template=\"http://localhost:5454/api/pet2\"/>" +
+                "</endpoint></call><log level=\"custom\"><property name=\"Message\" value=\"==== DONE scatter target 2 ====\"/>" +
+                "</log></sequence></target></scatter-gather>";
+
+        assertTrue(serialization(inputXML, scatterGatherMediatorFactory, scatterGatherMediatorSerializer));
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
@@ -36,7 +36,8 @@ public class ScatterGatherMediatorSerializationTest extends AbstractTestCase {
 
     public void testScatterGatherSerialization() {
 
-        String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" parallel-execution=\"true\">" +
+        String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" result-target=\"body\" " +
+                "content-type=\"XML\" parallel-execution=\"true\">" +
                 "<aggregation value=\"json-eval($)\" /><sequence>" +
                 "<payloadFactory media-type=\"json\"><format>{                    \"pet\": {                        " +
                 "\"name\": \"pet1\",                        \"type\": \"dog\"                    },                    " +

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
@@ -34,11 +34,27 @@ public class ScatterGatherMediatorSerializationTest extends AbstractTestCase {
         scatterGatherMediatorSerializer = new ScatterGatherMediatorSerializer();
     }
 
-    public void testScatterGatherSerialization() {
+    public void testScatterGatherXMLTypeSerialization() {
 
         String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" result-target=\"body\" " +
-                "content-type=\"XML\" parallel-execution=\"true\">" +
-                "<aggregation value=\"json-eval($)\" /><sequence>" +
+                "content-type=\"XML\" root-element=\"result\" parallel-execution=\"true\">" +
+                "<aggregation expression=\"json-eval($)\" /><sequence>" +
+                "<payloadFactory media-type=\"json\"><format>{                    \"pet\": {                        " +
+                "\"name\": \"pet1\",                        \"type\": \"dog\"                    },                    " +
+                "\"status\": \"success\"                    }</format><args/></payloadFactory><log level=\"custom\">" +
+                "<property name=\"Message\" value=\"==== DONE scatter target 1 ====\"/></log></sequence>" +
+                "<sequence><call><endpoint><http method=\"GET\" uri-template=\"http://localhost:5454/api/pet2\"/>" +
+                "</endpoint></call><log level=\"custom\"><property name=\"Message\" value=\"==== DONE scatter target 2 ====\"/>" +
+                "</log></sequence></scatter-gather>";
+
+        assertTrue(serialization(inputXML, scatterGatherMediatorFactory, scatterGatherMediatorSerializer));
+    }
+
+    public void testScatterGatherJSONTypeSerialization() {
+
+        String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" result-target=\"variable1\" " +
+                "content-type=\"JSON\" parallel-execution=\"false\">" +
+                "<aggregation expression=\"json-eval($)\" /><sequence>" +
                 "<payloadFactory media-type=\"json\"><format>{                    \"pet\": {                        " +
                 "\"name\": \"pet1\",                        \"type\": \"dog\"                    },                    " +
                 "\"status\": \"success\"                    }</format><args/></payloadFactory><log level=\"custom\">" +

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ScatterGatherMediatorSerializationTest.java
@@ -37,14 +37,14 @@ public class ScatterGatherMediatorSerializationTest extends AbstractTestCase {
     public void testScatterGatherSerialization() {
 
         String inputXML = "<scatter-gather xmlns=\"http://ws.apache.org/ns/synapse\" parallel-execution=\"true\">" +
-                "<aggregation value-to-aggregate=\"json-eval($)\" /><target><sequence>" +
+                "<aggregation value=\"json-eval($)\" /><sequence>" +
                 "<payloadFactory media-type=\"json\"><format>{                    \"pet\": {                        " +
                 "\"name\": \"pet1\",                        \"type\": \"dog\"                    },                    " +
                 "\"status\": \"success\"                    }</format><args/></payloadFactory><log level=\"custom\">" +
-                "<property name=\"Message\" value=\"==== DONE scatter target 1 ====\"/></log></sequence></target>" +
-                "<target><sequence><call><endpoint><http method=\"GET\" uri-template=\"http://localhost:5454/api/pet2\"/>" +
+                "<property name=\"Message\" value=\"==== DONE scatter target 1 ====\"/></log></sequence>" +
+                "<sequence><call><endpoint><http method=\"GET\" uri-template=\"http://localhost:5454/api/pet2\"/>" +
                 "</endpoint></call><log level=\"custom\"><property name=\"Message\" value=\"==== DONE scatter target 2 ====\"/>" +
-                "</log></sequence></target></scatter-gather>";
+                "</log></sequence></scatter-gather>";
 
         assertTrue(serialization(inputXML, scatterGatherMediatorFactory, scatterGatherMediatorSerializer));
     }


### PR DESCRIPTION
## Purpose

Add new mediator to clone the messages and aggregate the results.

**Syntax**

```xml
<scatter-gather parallel-execution=(true | false) result-target=(body | variable) content-type=(JSON | XML) root-element=(string) >
    <aggregation expression="expression" condition="expression" timeout="long"
    min-messages="expression" max-messages="expression"/>
        <sequence>
        (mediator)+
        </sequence>+
</scatter-gather>
```

**Sample configuration**

```xml
<scatter-gather parallel-execution="true">
    <aggregation value="json-eval($)"/>
        <sequence>
            <payloadFactory media-type="json" template-type="default">
                <format>{
                    "pet": {
                        "name": "pet1",
                        "type": "dog"
                    },
                    "status": "success"
                    }</format>
                <args>
                </args>
            </payloadFactory>
            <log category="INFO" level="custom">
                <property name="Message" value="==== DONE scatter target 1 ===="/>
            </log>
        </sequence>
        <sequence>
            <call>
                <endpoint>
                    <http method="get" uri-template="http://localhost:5454/api/pet2"/>
                </endpoint>
            </call>
            <log category="INFO" level="custom">
                <property name="Message" value="==== DONE scatter target 2 ===="/>
            </log>
        </sequence>
</scatter-gather>
```