### PR TITLE
Revert "Handle new resource file key values. "

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfigUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfigUtils.java
@@ -93,8 +93,6 @@ public class SynapseConfigUtils {
 
     private static final Log log = LogFactory.getLog(SynapseConfigUtils.class);
 
-    public static final String RESOURCES_IDENTIFIER = "resources:";
-    public static final String CONVERTED_RESOURCES_IDENTIFIER = "gov:mi-resources/";
 
     private static ConcurrentHashMap<String, SynapseConfiguration> lastRegisteredSynapseConfigurationMap =
                                                                  new ConcurrentHashMap<String, SynapseConfiguration>();
@@ -904,14 +902,6 @@ public class SynapseConfigUtils {
 
     public static void addSynapseConfiguration(String tenantDomain , SynapseConfiguration synapseConfiguration){
         lastRegisteredSynapseConfigurationMap.put(tenantDomain,synapseConfiguration);
-    }
-
-    public static String transformFileKey(String fileKey) {
-
-        if (fileKey.startsWith(RESOURCES_IDENTIFIER)) {
-            return CONVERTED_RESOURCES_IDENTIFIER + fileKey.substring(RESOURCES_IDENTIFIER.length());
-        }
-        return fileKey;
     }
 }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/SynapseConfiguration.java
@@ -1018,7 +1018,6 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
      * @return its value
      */
     public Entry getEntryDefinition(String key) {
-        String transformedKey = SynapseConfigUtils.transformFileKey(key);
         Object o = localRegistry.get(key);
         if (o == null || o instanceof Entry) {
             if (o == null) {
@@ -1026,7 +1025,7 @@ public class SynapseConfiguration implements ManagedLifecycle, SynapseArtifact {
                 synchronized (this) {
                     o = localRegistry.get(key);
                     if (o == null) {
-                        Entry entry = new Entry(transformedKey);
+                        Entry entry = new Entry(key);
                         entry.setType(Entry.REMOTE_ENTRY);
                         addEntry(key, entry);
                         return entry;

--- a/modules/core/src/test/java/org/apache/synapse/config/SynapseConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/SynapseConfigurationTest.java
@@ -23,8 +23,6 @@ import org.apache.synapse.api.API;
 
 import junit.framework.TestCase;
 import org.apache.synapse.endpoints.HTTPEndpoint;
-import org.apache.synapse.registry.url.SimpleURLRegistry;
-import org.apache.synapse.registry.url.SimpleURLRegistryTest;
 
 public class SynapseConfigurationTest extends TestCase {
 
@@ -121,13 +119,5 @@ public class SynapseConfigurationTest extends TestCase {
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	public void testGetEntryDefinition() throws Exception {
-
-		String key = "resources:xslt/sample.xslt";
-		SynapseConfiguration config = new SynapseConfiguration();
-		Entry entry = config.getEntryDefinition(key);
-		assertEquals("Key of entry should be transformed.", "gov:mi-resources/xslt/sample.xslt", entry.getKey());
 	}
 }


### PR DESCRIPTION
This change applies only to some scenarios involving resource file access, leaving out some cases. Since all scenarios can be handled with an update to `MicroIntegratorRegistry`, the changes introduced in wso2/wso2-synapse#2242 have been reverted.

Updates needed for `MicroIntegratorRegistry` are introduced with https://github.com/wso2/product-micro-integrator/pull/3846.

