### PR TITLE
Fix erroneous clearing of active aggregate map in Aggregate mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/eip/aggregator/AggregateMediator.java
@@ -830,7 +830,7 @@ public class AggregateMediator extends AbstractMediator implements ManagedLifecy
     
     private void handleException(Aggregate aggregate, String msg, Exception exception, MessageContext msgContext) {
         aggregate.clear();
-        activeAggregates.clear();
+        activeAggregates.remove(aggregate.getCorrelation());
         if (exception != null) {
             super.handleException(msg, exception, msgContext);
         } else {


### PR DESCRIPTION
## Purpose
Fix erroneous clearing of active aggregate map in Aggregate mediator

Fixes: https://github.com/wso2/product-micro-integrator/issues/3797