### PR TITLE
Improve invoke mediator to support connector response model

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -725,6 +725,9 @@ public final class SynapseConstants {
     public static final String OAUTH_TAG = "oauth";
     public static final String SCATTER_MESSAGES = "SCATTER_MESSAGES";
     public static final String CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER = "CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER";
+    public static final String RESPONSE_VARIABLE = "responseVariable";
+    public static final String OVERWRITE_BODY = "overwriteBody";
+    public static final String ORIGINAL_PAYLOAD = "ORIGINAL_PAYLOAD";
 
     public static final String DEFAULT_ERROR_TYPE = "ANY";
 }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/CallMediatorFactory.java
@@ -30,7 +30,7 @@ import org.apache.synapse.mediators.builtin.CallMediator;
 import org.apache.synapse.mediators.elementary.EnrichMediator;
 import org.apache.synapse.mediators.elementary.Source;
 import org.apache.synapse.mediators.elementary.Target;
-import org.apache.synapse.util.CallMediatorEnrichUtil;
+import org.apache.synapse.util.MeidatorEnrichUtil;
 import org.jaxen.JaxenException;
 
 import javax.xml.namespace.QName;
@@ -110,7 +110,7 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
         OMElement targetEle = elem.getFirstChildWithName(TARGET_Q);
         if (targetEle != null) {
             if (sourceEle == null) {
-                Source source = CallMediatorEnrichUtil.createSourceWithBody();
+                Source source = MeidatorEnrichUtil.createSourceWithBody();
                 callMediator.setSourceAvailable(true);
                 callMediator.setSourceForOutboundPayload(source);
             }
@@ -168,7 +168,7 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
     private void populateSource(CallMediator callMediator, Source source, OMElement sourceEle) {
         OMAttribute typeAttr = sourceEle.getAttribute(ATT_TYPE);
         if (typeAttr != null && typeAttr.getAttributeValue() != null) {
-            source.setSourceType(CallMediatorEnrichUtil.convertTypeToInt(typeAttr.getAttributeValue()));
+            source.setSourceType(MeidatorEnrichUtil.convertTypeToInt(typeAttr.getAttributeValue()));
         }
 
         OMAttribute contentTypeAtt = sourceEle.getAttribute(CONTENT_TYPE);
@@ -220,7 +220,7 @@ public class CallMediatorFactory extends AbstractMediatorFactory {
         OMAttribute typeAttr = sourceEle.getAttribute(ATT_TYPE);
         target.setAction("replace");
         if (typeAttr != null && typeAttr.getAttributeValue() != null) {
-            int type = CallMediatorEnrichUtil.convertTypeToInt(typeAttr.getAttributeValue());
+            int type = MeidatorEnrichUtil.convertTypeToInt(typeAttr.getAttributeValue());
             if (type >= 0) {
                 target.setTargetType(type);
             } else {

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -69,7 +69,7 @@ import org.apache.synapse.task.SynapseTaskManager;
 import org.apache.synapse.transport.util.MessageHandlerProvider;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.unittest.UnitTestingExecutor;
-import org.apache.synapse.util.CallMediatorEnrichUtil;
+import org.apache.synapse.util.MeidatorEnrichUtil;
 import org.apache.synapse.util.concurrent.InboundThreadPool;
 import org.apache.synapse.util.concurrent.SynapseThreadPool;
 import org.apache.synapse.util.logging.LoggingUtils;
@@ -851,26 +851,26 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
         Target targetForResponsePayload;
 
         if (isTargetAvailable) {
-            CallMediatorEnrichUtil.buildMessage(response);
+            MeidatorEnrichUtil.buildMessage(response);
         }
         if (isTargetAvailable && isSourceAvailable) {
-            sourceForResponsePayload = CallMediatorEnrichUtil.createSourceWithBody();
-            sourceForOriginalPayload = CallMediatorEnrichUtil.createSourceWithProperty(INTERMEDIATE_ORIGINAL_BODY);
-            targetForResponsePayload = CallMediatorEnrichUtil.createTargetWithBody();
-            CallMediatorEnrichUtil
+            sourceForResponsePayload = MeidatorEnrichUtil.createSourceWithBody();
+            sourceForOriginalPayload = MeidatorEnrichUtil.createSourceWithProperty(INTERMEDIATE_ORIGINAL_BODY);
+            targetForResponsePayload = MeidatorEnrichUtil.createTargetWithBody();
+            MeidatorEnrichUtil
                     .doEnrich(response, sourceForResponsePayload, targetForInboundPayload, sourceMessageType);
-            CallMediatorEnrichUtil
+            MeidatorEnrichUtil
                     .doEnrich(response, sourceForOriginalPayload, targetForResponsePayload, originalMessageType);
-            CallMediatorEnrichUtil.preservetransportHeaders(response, originalTransportHeaders);
+            MeidatorEnrichUtil.preservetransportHeaders(response, originalTransportHeaders);
             if (!sourceMessageType.equalsIgnoreCase(originalMessageType)) {
-                CallMediatorEnrichUtil.setContentType(response, originalMessageType, originalContentType);
+                MeidatorEnrichUtil.setContentType(response, originalMessageType, originalContentType);
                 if (sourceMessageType.equalsIgnoreCase(JSON_TYPE)) {
                     JsonUtil.removeJsonStream(((Axis2MessageContext) response).getAxis2MessageContext());
                 }
             }
         } else if (isTargetAvailable) {
-            sourceForResponsePayload = CallMediatorEnrichUtil.createSourceWithBody();
-            CallMediatorEnrichUtil
+            sourceForResponsePayload = MeidatorEnrichUtil.createSourceWithBody();
+            MeidatorEnrichUtil
                     .doEnrich(response, sourceForResponsePayload, targetForInboundPayload, sourceMessageType);
         }
         response.setProperty(IS_SOURCE_AVAILABLE, false);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -48,7 +48,7 @@ import org.apache.synapse.mediators.elementary.EnrichMediator;
 import org.apache.synapse.mediators.elementary.Source;
 import org.apache.synapse.mediators.elementary.Target;
 import org.apache.synapse.message.senders.blocking.BlockingMsgSender;
-import org.apache.synapse.util.CallMediatorEnrichUtil;
+import org.apache.synapse.util.MeidatorEnrichUtil;
 import org.apache.synapse.util.MessageHelper;
 
 import java.io.IOException;
@@ -158,33 +158,33 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
             sourceMessageType = originalMessageType;
         }
         if (isSourceAvailable) {
-            CallMediatorEnrichUtil.buildMessage(synInCtx);
+            MeidatorEnrichUtil.buildMessage(synInCtx);
         }
         if (isSourceAvailable && isTargetAvailable) {
-            Source sourceForInboundPayload = CallMediatorEnrichUtil.createSourceWithBody();
+            Source sourceForInboundPayload = MeidatorEnrichUtil.createSourceWithBody();
             Target targetForOriginalPayload =
-                    CallMediatorEnrichUtil.createTargetWithProperty(INTERMEDIATE_ORIGINAL_BODY);
-            Target targetForOutboundPayload = CallMediatorEnrichUtil.createTargetWithBody();
+                    MeidatorEnrichUtil.createTargetWithProperty(INTERMEDIATE_ORIGINAL_BODY);
+            Target targetForOutboundPayload = MeidatorEnrichUtil.createTargetWithBody();
             sourceForInboundPayload.setClone(true);
-            CallMediatorEnrichUtil
+            MeidatorEnrichUtil
                     .doEnrich(synInCtx, sourceForInboundPayload, targetForOriginalPayload, originalMessageType);
             if (!(EnrichMediator.BODY == sourceForOutboundPayload.getSourceType() &&
                 EnrichMediator.BODY == targetForOutboundPayload.getTargetType())) {
-                CallMediatorEnrichUtil
+                MeidatorEnrichUtil
                         .doEnrich(synInCtx, sourceForOutboundPayload, targetForOutboundPayload, getSourceMessageType());
             }
             if (!sourceMessageType.equalsIgnoreCase(originalMessageType)) {
-                CallMediatorEnrichUtil.setContentType(synInCtx, sourceMessageType, sourceMessageType);
+                MeidatorEnrichUtil.setContentType(synInCtx, sourceMessageType, sourceMessageType);
                 if (originalMessageType.equalsIgnoreCase(JSON_TYPE)) {
                     JsonUtil.removeJsonStream(axis2MessageContext);
                 }
             }
         } else if (isSourceAvailable) {
-            Target targetForOutboundPayload = CallMediatorEnrichUtil.createTargetWithBody();
-            CallMediatorEnrichUtil
+            Target targetForOutboundPayload = MeidatorEnrichUtil.createTargetWithBody();
+            MeidatorEnrichUtil
                     .doEnrich(synInCtx, sourceForOutboundPayload, targetForOutboundPayload, getSourceMessageType());
             if (!sourceMessageType.equalsIgnoreCase(originalMessageType)) {
-                CallMediatorEnrichUtil.setContentType(synInCtx, sourceMessageType, sourceMessageType);
+                MeidatorEnrichUtil.setContentType(synInCtx, sourceMessageType, sourceMessageType);
                 if (originalMessageType.equalsIgnoreCase(JSON_TYPE)) {
                     JsonUtil.removeJsonStream(axis2MessageContext);
                 }
@@ -280,27 +280,27 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
     public void postMediate(MessageContext response, String originalMessageType, String originalContentType,
                             Map originalTransportHeaders) {
         if (isTargetAvailable()) {
-            CallMediatorEnrichUtil.buildMessage(response);
+            MeidatorEnrichUtil.buildMessage(response);
         }
         if (isTargetAvailable && isSourceAvailable) {
-            Source sourceForResponsePayload = CallMediatorEnrichUtil.createSourceWithBody();
+            Source sourceForResponsePayload = MeidatorEnrichUtil.createSourceWithBody();
             Source sourceForOriginalPayload =
-                    CallMediatorEnrichUtil.createSourceWithProperty(INTERMEDIATE_ORIGINAL_BODY);
-            Target targetForResponsePayload = CallMediatorEnrichUtil.createTargetWithBody();
-            CallMediatorEnrichUtil.doEnrich(response, sourceForResponsePayload, targetForInboundPayload,
+                    MeidatorEnrichUtil.createSourceWithProperty(INTERMEDIATE_ORIGINAL_BODY);
+            Target targetForResponsePayload = MeidatorEnrichUtil.createTargetWithBody();
+            MeidatorEnrichUtil.doEnrich(response, sourceForResponsePayload, targetForInboundPayload,
                     getSourceMessageType());
-            CallMediatorEnrichUtil.doEnrich(response, sourceForOriginalPayload, targetForResponsePayload,
+            MeidatorEnrichUtil.doEnrich(response, sourceForOriginalPayload, targetForResponsePayload,
                     originalMessageType);
-            CallMediatorEnrichUtil.preservetransportHeaders(response, originalTransportHeaders);
+            MeidatorEnrichUtil.preservetransportHeaders(response, originalTransportHeaders);
             if (!sourceMessageType.equalsIgnoreCase(originalMessageType)) {
-                CallMediatorEnrichUtil.setContentType(response, originalMessageType, originalContentType);
+                MeidatorEnrichUtil.setContentType(response, originalMessageType, originalContentType);
                 if (sourceMessageType.equalsIgnoreCase(JSON_TYPE)) {
                     JsonUtil.removeJsonStream(((Axis2MessageContext) response).getAxis2MessageContext());
                 }
             }
         } else if (isTargetAvailable) {
-            Source sourceForResponsePayload = CallMediatorEnrichUtil.createSourceWithBody();
-            CallMediatorEnrichUtil.doEnrich(response, sourceForResponsePayload, targetForInboundPayload,
+            Source sourceForResponsePayload = MeidatorEnrichUtil.createSourceWithBody();
+            MeidatorEnrichUtil.doEnrich(response, sourceForResponsePayload, targetForInboundPayload,
                     getSourceMessageType());
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/elementary/Target.java
@@ -42,7 +42,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.apache.synapse.commons.json.Constants;
@@ -52,7 +51,7 @@ import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.Value;
 import org.apache.synapse.mediators.eip.EIPUtils;
-import org.apache.synapse.util.CallMediatorEnrichUtil;
+import org.apache.synapse.util.MeidatorEnrichUtil;
 import org.apache.synapse.util.InlineExpressionUtil;
 import org.apache.synapse.util.synapse.expression.constants.ExpressionConstants;
 import org.apache.synapse.util.xpath.SynapseJsonPath;
@@ -253,7 +252,7 @@ public class Target {
                         .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
                 JsonObject headers = EIPUtils.convertMapToJsonObj(transportHeaders);
                 result.put(ExpressionConstants.HEADERS, headers);
-                result.put(ExpressionConstants.ATTRIBUTES, CallMediatorEnrichUtil.populateTransportAttributes(synContext));
+                result.put(ExpressionConstants.ATTRIBUTES, MeidatorEnrichUtil.populateTransportAttributes(synContext));
                 synContext.setVariable(key, result);
             } else {
                 synLog.error("Action " + action + " is not supported when enriching variables");
@@ -501,7 +500,7 @@ public class Target {
                             .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
                     JsonObject headers = EIPUtils.convertMapToJsonObj(transportHeaders);
                     result.put(ExpressionConstants.HEADERS, headers);
-                    result.put(ExpressionConstants.ATTRIBUTES, CallMediatorEnrichUtil.populateTransportAttributes(synCtx));
+                    result.put(ExpressionConstants.ATTRIBUTES, MeidatorEnrichUtil.populateTransportAttributes(synCtx));
                     synCtx.setVariable(key, result);
                 }
                 break;

--- a/modules/core/src/main/java/org/apache/synapse/util/MeidatorEnrichUtil.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/MeidatorEnrichUtil.java
@@ -52,7 +52,7 @@ import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.Map;
 
-public class CallMediatorEnrichUtil {
+public class MeidatorEnrichUtil {
 
     public static final String CUSTOM = "custom";
     public static final String PROPERTY = "property";
@@ -63,7 +63,7 @@ public class CallMediatorEnrichUtil {
 
     public static final String JSON_TYPE = "application/json";
     public static final String TEXT_TYPE = "text/plain";
-    public static final Log log = LogFactory.getLog(CallMediatorEnrichUtil.class);
+    public static final Log log = LogFactory.getLog(MeidatorEnrichUtil.class);
     private final static QName TEXT_ELEMENT = new QName("http://ws.apache.org/commons/ns/payload", "text");
 
     public static int convertTypeToInt(String type) {
@@ -253,7 +253,7 @@ public class CallMediatorEnrichUtil {
 
     public static Source createSourceWithProperty(String propertyName) {
         Source source = new Source();
-        source.setSourceType(CallMediatorEnrichUtil.convertTypeToInt("property"));
+        source.setSourceType(MeidatorEnrichUtil.convertTypeToInt("property"));
         source.setProperty(propertyName);
         source.setClone(false);
         return source;
@@ -262,13 +262,13 @@ public class CallMediatorEnrichUtil {
     public static Source createSourceWithBody() {
         Source source = new Source();
         source.setClone(false);
-        source.setSourceType(CallMediatorEnrichUtil.convertTypeToInt("body"));
+        source.setSourceType(MeidatorEnrichUtil.convertTypeToInt("body"));
         return source;
     }
 
     public static Target createTargetWithProperty(String propertyName) {
         Target target = new Target();
-        target.setTargetType(CallMediatorEnrichUtil.convertTypeToInt("property"));
+        target.setTargetType(MeidatorEnrichUtil.convertTypeToInt("property"));
         target.setProperty(propertyName);
         target.setAction("replace");
         return target;
@@ -277,7 +277,7 @@ public class CallMediatorEnrichUtil {
     public static Target createTargetWithBody() {
         Target target = new Target();
         target.setAction("replace");
-        target.setTargetType(CallMediatorEnrichUtil.convertTypeToInt("body"));
+        target.setTargetType(MeidatorEnrichUtil.convertTypeToInt("body"));
         return target;
     }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Improve Invoke mediator to support connector response model. The message payload and transport headers before invoking the template are preserved and the output of the template is stored inside a variable. 

Also refactored CallMediatorEnrichUtil to MediatorEnrichUtil since it is not only used for Call Mediator.