### PR TITLE
Add option to export variables in tracing data

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/OpenEventCollector.java
@@ -62,7 +62,7 @@ public class OpenEventCollector extends RuntimeStatisticCollector {
 		}
 
 		boolean isCollectingTracing = false;
-		if (isCollectingProperties() || isCollectingPayloads()) {
+		if (isCollectingProperties() || isCollectingPayloads() || isCollectingVariables()) {
 			isCollectingTracing = (aspectConfiguration != null && aspectConfiguration.isTracingEnabled());
 		}
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/collectors/RuntimeStatisticCollector.java
@@ -60,6 +60,11 @@ public abstract class RuntimeStatisticCollector {
     private static boolean isCollectingProperties;
 
     /**
+     * Is message context variable collection enabled in synapse.properties file.
+     */
+    private static boolean isCollectingVariables;
+
+    /**
      * Is collecting statistics of all artifacts
      */
     private static boolean isCollectingAllStatistics;
@@ -102,6 +107,13 @@ public abstract class RuntimeStatisticCollector {
                 log.debug("Property collecting is not enabled in \'synapse.properties\' file.");
             }
 
+            isCollectingVariables =
+                    SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.COLLECT_MESSAGE_VARIABLES, false);
+
+            if (!isCollectingVariables && log.isDebugEnabled()) {
+                log.debug("Variable collecting is not enabled in \'synapse.properties\' file.");
+            }
+
             isCollectingAllStatistics =
                 SynapsePropertiesLoader.getBooleanProperty(StatisticsConstants.COLLECT_ALL_STATISTICS, false);
 
@@ -116,7 +128,7 @@ public abstract class RuntimeStatisticCollector {
                     log.debug("OpenTelemetry based tracing is enabled");
                 }
                 OpenTelemetryManagerHolder.loadTracerConfigurations();
-                OpenTelemetryManagerHolder.setCollectingFlags(isCollectingPayloads, isCollectingProperties);
+                OpenTelemetryManagerHolder.setCollectingFlags(isCollectingPayloads, isCollectingProperties, isCollectingVariables);
             }
         } else {
             if (log.isDebugEnabled()) {
@@ -200,6 +212,16 @@ public abstract class RuntimeStatisticCollector {
      */
     public static boolean isCollectingProperties() {
         return isStatisticsEnabled && isCollectingProperties;
+    }
+
+    /**
+     * Return whether collecting message variables is enabled.
+     *
+     * @return true if need to collect message-variables.
+     */
+    public static boolean isCollectingVariables() {
+
+        return isStatisticsEnabled && isCollectingVariables;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticDataUnit.java
@@ -102,6 +102,11 @@ public class StatisticDataUnit extends BasicStatisticDataUnit {
 	private Map<String, Object> contextPropertyMap;
 
 	/**
+	 * Message context variable map.
+	 */
+	private Map<String, Object> contextVariableMap;
+
+	/**
 	 * Transport property map.
 	 */
 	private Map<String, Object> transportPropertyMap;
@@ -189,6 +194,14 @@ public class StatisticDataUnit extends BasicStatisticDataUnit {
 
 	public void setContextPropertyMap(Map<String, Object> contextPropertyMap) {
 		this.contextPropertyMap = contextPropertyMap;
+	}
+
+	public void setContextVariableMap(Map<String, Object> contextVariableMap) {
+		this.contextVariableMap = contextVariableMap;
+	}
+
+	public Map<String, Object> getContextVariableMap() {
+		return contextVariableMap;
 	}
 
 	public Map<String, Object> getTransportPropertyMap() {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/data/raw/StatisticsLog.java
@@ -126,6 +126,11 @@ public class StatisticsLog {
 	private Map<String, Object> contextPropertyMap;
 
 	/**
+	 * Synapse Message context variables for the component.
+	 */
+	private Map<String, Object> contextVariableMap;
+
+	/**
 	 * Transport properties for the component.
 	 */
 	private Map<String, Object> transportPropertyMap;
@@ -181,6 +186,7 @@ public class StatisticsLog {
 		this.messageFlowId = statisticDataUnit.getStatisticId();
 		this.beforePayload = statisticDataUnit.getPayload();
 		this.contextPropertyMap = statisticDataUnit.getContextPropertyMap();
+		this.contextVariableMap = statisticDataUnit.getContextVariableMap();
 		this.transportPropertyMap = statisticDataUnit.getTransportPropertyMap();
 		this.componentType = statisticDataUnit.getComponentType();
 		this.hashCode = statisticDataUnit.getHashCode();
@@ -277,6 +283,10 @@ public class StatisticsLog {
 
 	public Map<String, Object> getContextPropertyMap() {
 		return contextPropertyMap;
+	}
+
+	public Map<String, Object> getContextVariableMap() {
+		return contextVariableMap;
 	}
 
 	public void setAfterPayload(String afterPayload) {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/publishing/PublishingEvent.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/publishing/PublishingEvent.java
@@ -46,6 +46,7 @@ public class PublishingEvent {
 
 	private Map contextPropertyMap;
 	private Map transportPropertyMap;
+	private Map contextVariableMap;
 
 	private Integer[] children;
 
@@ -72,6 +73,7 @@ public class PublishingEvent {
 
 		this.contextPropertyMap = extractProperties(statisticsLog.getContextPropertyMap());
 		this.transportPropertyMap = extractProperties(statisticsLog.getTransportPropertyMap());
+		this.contextVariableMap = extractProperties(statisticsLog.getContextVariableMap());
 
 		if (statisticsLog.getChildren().size() > 0) {
 			this.children = new Integer[statisticsLog.getChildren().size()];
@@ -288,6 +290,12 @@ public class PublishingEvent {
 			objectList.add(null);
 		} else {
 			objectList.add(this.transportPropertyMap.toString());
+		}
+
+		if (this.contextVariableMap == null) {
+			objectList.add(null);
+		} else {
+			objectList.add(this.contextVariableMap.toString());
 		}
 
 		objectList.add(Arrays.toString(this.children));

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/OpenTelemetryManagerHolder.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/OpenTelemetryManagerHolder.java
@@ -33,6 +33,7 @@ public class OpenTelemetryManagerHolder {
     private static Log logger = LogFactory.getLog(OpenTelemetryManagerHolder.class);
     private static boolean isCollectingPayloads;
     private static boolean isCollectingProperties;
+    private static boolean isCollectingVariables;
     private static OpenTelemetryManager openTelemetryManager;
 
     /**
@@ -60,10 +61,12 @@ public class OpenTelemetryManagerHolder {
      *
      * @param collectPayloads   Whether to collect payloads
      * @param collectProperties Whether to collect properties
+     * @param collectVariables  Whether to collect variables
      */
-    public static void setCollectingFlags(boolean collectPayloads, boolean collectProperties) {
+    public static void setCollectingFlags(boolean collectPayloads, boolean collectProperties, boolean collectVariables) {
         isCollectingPayloads = collectPayloads;
         isCollectingProperties = collectProperties;
+        isCollectingVariables = collectVariables;
     }
 
     public static boolean isCollectingPayloads() {
@@ -72,6 +75,10 @@ public class OpenTelemetryManagerHolder {
 
     public static boolean isCollectingProperties() {
         return isCollectingProperties;
+    }
+
+    public static boolean isCollectingVariables() {
+        return isCollectingVariables;
     }
 
     public static OpenTelemetryManager getOpenTelemetryManager() {

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -68,6 +68,8 @@ public class TelemetryConstants {
     public static final String AFTER_PAYLOAD_ATTRIBUTE_KEY = "afterPayload";
     public static final String BEFORE_CONTEXT_PROPERTY_MAP_ATTRIBUTE_KEY = "beforeContextPropertyMap";
     public static final String AFTER_CONTEXT_PROPERTY_MAP_ATTRIBUTE_KEY = "afterContextPropertyMap";
+    public static final String BEFORE_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY = "beforeContextVariableMap";
+    public static final String AFTER_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY = "afterContextVariableMap";
     public static final String PROPERTY_MEDIATOR_VALUE_ATTRIBUTE_KEY = "propertyMediatorValue";
     public static final String COMPONENT_NAME_ATTRIBUTE_KEY = "componentName";
     public static final String COMPONENT_TYPE_ATTRIBUTE_KEY = "componentType";

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
@@ -46,7 +46,8 @@ public class SpanTagger {
     public static void setSpanTags(SpanWrapper spanWrapper, MessageContext synCtx) {
         StatisticsLog openStatisticsLog = new StatisticsLog(spanWrapper.getStatisticDataUnit());
         Span span = spanWrapper.getSpan();
-        if (OpenTelemetryManagerHolder.isCollectingPayloads() || OpenTelemetryManagerHolder.isCollectingProperties()) {
+        if (OpenTelemetryManagerHolder.isCollectingPayloads() || OpenTelemetryManagerHolder.isCollectingProperties()
+                || OpenTelemetryManagerHolder.isCollectingVariables()) {
             if (OpenTelemetryManagerHolder.isCollectingPayloads()) {
                 if(openStatisticsLog.getBeforePayload() != null) {
                     span.setAttribute(TelemetryConstants.BEFORE_PAYLOAD_ATTRIBUTE_KEY,
@@ -83,6 +84,22 @@ public class SpanTagger {
                         spanWrapper.getCloseEventStatisticDataUnit().getPropertyValue() != null) {
                     span.setAttribute(TelemetryConstants.PROPERTY_MEDIATOR_VALUE_ATTRIBUTE_KEY,
                             spanWrapper.getCloseEventStatisticDataUnit().getPropertyValue());
+                }
+            }
+
+            if (OpenTelemetryManagerHolder.isCollectingVariables()) {
+                if (spanWrapper.getStatisticDataUnit().getContextVariableMap() != null) {
+                    span.setAttribute(TelemetryConstants.BEFORE_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                            spanWrapper.getStatisticDataUnit().getContextVariableMap().toString());
+                }
+                if (spanWrapper.getCloseEventStatisticDataUnit() != null) {
+                    if (spanWrapper.getCloseEventStatisticDataUnit().getContextVariableMap() != null) {
+                        span.setAttribute(TelemetryConstants.AFTER_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                                spanWrapper.getCloseEventStatisticDataUnit().getContextVariableMap().toString());
+                    }
+                } else if (openStatisticsLog.getContextVariableMap() != null) {
+                    span.setAttribute(TelemetryConstants.AFTER_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                            openStatisticsLog.getContextVariableMap().toString());
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticDataCollectionHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticDataCollectionHelper.java
@@ -134,6 +134,10 @@ public class StatisticDataCollectionHelper {
 				statisticDataUnit.setTransportPropertyMap(
 						TracingDataCollectionHelper.extractTransportProperties(messageContext));
 			}
+			if (RuntimeStatisticCollector.isCollectingVariables()) {
+				statisticDataUnit
+						.setContextVariableMap(TracingDataCollectionHelper.extractContextVariables(messageContext));
+			}
 		}
 	}
 

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/StatisticsConstants.java
@@ -64,6 +64,11 @@ public class StatisticsConstants {
 	public final static String COLLECT_MESSAGE_PROPERTIES = "mediation.flow.statistics.tracer.collect.properties";
 
 	/**
+	 * Enable collecting message context variables.
+	 */
+	public final static String COLLECT_MESSAGE_VARIABLES = "mediation.flow.statistics.tracer.collect.variables";
+
+	/**
 	 * Enable statistics collecting for all artifacts
 	 */
 	public final static String COLLECT_ALL_STATISTICS = "mediation.flow.statistics.collect.all";

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/TracingDataCollectionHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/util/TracingDataCollectionHelper.java
@@ -90,6 +90,24 @@ public class TracingDataCollectionHelper {
 	}
 
 	/**
+	 * Extract context variables from the synapse message context.
+	 *
+	 * @param synCtx synapse message context
+	 * @return context variable map
+	 */
+	public static Map<String, Object> extractContextVariables(MessageContext synCtx) {
+
+		Set<String> variableSet = synCtx.getVariableKeySet();
+		Map<String, Object> variableMap = new TreeMap<>();
+
+		for (String variable : variableSet) {
+			Object variableValue = synCtx.getVariable(variable);
+			variableMap.put(variable, variableValue);
+		}
+		return variableMap;
+	}
+
+	/**
 	 * Extract transport headers from the synapse message context.
 	 *
 	 * @param synCtx synapse message context


### PR DESCRIPTION
## Purpose
Add option to export variables in tracing data

TOML config

```toml
[mediation]
stat.tracer.collect_mediation_variables= true
```

## Related Issue
https://github.com/wso2/product-micro-integrator/issues/3625