### PR TITLE
Add variable support for call mediator and improve synapse expression

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
@@ -237,8 +237,15 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
             }
         } else if (target.getTargetType() == EnrichMediator.BODY) {
             callMediator.setTargetAvailable(false);
+        } else if (target.getTargetType() == EnrichMediator.VARIABLE) {
+            String variableName = sourceEle.getText();
+            if (variableName != null) {
+                target.setVariable(variableName);
+                callMediator.setTargetAvailable(true);
+            } else {
+                handleException("Variable name is required for VARIABLE type");
+            }
         }
-
     }
 
     public QName getTagQName() {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
@@ -238,10 +238,10 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
         } else if (target.getTargetType() == EnrichMediator.BODY) {
             callMediator.setTargetAvailable(false);
         } else if (target.getTargetType() == EnrichMediator.VARIABLE) {
-            String variableName = sourceEle.getText();
-            if (variableName != null) {
-                target.setVariable(variableName);
+            // check if variable is surrounded by curly braces
+            if (StringUtils.isNotEmpty(sourceEle.getText())) {
                 callMediator.setTargetAvailable(true);
+                target.setVariable(new ValueFactory().createTextValue(sourceEle));
             } else {
                 handleException("Variable name is required for VARIABLE type");
             }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorSerializer.java
@@ -108,6 +108,8 @@ public class CallMediatorSerializer extends AbstractMediatorSerializer {
         targetEle.addAttribute(fac.createOMAttribute("type", nullNS, intTypeToString(target.getTargetType())));
         if (target.getTargetType() == EnrichMediator.PROPERTY) {
             targetEle.setText(target.getProperty());
+        } else if (target.getTargetType() == EnrichMediator.VARIABLE) {
+            targetEle.setText(target.getVariable().getKeyValue());
         }
 
         return targetEle;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ValueFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ValueFactory.java
@@ -111,6 +111,10 @@ public class ValueFactory {
                     textValue = textValue.substring(1, textValue.length() - 1);
                     SynapseJsonPath synJsonPath = createSynJsonPath(textValue);
                     key = new Value(synJsonPath);
+                } else if (textValue.startsWith("{${") && textValue.endsWith("}}")) {
+                    textValue = textValue.substring(1, textValue.length() - 1);
+                    SynapseExpression synapseExpression = createSynapseExpression(textValue);
+                    key = new Value(synapseExpression);
                 } else {
                     SynapseXPath synXpath = createSynXpath(elem, textValue);
                     key = new Value(synXpath);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -44,6 +44,7 @@ import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.EndpointDefinition;
 import org.apache.synapse.endpoints.IndirectEndpoint;
 import org.apache.synapse.mediators.AbstractMediator;
+import org.apache.synapse.mediators.elementary.EnrichMediator;
 import org.apache.synapse.mediators.elementary.Source;
 import org.apache.synapse.mediators.elementary.Target;
 import org.apache.synapse.message.senders.blocking.BlockingMsgSender;
@@ -167,8 +168,11 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
             sourceForInboundPayload.setClone(true);
             CallMediatorEnrichUtil
                     .doEnrich(synInCtx, sourceForInboundPayload, targetForOriginalPayload, originalMessageType);
-            CallMediatorEnrichUtil
-                    .doEnrich(synInCtx, sourceForOutboundPayload, targetForOutboundPayload, getSourceMessageType());
+            if (!(EnrichMediator.BODY == sourceForOutboundPayload.getSourceType() &&
+                EnrichMediator.BODY == targetForOutboundPayload.getTargetType())) {
+                CallMediatorEnrichUtil
+                        .doEnrich(synInCtx, sourceForOutboundPayload, targetForOutboundPayload, getSourceMessageType());
+            }
             if (!sourceMessageType.equalsIgnoreCase(originalMessageType)) {
                 CallMediatorEnrichUtil.setContentType(synInCtx, sourceMessageType, sourceMessageType);
                 if (originalMessageType.equalsIgnoreCase(JSON_TYPE)) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/EIPUtils.java
@@ -434,4 +434,8 @@ public class EIPUtils {
         });
     }
 
+    public static JsonObject convertMapToJsonObj(Object map) {
+        return new GsonBuilder().create().toJsonTree(map).getAsJsonObject();
+    }
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/EnrichMediator.java
@@ -85,6 +85,8 @@ public class EnrichMediator extends AbstractMediator {
 
     public static final int KEY = 5;
 
+    public static final int VARIABLE = 6;
+
     private Source source = null;
 
     private Target target = null;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
@@ -50,6 +50,7 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.eip.EIPUtils;
 import org.apache.synapse.util.CallMediatorEnrichUtil;
 import org.apache.synapse.util.InlineExpressionUtil;
@@ -91,7 +92,7 @@ public class Target {
 
     private String property = null;
 
-    private String variable = null;
+    private Value variable = null;
 
     private int targetType = EnrichMediator.CUSTOM;
 
@@ -474,7 +475,7 @@ public class Target {
                     JsonObject headers = EIPUtils.convertMapToJsonObj(transportHeaders);
                     result.put("headers", headers);
                     result.put("attributes", CallMediatorEnrichUtil.populateTransportAttributes(synCtx));
-                    synCtx.setVariable(variable, result);
+                    synCtx.setVariable(variable.evaluateValue(synCtx), result);
                 }
                 break;
             default: {
@@ -701,11 +702,11 @@ public class Target {
         this.property = property;
     }
 
-    public void setVariable(String variable) {
-        this.variable    = variable;
+    public void setVariable(Value variable) {
+        this.variable = variable;
     }
 
-    public String getVariable() {
+    public Value getVariable() {
         return variable;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/util/CallMediatorEnrichUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CallMediatorEnrichUtil.java
@@ -301,6 +301,12 @@ public class CallMediatorEnrichUtil {
         return new MediatorLog(log, false, synCtx);
     }
 
+    /**
+     * Populates the transport attributes of the message context to a JSON object.
+     *
+     * @param synCtx The message context.
+     * @return The JSON object containing the transport attributes.
+     */
     public static JsonObject populateTransportAttributes(MessageContext synCtx) {
         JsonObject attributes = new JsonObject();
         Object httpStatusCodeObj = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(

--- a/modules/core/src/main/java/org/apache/synapse/util/CallMediatorEnrichUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/CallMediatorEnrichUtil.java
@@ -37,6 +37,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.protocol.HTTP;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -58,6 +59,7 @@ public class CallMediatorEnrichUtil {
     public static final String ENVELOPE = "envelope";
     public static final String BODY = "body";
     public static final String INLINE = "inline";
+    public static final String VARIABLE = "variable";
 
     public static final String JSON_TYPE = "application/json";
     public static final String TEXT_TYPE = "text/plain";
@@ -75,6 +77,8 @@ public class CallMediatorEnrichUtil {
             return EnrichMediator.CUSTOM;
         } else if (type.equals(INLINE)) {
             return EnrichMediator.INLINE;
+        } else if (type.equals(VARIABLE)) {
+            return EnrichMediator.VARIABLE;
         }
         return -1;
     }
@@ -295,6 +299,20 @@ public class CallMediatorEnrichUtil {
 
     public static SynapseLog getLog(MessageContext synCtx) {
         return new MediatorLog(log, false, synCtx);
+    }
+
+    public static JsonObject populateTransportAttributes(MessageContext synCtx) {
+        JsonObject attributes = new JsonObject();
+        Object httpStatusCodeObj = ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(
+                SynapseConstants.HTTP_SC);
+        if (httpStatusCodeObj != null) {
+            if (httpStatusCodeObj instanceof String) {
+                attributes.addProperty("statusCode", (String) httpStatusCodeObj);
+            } else if (httpStatusCodeObj instanceof Integer) {
+                attributes.addProperty("statusCode", (Integer) httpStatusCodeObj);
+            }
+        }
+        return attributes;
     }
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/ast/PayloadAccessNode.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/ast/PayloadAccessNode.java
@@ -129,7 +129,11 @@ public class PayloadAccessNode implements ExpressionNode {
                 if (StringUtils.isEmpty(expressionToEvaluate)) {
                     result = variable;
                 } else if (variable instanceof Map) {
-                    String[] keyAndExpression = ExpressionUtils.extractVariableAndJsonPath("var." + expressionToEvaluate);
+                    if (StringUtils.isNotEmpty(expressionToEvaluate)) {
+                        expressionToEvaluate = expressionToEvaluate.startsWith(".") ? "var" + expressionToEvaluate
+                                : "var." + expressionToEvaluate;
+                    }
+                    String[] keyAndExpression = ExpressionUtils.extractVariableAndJsonPath(expressionToEvaluate);
                     String key = keyAndExpression[0];
                     String expression = keyAndExpression[1];
                     if (StringUtils.isNotEmpty(expression)) {

--- a/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/ast/PayloadAccessNode.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/ast/PayloadAccessNode.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Represents a node in the AST that accesses a value in the payload or variable.
@@ -126,6 +128,29 @@ public class PayloadAccessNode implements ExpressionNode {
                 // if no expression just return variable
                 if (StringUtils.isEmpty(expressionToEvaluate)) {
                     result = variable;
+                } else if (variable instanceof Map) {
+                    String[] keyAndExpression = ExpressionUtils.extractVariableAndJsonPath("var." + expressionToEvaluate);
+                    String key = keyAndExpression[0];
+                    String expression = keyAndExpression[1];
+                    if (StringUtils.isNotEmpty(expression)) {
+                        expression = expression.startsWith(".") ? "$" + expression : "$." + expression;
+                    }
+                    Object keyValue = ((Map) variable).get(key);
+                    if (keyValue == null) {
+                        throw new EvaluationException("Could not find key: " + key + " in the variable: " + variable);
+                    } else if (StringUtils.isEmpty(expression)) {
+                        result = keyValue;
+                    } else if (keyValue instanceof JsonElement) {
+                        try {
+                            result = JsonPath.parse(keyValue.toString()).read(expression);
+                        } catch (PathNotFoundException e) {
+                            // convert jsonPath error to native one
+                            throw new EvaluationException(e.getMessage());
+                        }
+                    } else {
+                        throw new EvaluationException("Could not evaluate JSONPath expression: " + expression
+                                + " on non-JSON object");
+                    }
                 } else {
                     expressionToEvaluate = expressionToEvaluate.startsWith(".") ? "$" + expressionToEvaluate
                             : "$." + expressionToEvaluate;

--- a/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/constants/ExpressionConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/constants/ExpressionConstants.java
@@ -78,4 +78,6 @@ public class ExpressionConstants {
 
     public static final String UNKNOWN = "unknown";
     public static final String VAULT_LOOKUP = "wso2:vault-lookup('";
+    public static final String HEADERS = "headers";
+    public static final String ATTRIBUTES = "attributes";
 }

--- a/modules/core/src/test/java/org/apache/synapse/util/synapse/expression/PayloadAndVariableAccessTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/util/synapse/expression/PayloadAndVariableAccessTest.java
@@ -147,5 +147,11 @@ public class PayloadAndVariableAccessTest {
                 "var.random", 0, 1));
         Assert.assertEquals("", TestUtils.evaluateExpressionWithPayloadAndVariables(
                 "var.num1[0]", 0, 1));
+        Assert.assertEquals("201", TestUtils.evaluateExpressionWithPayloadAndVariables(
+                "var.fileRead_1.['attributes'].statusCode", 0, 3));
+        Assert.assertEquals("101", TestUtils.evaluateExpressionWithPayloadAndVariables(
+                "var[\"fileRead_1\"][\"headers\"]['Content-Length']", 0, 3));
+        Assert.assertEquals("[\"Moby Dick\",\"To Kill a Mockingbird\"]", TestUtils.evaluateExpressionWithPayloadAndVariables(
+                "var.fileRead_1['payload'][\"store\"][\"book\"][1,3].title", 2, 3));
     }
 }

--- a/modules/core/src/test/java/org/apache/synapse/util/synapse/expression/TestUtils.java
+++ b/modules/core/src/test/java/org/apache/synapse/util/synapse/expression/TestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.synapse.util.synapse.expression;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -97,11 +98,17 @@ public class TestUtils {
             "  \"selectedCategory\": \"biography\"\n" +
             "}\n";
 
+    private static final JsonObject responseHeaders;
+
+    private static final JsonObject responseAttributes;
+
     private static final String PAYLOAD3 = "[\"When\",\"my\",\"time\",\"comes\",\"Forget\",\"the\",\"wrong\",\"that\"" +
             ",\"I've\",\"done\"]";
     private static final Map<String, Object> variableMap1;
 
     private static final Map<String, Object> variableMap2;
+
+    private static final Map<String, Object> variableMap3;
 
     static {
         variableMap1 = new HashMap<>();
@@ -119,6 +126,18 @@ public class TestUtils {
         variableMap2.put("json1", PAYLOAD1);
         variableMap2.put("json2", PAYLOAD2);
         variableMap2.put("json3", "[1,2,3,\"abc\"]");
+        variableMap3 = new HashMap<>();
+        responseHeaders = new JsonObject();
+        responseHeaders.addProperty("Content-Type", "application/json");
+        responseHeaders.addProperty("Content-Length", "101");
+        responseAttributes = new JsonObject();
+        responseAttributes.addProperty("statusCode", 201);
+        Map<String, Object> result = new HashMap<>();
+        result.put("headers", responseHeaders);
+        result.put("attributes", responseAttributes);
+        result.put("payload", JsonParser.parseString(PAYLOAD2));
+        variableMap3.put("fileRead_1", result);
+
         try {
             synCtx = org.apache.synapse.mediators.TestUtils.getAxis2MessageContext("<test/>", null);
         } catch (Exception e) {
@@ -149,6 +168,10 @@ public class TestUtils {
                 }
             } else if (variableMapId == 2) {
                 for (Map.Entry<String, Object> entry : variableMap2.entrySet()) {
+                    synCtx.setVariable(entry.getKey(), entry.getValue());
+                }
+            } else if (variableMapId == 3) {
+                for (Map.Entry<String, Object> entry : variableMap3.entrySet()) {
                     synCtx.setVariable(entry.getKey(), entry.getValue());
                 }
             }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR adds variable support to Call mediator target so that the response elements (payload, headers and attributes) can be stored in a variable. 

```
          <call>
            <endpoint>
               <http method="POST" uri-template="https://run.mocky.io/v3/fc50337e-e54d-45a7-8bc8-f5c1b53b2519"/>
            </endpoint>
            <target type="variable">{${params.funcParams.targetVariable}}</target>
         </call>
```

The Synapse expression has been improved to handle Map type variables so that the above stored response elements can be accessed.

Eg:

```
         <log level="simple">
            <property name="messagenew" expression="${var.resultMocky['payload']}"/>
            <property name="statusCode" expression="${var.resultMocky['attributes'].statusCode}"></property>
            <property name="content-length" expression="${var.resultMocky['headers']['Content-Length']}"></property>
         </log>
```