### PR TITLE
Fix classloader loader issue when adding connector zip with libs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
@@ -76,23 +76,15 @@ public class LibDeployerUtils {
         if (deployedLibClassLoader == null) {
             //create a ClassLoader for loading this synapse lib classes/resources
             try {
+                ClassLoader libLoader;
                 if (classLoader != null) {
-                    synapseLib.setLibClassLoader(classLoader);
-                    SynapseConfiguration.addLibraryClassLoader(libArtifactName, classLoader);
-                    if (classLoader instanceof LibClassLoader) {
-                        try {
-                            ((LibClassLoader) classLoader).addURL(new File(extractPath).toURI().toURL());
-                        } catch (MalformedURLException e) {
-                            throw new DeploymentException("Error while adding URL to the classloader", e);
-                        }
-                    }
+                    libLoader = Utils.getClassLoader(classLoader, extractPath, false);
                 } else {
-                    ClassLoader libLoader = Utils.getClassLoader(LibDeployerUtils.class.getClassLoader(),
-                        extractPath, false);
-                    SynapseConfiguration.addLibraryClassLoader(libArtifactName, libLoader);
-                    synapseLib.setLibClassLoader(libLoader);
+                    libLoader = Utils.getClassLoader(LibDeployerUtils.class.getClassLoader(),
+                            extractPath, false);
                 }
-
+                SynapseConfiguration.addLibraryClassLoader(libArtifactName, libLoader);
+                synapseLib.setLibClassLoader(libLoader);
             } catch (DeploymentException e) {
                 throw new SynapseArtifactDeploymentException("Error setting up lib classpath for Synapse" +
                         " Library  : " + libFile.getAbsolutePath(), e);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

When connector zips have libraries inside, there location needs to be added to the ClassLoader. To recursively add, we need to use the method Utils.getClassLoader.