### PR TITLE
Fix Error while access large xml in PayloadFactory

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/PayloadFactoryMediator.java
@@ -84,6 +84,16 @@ public class PayloadFactoryMediator extends AbstractMediator {
     private static final Log log = LogFactory.getLog(PayloadFactoryMediator.class);
 
     public PayloadFactoryMediator() {
+        //ignore DTDs for XML Input
+        inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        inputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
+        Map props = StAXUtils.loadFactoryProperties("XMLInputFactory.properties");
+        if (props != null) {
+            for (Object o : props.entrySet()) {
+                Map.Entry entry = (Map.Entry) o;
+                inputFactory.setProperty((String) entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION

## Purpose
Initialize XMLInputFactory with XMLInputFactory.properties when instantiating PF to avoid skipping mandatory properties being added to factory.

Fixes: https://github.com/wso2/product-micro-integrator/issues/3775
