### PR TITLE
[APIM] Bring the OPTIONS Resource to the 0th Index of the acceptableResourcesList

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/api/ApiUtils.java
@@ -43,7 +43,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -184,13 +186,17 @@ public class ApiUtils {
     }
 
     public static Set<Resource> getAcceptableResources(Map<String, Resource> resources, MessageContext synCtx) {
-        Set<Resource> acceptableResources = new LinkedHashSet<Resource>();
+        List<Resource> acceptableResourcesList = new LinkedList<>();
         for (Resource r : resources.values()) {
             if (isBound(r, synCtx) && r.canProcess(synCtx)) {
-                acceptableResources.add(r);
+                if (Arrays.asList(r.getMethods()).contains(RESTConstants.METHOD_OPTIONS)) {
+                    acceptableResourcesList.add(0, r);
+                } else {
+                    acceptableResourcesList.add(r);
+                }
             }
         }
-        return acceptableResources;
+        return new LinkedHashSet<Resource>(acceptableResourcesList);
     }
 
     /**


### PR DESCRIPTION
### Description
Resources having the OPTIONS method bring to the 0th index of the `acceptableResourcesList` to be selected in the `dispatcher.findResource` logic when routing the OPTIONS traffic to backend.
Related Issue: https://github.com/wso2/api-manager/issues/2226

- Resolves https://github.com/wso2/api-manager/issues/3377