### PR TITLE
Escape special characters when XML is considered literal

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/RegexTemplateProcessor.java
@@ -108,7 +108,7 @@ public class RegexTemplateProcessor extends TemplateProcessor {
                         } else if (JSON_TYPE.equals(mediaType)) {
                             if (isXML(replacementValue)) {
                                 // consider the replacement value as a literal XML
-                                replacementValue = Matcher.quoteReplacement(replacementValue);
+                                replacementValue = escapeSpecialChars(Matcher.quoteReplacement(replacementValue));
                             } else {
                                 replacementValue = escapeSpecialCharactersOfJson(replacementValue);
                             }


### PR DESCRIPTION
## Purpose

Escape special characters when XML is considered literal