### PR TITLE
Handle certificates mentioned in HTTP connection during local entry deployment.

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/IKeyStoreLoader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/IKeyStoreLoader.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.apache.synapse.transport.dynamicconfigurations;
 
 import org.apache.axis2.AxisFault;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/IKeyStoreLoader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/IKeyStoreLoader.java
@@ -1,0 +1,9 @@
+package org.apache.synapse.transport.dynamicconfigurations;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.description.ParameterInclude;
+
+public interface IKeyStoreLoader {
+
+    void loadKeyStore(ParameterInclude transport) throws AxisFault;
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.apache.synapse.transport.dynamicconfigurations;
 
 import org.apache.axis2.AxisFault;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
@@ -38,12 +38,8 @@ public class KeyStoreReloader {
         KeyStoreReloaderHolder.getInstance().addKeyStoreLoader(this);
     }
 
-    public void update() {
+    public void update() throws AxisFault {
 
-        try {
-            keyStoreLoader.loadKeyStore(transportOutDescription);
-        } catch (AxisFault e) {
-            throw new RuntimeException(e);
-        }
+        keyStoreLoader.loadKeyStore(transportOutDescription);
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
@@ -1,0 +1,32 @@
+package org.apache.synapse.transport.dynamicconfigurations;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.description.ParameterInclude;
+
+public class KeyStoreReloader {
+
+    private IKeyStoreLoader keyStoreLoader;
+    private ParameterInclude transportOutDescription;
+
+    public KeyStoreReloader(IKeyStoreLoader keyStoreLoader, ParameterInclude transportOutDescription) {
+
+        this.keyStoreLoader = keyStoreLoader;
+        this.transportOutDescription = transportOutDescription;
+
+        registerListener(transportOutDescription);
+    }
+
+    private void registerListener(ParameterInclude transportOutDescription) {
+
+        KeyStoreReloaderHolder.getInstance().addKeyStoreLoader(this);
+    }
+
+    public void update() {
+
+        try {
+            keyStoreLoader.loadKeyStore(transportOutDescription);
+        } catch (AxisFault e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
@@ -17,6 +17,8 @@
  */
 package org.apache.synapse.transport.dynamicconfigurations;
 
+import org.apache.axis2.AxisFault;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +39,7 @@ public class KeyStoreReloaderHolder {
         keyStoreLoaders.add(keyStoreLoader);
     }
 
-    public void reloadAllKeyStores() {
+    public void reloadAllKeyStores() throws AxisFault {
         for (KeyStoreReloader keyStoreLoader : keyStoreLoaders) {
             keyStoreLoader.update();
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.apache.synapse.transport.dynamicconfigurations;
 
 import java.util.ArrayList;

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
@@ -1,0 +1,28 @@
+package org.apache.synapse.transport.dynamicconfigurations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KeyStoreReloaderHolder {
+
+    private static KeyStoreReloaderHolder instance = new KeyStoreReloaderHolder();
+    private List<KeyStoreReloader> keyStoreLoaders;
+
+    private KeyStoreReloaderHolder() {
+        keyStoreLoaders = new ArrayList<>();
+    }
+
+    public static KeyStoreReloaderHolder getInstance() {
+        return instance;
+    }
+
+    public void addKeyStoreLoader(KeyStoreReloader keyStoreLoader) {
+        keyStoreLoaders.add(keyStoreLoader);
+    }
+
+    public void reloadAllKeyStores() {
+        for (KeyStoreReloader keyStoreLoader : keyStoreLoaders) {
+            keyStoreLoader.update();
+        }
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ClientConnFactoryBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/ClientConnFactoryBuilder.java
@@ -370,14 +370,18 @@ public class ClientConnFactoryBuilder {
                 if (log.isDebugEnabled()) {
                     log.debug(name + " Loading Trust Keystore from : " + location);
                 }
-                SslSenderTrustStoreHolder.getInstance().setLocation(location);
-                SslSenderTrustStoreHolder.getInstance().setPassword(passwordElement.getText());
-                SslSenderTrustStoreHolder.getInstance().setType(type);
+
                 trustStore.load(fis, storePassword.toCharArray());
                 TrustManagerFactory trustManagerfactory = TrustManagerFactory.getInstance(
                         TrustManagerFactory.getDefaultAlgorithm());
                 trustManagerfactory.init(trustStore);
                 trustManagers = trustManagerfactory.getTrustManagers();
+
+                SslSenderTrustStoreHolder sslSenderTrustStoreHolder = SslSenderTrustStoreHolder.getInstance();
+                sslSenderTrustStoreHolder.setKeyStore(trustStore);
+                sslSenderTrustStoreHolder.setLocation(location);
+                sslSenderTrustStoreHolder.setPassword(storePassword);
+                SslSenderTrustStoreHolder.getInstance().setType(type);
             } catch (GeneralSecurityException gse) {
                 log.error(name + " Error loading Key store : " + location, gse);
                 throw new AxisFault("Error loading Key store : " + location, gse);
@@ -471,6 +475,11 @@ public class ClientConnFactoryBuilder {
                         TrustManagerFactory.getDefaultAlgorithm());
                 trustManagerfactory.init(trustStore);
                 trustManagers = trustManagerfactory.getTrustManagers();
+
+                SslSenderTrustStoreHolder sslSenderTrustStoreHolder = SslSenderTrustStoreHolder.getInstance();
+                sslSenderTrustStoreHolder.setKeyStore(trustStore);
+                sslSenderTrustStoreHolder.setLocation(location);
+                sslSenderTrustStoreHolder.setPassword(storePassword);
 
             } catch (GeneralSecurityException gse) {
                 log.error(name + " Error loading Key store : " + location, gse);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolder.java
@@ -17,6 +17,8 @@
  */
 package org.apache.synapse.transport.nhttp.config;
 
+import java.security.KeyStore;
+
 /**
  * The SSL Sender TrustStore Holder class to store the client trust store's configurable details.
  */
@@ -26,6 +28,7 @@ public class SslSenderTrustStoreHolder {
 
     private SslSenderTrustStoreHolder() {}
 
+    private KeyStore keyStore;
     private String location;
     private String password;
     private String type;
@@ -33,13 +36,28 @@ public class SslSenderTrustStoreHolder {
     public static SslSenderTrustStoreHolder getInstance() {
 
         if (instance == null) {
-            synchronized (TrustStoreHolder.class) {
+            synchronized (SslSenderTrustStoreHolder.class) {
                 if (instance == null) {
                     instance = new SslSenderTrustStoreHolder();
                 }
             }
         }
         return instance;
+    }
+
+    public static void resetInstance() {
+
+        instance = null;
+    }
+
+    public KeyStore getKeyStore() {
+
+        return keyStore;
+    }
+
+    public void setKeyStore(KeyStore keyStore) {
+
+        this.keyStore = keyStore;
     }
 
     public void setLocation(String location) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolder.java
@@ -83,4 +83,9 @@ public class SslSenderTrustStoreHolder {
     public String getType() {
         return this.type;
     }
+
+    public boolean isValid() {
+        return keyStore != null && location != null && !location.isEmpty() &&
+                password != null && !password.isEmpty();
+    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSSLSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSSLSender.java
@@ -21,18 +21,21 @@ import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.description.ParameterInclude;
 import org.apache.axis2.description.TransportOutDescription;
 import org.apache.synapse.transport.certificatevalidation.cache.CertCache;
+import org.apache.synapse.transport.dynamicconfigurations.IKeyStoreLoader;
+import org.apache.synapse.transport.dynamicconfigurations.KeyStoreReloader;
 import org.apache.synapse.transport.dynamicconfigurations.SSLProfileLoader;
 import org.apache.synapse.transport.dynamicconfigurations.SenderProfileReloader;
 import org.apache.synapse.transport.http.conn.Scheme;
 import org.apache.synapse.transport.nhttp.config.ClientConnFactoryBuilder;
 import org.apache.synapse.transport.nhttp.config.TrustStoreHolder;
 
-public class PassThroughHttpSSLSender extends PassThroughHttpSender implements SSLProfileLoader {
+public class PassThroughHttpSSLSender extends PassThroughHttpSender implements SSLProfileLoader, IKeyStoreLoader {
 
     @Override
     public void init(ConfigurationContext configurationContext,
                      TransportOutDescription transportOutDescription) throws AxisFault {
         super.init(configurationContext, transportOutDescription);
+        new KeyStoreReloader(this, transportOutDescription);
         new SenderProfileReloader(this, transportOutDescription);
     }
 
@@ -60,4 +63,10 @@ public class PassThroughHttpSSLSender extends PassThroughHttpSender implements S
         reloadDynamicSSLConfig((TransportOutDescription) transport);
     }
 
+    @Override
+    public void loadKeyStore(ParameterInclude transport) throws AxisFault {
+        CertCache.resetCache();
+        TrustStoreHolder.resetInstance();
+        reloadSSL((TransportOutDescription) transport);
+    }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -722,6 +722,18 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
         }
     }
 
+    public void reloadSSL(TransportOutDescription transport) throws AxisFault {
+        log.info("PassThroughHttpSender SSL Config..");
+        ClientConnFactoryBuilder connFactoryBuilder =
+                initConnFactoryBuilder(transport, this.configurationContext).parseSSL();
+        connFactory = connFactoryBuilder.createConnFactory(targetConfiguration.getHttpParams());
+
+        handler.setConnFactory(connFactory);
+        ioEventDispatch.setConnFactory(connFactory);
+
+        log.info("Pass-through " + namePrefix + " Sender updated with SSL Configuration Updates ...");
+    }
+
     /**
      * Set content type headers along with the charactor encoding if content type header is not preserved
      * @param msgContext    message context

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
@@ -26,6 +26,6 @@ public class SslSenderTrustStoreHolderTest {
     public void testGetInstance() {
         SslSenderTrustStoreHolder instance = SslSenderTrustStoreHolder.getInstance();
         SslSenderTrustStoreHolder instance2 = SslSenderTrustStoreHolder.getInstance();
-        Assert.assertEquals(instance, instance2);
+        Assert.assertEquals("Instances should be the same.", instance, instance2);
     }
 }

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.apache.synapse.transport.nhttp.config;
 
 import org.junit.Assert;

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/nhttp/config/SslSenderTrustStoreHolderTest.java
@@ -1,0 +1,14 @@
+package org.apache.synapse.transport.nhttp.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SslSenderTrustStoreHolderTest {
+
+    @Test
+    public void testGetInstance() {
+        SslSenderTrustStoreHolder instance = SslSenderTrustStoreHolder.getInstance();
+        SslSenderTrustStoreHolder instance2 = SslSenderTrustStoreHolder.getInstance();
+        Assert.assertEquals(instance, instance2);
+    }
+}


### PR DESCRIPTION
## Purpose
Certificates specified in the HTTP connector connection need to be loaded into the respective JKS during the local entry deployment. Following this, the PassThroughHttpSSLSender have to be reloaded with the updated SSLContext.