### PR TITLE
Fix infinite dispatch loop in MP due to stale channel

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/MessageConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/MessageConsumer.java
@@ -62,4 +62,10 @@ public interface MessageConsumer {
      * @return ID
      */
     public String getId();
+
+    /**
+     * Re-initializes the message consumer.
+     * @return {@code true} if re-initialization is successful, {@code false} otherwise.
+     */
+    public boolean reInitialize();
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -681,7 +681,7 @@ public class ForwardingService implements Task, ManagedLifecycle {
 			// For each retry we need to have a fresh copy of the original message
 			getFreshCopyOfOriginalMessage(messageToDispatch, originalEnvelop, originalJsonInputStream);
 
-			if (messageConsumer != null && messageConsumer.isAlive()) {
+			if (messageConsumer != null && (messageConsumer.isAlive() || messageConsumer.reInitialize())) {
 				messageToDispatch.setProperty(SynapseConstants.BLOCKING_MSG_SENDER, sender);
 				// Clear the message context properties related to endpoint in last service invocation
 				Set keySet = messageToDispatch.getPropertyKeySet();

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jdbc/JDBCConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jdbc/JDBCConsumer.java
@@ -90,6 +90,11 @@ public class JDBCConsumer implements MessageConsumer {
         }
     }
 
+    public boolean reInitialize() {
+        // To keep the existing behaviour, return false
+        return false;
+    }
+
     /**
      * Ack on success message sending by processor
      *

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
@@ -283,6 +283,11 @@ public class JmsConsumer implements MessageConsumer {
         }
     }
 
+    public boolean reInitialize() {
+        // To keep the existing behaviour, return false
+        return false;
+    }
+
     private final class CachedMessage {
         private Message message = null;
         private MessageContext mc = null;

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/memory/InMemoryConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/memory/InMemoryConsumer.java
@@ -98,4 +98,10 @@ public class InMemoryConsumer implements MessageConsumer {
         this.queue = queue;
         return this;
     }
+
+    @Override
+    public boolean reInitialize() {
+        // To keep the existing behaviour, return false
+        return false;
+    }
 }


### PR DESCRIPTION

## Purpose
The issue occurred when the message processor repeatedly attempted to dispatch a message in a loop, leaving an unacknowledged message in the RabbitMQ queue. Over time, the channel to the queue became stale. Although there is a check in the dispatch logic for a healthy store connection, this check failed to terminate the loop, causing the dispatch process to run indefinitely. This commit addresses the issue by ensuring the loop exits when the channel becomes stale or the store connection is deemed unhealthy.

Fixes: https://github.com/wso2/product-micro-integrator/issues/3771
