### PR TITLE
Improve Script mediator and class mediator to support inputs and outputs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorFactory.java
@@ -82,6 +82,8 @@ public abstract class AbstractMediatorFactory implements MediatorFactory {
     protected static final QName RESULT_TARGET_Q = new QName("result-target");
     protected static final QName ATT_TYPE = new QName("type");
     protected static final QName ATT_ARGUMENT = new QName("argument");
+    protected static final QName INPUTS
+            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "inputs");
 
     /**
      * A constructor that makes subclasses pick up the correct logger
@@ -252,7 +254,7 @@ public abstract class AbstractMediatorFactory implements MediatorFactory {
      * @param inputArgsElement input arguments element
      * @return List of input arguments
      */
-    protected List<InputArgument> getInputArguments(OMElement inputArgsElement) {
+    protected List<InputArgument> getInputArguments(OMElement inputArgsElement, String mediator) {
 
         List<InputArgument> inputArgsMap = new ArrayList<>();
         Iterator inputIterator = inputArgsElement.getChildrenWithName(ATT_ARGUMENT);
@@ -271,7 +273,7 @@ public abstract class AbstractMediatorFactory implements MediatorFactory {
                             new QName("expression")), typeAttribute);
                 } catch (JaxenException e) {
                     handleException("Error setting expression : " + expressionAttribute + " as an input argument to " +
-                            "script mediator. " + e.getMessage(), e);
+                                    mediator + " mediator. " + e.getMessage(), e);
                 }
             }
             inputArgsMap.add(argument);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/AbstractMediatorSerializer.java
@@ -32,8 +32,10 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.aspects.AspectConfigurable;
 import org.apache.synapse.aspects.statistics.StatisticsConfigurable;
+import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.mediators.builtin.CommentMediator;
+import org.apache.synapse.mediators.v2.ext.InputArgument;
 
 import javax.xml.namespace.QName;
 import java.util.Collection;

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorSerializer.java
@@ -21,6 +21,7 @@ package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMNode;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.mediators.ext.ClassMediator;
 
@@ -51,7 +52,14 @@ public class ClassMediatorSerializer extends AbstractMediatorSerializer  {
             handleException("Invalid class mediator. The class name is required");
         }
 
-        super.serializeProperties(clazz, mediator.getProperties());
+        if (StringUtils.isNotBlank(mediator.getResultTarget())) {
+            // If result target is set, this is V2 class mediator
+            clazz.addAttribute(fac.createOMAttribute("result-target", nullNS, mediator.getResultTarget()));
+            clazz.addAttribute(fac.createOMAttribute("method", nullNS, mediator.getMethodName()));
+            clazz.addChild(InputArgumentSerializer.serializeInputArguments(mediator.getInputArguments()));
+        } else {
+            super.serializeProperties(clazz, mediator.getProperties());
+        }
 
         serializeComments(clazz, mediator.getCommentsList());
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/InputArgumentSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/InputArgumentSerializer.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.config.xml;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.mediators.v2.ext.InputArgument;
+
+import java.util.List;
+
+/**
+ * Serializer for input arguments
+ */
+public class InputArgumentSerializer {
+
+    private static final OMFactory fac = OMAbstractFactory.getOMFactory();
+    private static final OMNamespace nullNS = fac.createOMNamespace(XMLConfigConstants.NULL_NAMESPACE, "");
+    private static final String INPUTS = "inputs";
+    private static final String ARGUMENT = "argument";
+    private static final String NAME = "name";
+    private static final String TYPE = "type";
+    private static final String EXPRESSION = "expression";
+    private static final String VALUE = "value";
+
+    public static OMElement serializeInputArguments(List<InputArgument> inputArguments) {
+
+        OMElement inputElement = fac.createOMElement(INPUTS, SynapseConstants.SYNAPSE_OMNAMESPACE);
+        for (InputArgument inputArgument : inputArguments) {
+            OMElement inputArgElement = fac.createOMElement(ARGUMENT, SynapseConstants.SYNAPSE_OMNAMESPACE);
+            inputArgElement.addAttribute(fac.createOMAttribute(NAME, nullNS, inputArgument.getName()));
+            inputArgElement.addAttribute(fac.createOMAttribute(TYPE, nullNS, inputArgument.getType()));
+            if (inputArgument.getExpression() != null) {
+                SynapsePathSerializer.serializePath(inputArgument.getExpression(),
+                        inputArgument.getExpression().getExpression(), inputArgElement, EXPRESSION);
+            } else {
+                inputArgElement.addAttribute(fac.createOMAttribute(VALUE, nullNS, inputArgument.getValue().toString()));
+            }
+            inputElement.addChild(inputArgElement);
+        }
+        return inputElement;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ScatterGatherMediatorFactory.java
@@ -61,7 +61,6 @@ public class ScatterGatherMediatorFactory extends AbstractMediatorFactory {
     private static final QName ATT_MAX_MESSAGES = new QName("max-messages");
     private static final QName SEQUENCE_Q = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "sequence");
     private static final QName PARALLEL_EXEC_Q = new QName("parallel-execution");
-    private static final QName RESULT_TARGET_Q = new QName("result-target");
     private static final QName ROOT_ELEMENT_Q = new QName("root-element");
     private static final QName CONTENT_TYPE_Q = new QName("content-type");
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
@@ -80,7 +80,7 @@ public class SynapsePathSerializer {
                             attribName, nullNS, "{${" + expression.substring(1, expression.length() - 1) + "}}"));
                 } else {
                     elem.addAttribute(elem.getOMFactory().createOMAttribute(
-                            attribName, nullNS, "{${" + expression + "}"));
+                            attribName, nullNS, "${" + expression + "}"));
                 }
             }
 

--- a/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/MediatorWorker.java
@@ -33,7 +33,7 @@ import org.apache.synapse.continuation.ContinuationStackManager;
 import org.apache.synapse.continuation.SeqContinuationState;
 import org.apache.synapse.debug.SynapseDebugManager;
 import org.apache.synapse.mediators.base.SequenceMediator;
-import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+import org.apache.synapse.mediators.v2.Utils;
 import org.apache.synapse.util.logging.LoggingUtils;
 
 /**
@@ -96,7 +96,7 @@ public class MediatorWorker implements Runnable {
 
             boolean result = seq.mediate(synCtx);
             // If this is a scatter message, then we need to use the continuation state and continue the mediation
-            if (ScatterGatherUtils.isScatterMessage(synCtx) && result) {
+            if (Utils.isScatterMessage(synCtx) && result) {
                 SeqContinuationState seqContinuationState = (SeqContinuationState) ContinuationStackManager.peakContinuationStateStack(synCtx);
                 if (seqContinuationState == null) {
                     return;
@@ -143,7 +143,7 @@ public class MediatorWorker implements Runnable {
                 debugManager.advertiseMediationFlowTerminatePoint(synCtx);
                 debugManager.releaseMediationFlowLock();
             }
-            if (RuntimeStatisticCollector.isStatisticsEnabled() && !ScatterGatherUtils.isScatterMessage(synCtx)) {
+            if (RuntimeStatisticCollector.isStatisticsEnabled() && !Utils.isScatterMessage(synCtx)) {
                 this.statisticsCloseEventListener.invokeCloseEventEntry(synCtx);
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/base/SequenceMediator.java
@@ -32,7 +32,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector
 import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.aspects.flow.statistics.data.artifact.ArtifactHolder;
-import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+import org.apache.synapse.mediators.v2.Utils;
 import org.apache.synapse.transport.customlogsetter.CustomLogSetter;
 import org.apache.synapse.aspects.ComponentType;
 import org.apache.synapse.continuation.ContinuationStackManager;
@@ -158,7 +158,7 @@ public class SequenceMediator extends AbstractListMediator implements Nameable,
 
                 boolean result = super.mediate(synCtx);
 
-                if (result && !skipAddition && !ScatterGatherUtils.isScatterMessage(synCtx)) {
+                if (result && !skipAddition && !Utils.isScatterMessage(synCtx)) {
                     // if flow completed remove the previously added SeqContinuationState
                     ContinuationStackManager.removeSeqContinuationState(synCtx, sequenceType);
                 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/ext/ClassMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/ext/ClassMediator.java
@@ -30,7 +30,7 @@ import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.MediatorProperty;
-import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+import org.apache.synapse.mediators.v2.Utils;
 import org.apache.synapse.mediators.v2.ext.AbstractClassMediator;
 import org.apache.synapse.mediators.v2.ext.InputArgument;
 
@@ -140,7 +140,7 @@ public class ClassMediator extends AbstractMediator implements ManagedLifecycle 
         }
         try {
             Object result = targetMethod.invoke(mediator, methodArgs.toArray());
-            return ScatterGatherUtils.setResultTarget(synCtx, resultTarget, result);
+            return Utils.setResultTarget(synCtx, resultTarget, result);
         } catch (IllegalAccessException | InvocationTargetException e) {
             handleException("Error while invoking method: " + methodName + " in class "
                     + mediator.getClass().getSimpleName(), e, synCtx);

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ForEachMediatorV2.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ForEachMediatorV2.java
@@ -256,7 +256,7 @@ public class ForEachMediatorV2 extends AbstractMediator implements ManagedLifecy
         // If there are no children and the continuation was triggered from a mediator worker start aggregation
         // otherwise mediate through the sub branch sequence
         if (!continuationState.hasChild()) {
-            if (ScatterGatherUtils.isContinuationTriggeredFromMediatorWorker(synCtx)) {
+            if (Utils.isContinuationTriggeredFromMediatorWorker(synCtx)) {
                 synLog.traceOrDebug("Continuation is triggered from a mediator worker");
                 result = true;
             } else {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
@@ -615,7 +615,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             // setting the new JSON payload to the messageContext
             try {
                 newCtx = MessageHelper.cloneMessageContext(aggregate.getLastMessage(), false, false, true);
-                SOAPEnvelope newEnvelope = createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
+                SOAPEnvelope newEnvelope = ScatterGatherUtils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
                 newCtx.setEnvelope(newEnvelope);
                 JsonUtil.getNewJsonPayload(((Axis2MessageContext) newCtx).getAxis2MessageContext(), new
                         ByteArrayInputStream(jsonArray.toString().getBytes()), true, true);
@@ -629,7 +629,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             setXMLResultToRootOMElement(rootElement, aggregate);
             try {
                 newCtx = MessageHelper.cloneMessageContext(aggregate.getLastMessage(), false, false, true);
-                SOAPEnvelope newEnvelope = createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
+                SOAPEnvelope newEnvelope = ScatterGatherUtils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
                 newEnvelope.getBody().addChild(rootElement);
                 newCtx.setEnvelope(newEnvelope);
             } catch (AxisFault axisFault) {
@@ -645,17 +645,6 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
         }
         StatisticDataCollectionHelper.collectAggregatedParents(aggregate.getMessages(), newCtx);
         return newCtx;
-    }
-
-    private SOAPEnvelope createNewSoapEnvelope(SOAPEnvelope envelope) {
-
-        SOAPFactory fac;
-        if (SOAP11Constants.SOAP_ENVELOPE_NAMESPACE_URI.equals(envelope.getBody().getNamespace().getNamespaceURI())) {
-            fac = OMAbstractFactory.getSOAP11Factory();
-        } else {
-            fac = OMAbstractFactory.getSOAP12Factory();
-        }
-        return fac.getDefaultEnvelope();
     }
 
     public SynapsePath getCorrelateExpression() {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGather.java
@@ -24,9 +24,7 @@ import com.google.gson.JsonSyntaxException;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
-import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAPEnvelope;
-import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.context.OperationContext;
@@ -268,7 +266,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
         // If there are no children and the continuation was triggered from a mediator worker start aggregation
         // otherwise mediate through the sub branch sequence
         if (!continuationState.hasChild()) {
-            if (ScatterGatherUtils.isContinuationTriggeredFromMediatorWorker(synCtx)) {
+            if (Utils.isContinuationTriggeredFromMediatorWorker(synCtx)) {
                 synLog.traceOrDebug("Continuation is triggered from a mediator worker");
                 result = true;
             } else {
@@ -615,7 +613,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             // setting the new JSON payload to the messageContext
             try {
                 newCtx = MessageHelper.cloneMessageContext(aggregate.getLastMessage(), false, false, true);
-                SOAPEnvelope newEnvelope = ScatterGatherUtils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
+                SOAPEnvelope newEnvelope = Utils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
                 newCtx.setEnvelope(newEnvelope);
                 JsonUtil.getNewJsonPayload(((Axis2MessageContext) newCtx).getAxis2MessageContext(), new
                         ByteArrayInputStream(jsonArray.toString().getBytes()), true, true);
@@ -629,7 +627,7 @@ public class ScatterGather extends AbstractMediator implements ManagedLifecycle,
             setXMLResultToRootOMElement(rootElement, aggregate);
             try {
                 newCtx = MessageHelper.cloneMessageContext(aggregate.getLastMessage(), false, false, true);
-                SOAPEnvelope newEnvelope = ScatterGatherUtils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
+                SOAPEnvelope newEnvelope = Utils.createNewSoapEnvelope(aggregate.getLastMessage().getEnvelope());
                 newEnvelope.getBody().addChild(rootElement);
                 newCtx.setEnvelope(newEnvelope);
             } catch (AxisFault axisFault) {

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGatherUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ScatterGatherUtils.java
@@ -18,8 +18,23 @@
 
 package org.apache.synapse.mediators.v2;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.soap.SOAP11Constants;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axis2.util.JavaUtils;
+import org.apache.commons.logging.Log;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapseConfigUtils;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.config.xml.XMLConfigConstants;
 
 public class ScatterGatherUtils {
 
@@ -46,5 +61,210 @@ public class ScatterGatherUtils {
         Boolean isContinuationTriggeredMediatorWorker =
                 (Boolean) synCtx.getProperty(SynapseConstants.CONTINUE_FLOW_TRIGGERED_FROM_MEDIATOR_WORKER);
         return isContinuationTriggeredMediatorWorker != null && isContinuationTriggeredMediatorWorker;
+    }
+
+    public static Object convertValue(String value, String type, Log log) {
+
+        if (type == null) {
+            return value;
+        }
+        try {
+            XMLConfigConstants.VARIABLE_DATA_TYPES dataType = XMLConfigConstants.VARIABLE_DATA_TYPES.valueOf(type);
+            switch (dataType) {
+                case BOOLEAN:
+                    return JavaUtils.isTrueExplicitly(value);
+                case DOUBLE:
+                    return Double.parseDouble(value);
+                case INTEGER:
+                    return Integer.parseInt(value);
+                case LONG:
+                    return Long.parseLong(value);
+                case XML:
+                    return buildOMElement(value);
+                case JSON:
+                    return buildJSONElement(value, log);
+                default:
+                    return value;
+            }
+        } catch (IllegalArgumentException e) {
+            String msg = "Unknown type : " + type + " for the variable mediator or the " +
+                    "variable value cannot be converted into the specified type.";
+            log.error(msg, e);
+            throw new SynapseException(msg, e);
+        }
+    }
+
+    public static OMElement buildOMElement(String xml) {
+
+        if (xml == null) {
+            return null;
+        }
+        OMElement result = SynapseConfigUtils.stringToOM(xml);
+        result.buildWithAttachments();
+        return result;
+    }
+
+    private static JsonElement buildJSONElement(String jsonPayload, Log log) {
+
+        JsonParser jsonParser = new JsonParser();
+        try {
+            return jsonParser.parse(jsonPayload);
+        } catch (JsonSyntaxException ex) {
+            // Enclosing using quotes due to the following issue
+            // https://github.com/google/gson/issues/1286
+            String enclosed = "\"" + jsonPayload + "\"";
+            try {
+                return jsonParser.parse(enclosed);
+            } catch (JsonSyntaxException e) {
+                // log the original exception and discard the new exception
+                log.error("Malformed JSON payload : " + jsonPayload, ex);
+                return null;
+            }
+        }
+    }
+
+    private static boolean isXMLType(String type) {
+
+        return type != null && XMLConfigConstants.VARIABLE_DATA_TYPES.XML.equals(XMLConfigConstants.VARIABLE_DATA_TYPES.valueOf(type));
+    }
+
+    private static boolean isStringType(String type) {
+
+        return type != null && XMLConfigConstants.VARIABLE_DATA_TYPES.STRING.equals(XMLConfigConstants.VARIABLE_DATA_TYPES.valueOf(type));
+    }
+
+    public static Object getResolvedValue(MessageContext synCtx, SynapsePath expression, Object value, String type, Log log) {
+
+        if (value != null) {
+            return value;
+        } else {
+            if (expression != null) {
+                if (isXMLType(type)) {
+                    return ScatterGatherUtils.buildOMElement(expression.stringValueOf(synCtx));
+                } else if (isStringType(type)) {
+                    return expression.stringValueOf(synCtx);
+                }
+                return convertExpressionResult(expression.objectValueOf(synCtx), type, expression.getExpression(), log);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convert the evaluated value to the expected data type.
+     *
+     * @param evaluatedValue Evaluated value to be converted
+     * @param type           Expected data type
+     * @return Converted value
+     */
+    private static Object convertExpressionResult(Object evaluatedValue, String type, String expression, Log log) {
+
+        if (type == null) {
+            return evaluatedValue;
+        }
+
+        if (evaluatedValue instanceof JsonPrimitive) {
+            return convertJsonPrimitive((JsonPrimitive) evaluatedValue, type, expression, log);
+        }
+
+        XMLConfigConstants.VARIABLE_DATA_TYPES dataType = XMLConfigConstants.VARIABLE_DATA_TYPES.valueOf(type);
+        switch (dataType) {
+            case BOOLEAN:
+                if (!(evaluatedValue instanceof Boolean)) {
+                    handleDataTypeException("BOOLEAN", expression, log);
+                }
+                break;
+            case DOUBLE:
+                if (!(evaluatedValue instanceof Double)) {
+                    handleDataTypeException("DOUBLE", expression, log);
+                }
+                break;
+            case INTEGER:
+                if (!(evaluatedValue instanceof Integer)) {
+                    handleDataTypeException("INTEGER", expression, log);
+                }
+                break;
+            case LONG:
+                if (!(evaluatedValue instanceof Long)) {
+                    handleDataTypeException("LONG", expression, log);
+                }
+                break;
+            case XML:
+                if (!(evaluatedValue instanceof OMElement)) {
+                    handleDataTypeException("XML", expression, log);
+                }
+                break;
+            case JSON:
+                if (!(evaluatedValue instanceof JsonElement)) {
+                    handleDataTypeException("JSON", expression, log);
+                }
+                break;
+            default:
+        }
+        return evaluatedValue;
+    }
+
+    /**
+     * Convert the JSON primitive to the expected data type.
+     *
+     * @param jsonPrimitive JSON primitive to be converted
+     * @param type          Expected data type
+     * @return Converted JSON primitive
+     */
+    private static Object convertJsonPrimitive(JsonPrimitive jsonPrimitive, String type, String expression, Log log) {
+
+        XMLConfigConstants.VARIABLE_DATA_TYPES dataType = XMLConfigConstants.VARIABLE_DATA_TYPES.valueOf(type);
+        switch (dataType) {
+            case BOOLEAN:
+                if (jsonPrimitive.isBoolean()) {
+                    return jsonPrimitive.getAsBoolean();
+                } else {
+                    handleDataTypeException("BOOLEAN", expression, log);
+                }
+            case DOUBLE:
+                if (jsonPrimitive.isNumber()) {
+                    return jsonPrimitive.getAsDouble();
+                } else {
+                    handleDataTypeException("DOUBLE", expression, log);
+                }
+            case INTEGER:
+                if (jsonPrimitive.isNumber()) {
+                    return jsonPrimitive.getAsInt();
+                } else {
+                    handleDataTypeException("INTEGER", expression, log);
+                }
+            case LONG:
+                if (jsonPrimitive.isNumber()) {
+                    return jsonPrimitive.getAsLong();
+                } else {
+                    handleDataTypeException("LONG", expression, log);
+                }
+            default:
+                return jsonPrimitive.getAsString();
+        }
+    }
+
+    /**
+     * This method will throw a SynapseException with a message indicating that the expression result does not match
+     * the expected data type.
+     *
+     * @param dataType Expected data type
+     */
+    private static void handleDataTypeException(String dataType, String expression, Log log) {
+
+        String msg = "Expression '${" + expression + "}' result does not match the expected data type '" + dataType + "'";
+        log.error(msg);
+        throw new SynapseException(msg);
+    }
+
+    public static SOAPEnvelope createNewSoapEnvelope(SOAPEnvelope envelope) {
+
+        SOAPFactory fac;
+        if (SOAP11Constants.SOAP_ENVELOPE_NAMESPACE_URI.equals(envelope.getBody().getNamespace().getNamespaceURI())) {
+            fac = OMAbstractFactory.getSOAP11Factory();
+        } else {
+            fac = OMAbstractFactory.getSOAP12Factory();
+        }
+        return fac.getDefaultEnvelope();
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/Utils.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/Utils.java
@@ -42,7 +42,7 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import java.io.ByteArrayInputStream;
 import javax.xml.namespace.QName;
 
-public class ScatterGatherUtils {
+public class Utils {
 
     /**
      * Check whether the message is a scatter message or not
@@ -146,7 +146,7 @@ public class ScatterGatherUtils {
         } else {
             if (expression != null) {
                 if (isXMLType(type)) {
-                    return ScatterGatherUtils.buildOMElement(expression.stringValueOf(synCtx));
+                    return Utils.buildOMElement(expression.stringValueOf(synCtx));
                 } else if (isStringType(type)) {
                     return expression.stringValueOf(synCtx);
                 }
@@ -314,11 +314,11 @@ public class ScatterGatherUtils {
     public static boolean setResultTarget(MessageContext synCtx, String resultTarget, Object result) throws AxisFault,
             SynapseException {
 
-        if (ScatterGatherUtils.isTargetNone(resultTarget)) {
+        if (Utils.isTargetNone(resultTarget)) {
             return true;
         }
         if (result != null) {
-            if (ScatterGatherUtils.isTargetBody(resultTarget)) {
+            if (Utils.isTargetBody(resultTarget)) {
                 // set result to body
                 if (result instanceof JsonElement) {
                     JsonUtil.getNewJsonPayload(((Axis2MessageContext) synCtx).getAxis2MessageContext(), new
@@ -327,13 +327,13 @@ public class ScatterGatherUtils {
                     OMElement rootElement = OMAbstractFactory.getOMFactory().createOMElement(new QName(
                             "result"));
                     rootElement.setText(result.toString());
-                    SOAPEnvelope newEnvelope = ScatterGatherUtils.createNewSoapEnvelope(synCtx.getEnvelope());
+                    SOAPEnvelope newEnvelope = Utils.createNewSoapEnvelope(synCtx.getEnvelope());
                     newEnvelope.getBody().addChild(rootElement);
                     synCtx.setEnvelope(newEnvelope);
                 }
             } else {
                 // set result to variable
-                if (ScatterGatherUtils.isValidReturnObjectType(result)) {
+                if (Utils.isValidReturnObjectType(result)) {
                     synCtx.setVariable(resultTarget, result);
                 } else {
                     throw new SynapseException("Return object type is not supported. Supported types are " +

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/VariableMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/VariableMediator.java
@@ -119,7 +119,7 @@ public class VariableMediator extends AbstractMediator {
     public void setValue(String value, String type) {
 
         this.type = type;
-        this.value = ScatterGatherUtils.convertValue(value, type, log);
+        this.value = Utils.convertValue(value, type, log);
     }
 
     public String getType() {
@@ -157,7 +157,7 @@ public class VariableMediator extends AbstractMediator {
 
     private Object getResultValue(MessageContext synCtx) {
 
-        return ScatterGatherUtils.getResolvedValue(synCtx, expression, value, type, log);
+        return Utils.getResolvedValue(synCtx, expression, value, type, log);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/AbstractClassMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/AbstractClassMediator.java
@@ -9,6 +9,11 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.PARAMETER;
 
+/**
+ * This is the super class for custom class mediators. The user can extend this class and implement a custom method with
+ * the allowed argument types. The method parameters should be annotated with the @Arg annotation to specify the
+ * argument name and the type. The method may return a value if needed. The return type should be one of the allowed.
+ */
 public class AbstractClassMediator extends AbstractMediator {
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/AbstractClassMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/AbstractClassMediator.java
@@ -1,0 +1,57 @@
+package org.apache.synapse.mediators.v2.ext;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+
+public class AbstractClassMediator extends AbstractMediator {
+
+    @Override
+    public boolean mediate(MessageContext synCtx) {
+
+        // User implemented method will be invoked from the Class mediator
+        return true;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({PARAMETER})
+    public @interface Arg {
+
+        String name();
+
+        ArgumentType type();
+    }
+
+    public enum ArgumentType {
+        STRING("String"),
+        BOOLEAN("Boolean"),
+        INTEGER("Integer"),
+        LONG("Long"),
+        DOUBLE("Double"),
+        JSON("Json"),
+        XML("Xml");
+
+        private final String typeName;
+
+        ArgumentType(String typeName) {
+
+            this.typeName = typeName;
+        }
+
+        public String getTypeName() {
+
+            return typeName;
+        }
+
+        @Override
+        public String toString() {
+
+            return typeName;
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/InputArgument.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/InputArgument.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.mediators.v2.ext;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+
+public class InputArgument {
+
+    private static final Log log = LogFactory.getLog(InputArgument.class);
+    private String name;
+    private SynapsePath expression;
+    private Object value;
+    private String type;
+
+    public InputArgument(String name) {
+
+        this.name = name;
+    }
+
+    public Object getResolvedArgument(MessageContext synCtx) {
+
+        return ScatterGatherUtils.getResolvedValue(synCtx, expression, value, type, log);
+    }
+
+    public void setExpression(SynapsePath expression, String type) {
+
+        this.type = type;
+        this.expression = expression;
+    }
+
+    public void setValue(String value, String type) {
+
+        this.type = type;
+        this.value = ScatterGatherUtils.convertValue(value, type, log);
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public SynapsePath getExpression() {
+
+        return expression;
+    }
+
+    public Object getValue() {
+
+        return value;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/InputArgument.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ext/InputArgument.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.config.xml.SynapsePath;
-import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+import org.apache.synapse.mediators.v2.Utils;
 
 public class InputArgument {
 
@@ -39,7 +39,7 @@ public class InputArgument {
 
     public Object getResolvedArgument(MessageContext synCtx) {
 
-        return ScatterGatherUtils.getResolvedValue(synCtx, expression, value, type, log);
+        return Utils.getResolvedValue(synCtx, expression, value, type, log);
     }
 
     public void setExpression(SynapsePath expression, String type) {
@@ -51,7 +51,7 @@ public class InputArgument {
     public void setValue(String value, String type) {
 
         this.type = type;
-        this.value = ScatterGatherUtils.convertValue(value, type, log);
+        this.value = Utils.convertValue(value, type, log);
     }
 
     public String getName() {

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ClassMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ClassMediatorSerializationTest.java
@@ -72,4 +72,17 @@ public class ClassMediatorSerializationTest extends AbstractTestCase {
 
         assertTrue(failed);
     }
+
+    public void testV2ClassMediator() throws Exception {
+
+        String inputXml = "<class xmlns=\"http://ws.apache.org/ns/synapse\" name=\"org.apache.synapse.config.xml.TestMediator\" " +
+                "method=\"mediate\" result-target=\"body\">" +
+                "<inputs>" +
+                "<argument name=\"num1\" expression=\"${payload.requestId}\" type=\"INTEGER\"/>" +
+                "<argument name=\"num2\" value=\"20\" type=\"INTEGER\"/>" +
+                "</inputs>" +
+                "</class>";
+        assertTrue(serialization(inputXml, classMediatorFactory, classMediatorSerializer));
+        assertTrue(serialization(inputXml, classMediatorSerializer));
+    }
 }

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -44,7 +44,7 @@ import org.apache.synapse.mediators.bsf.access.control.SandboxContextFactory;
 import org.apache.synapse.mediators.bsf.access.control.config.AccessControlConfig;
 import org.apache.synapse.mediators.bsf.access.control.config.AccessControlListType;
 import org.apache.synapse.mediators.eip.EIPUtils;
-import org.apache.synapse.mediators.v2.ScatterGatherUtils;
+import org.apache.synapse.mediators.v2.Utils;
 import org.apache.synapse.mediators.v2.ext.InputArgument;
 import org.graalvm.polyglot.Context;
 import org.mozilla.javascript.ClassShutter;
@@ -302,7 +302,7 @@ public class ScriptMediator extends AbstractMediator {
                 // If result target is set, this is V2 script mediator
                 // Set the result to the target and returnValue to true
                 if (StringUtils.isNotBlank(resultTarget)) {
-                    returnValue = ScatterGatherUtils.setResultTarget(synCtx, resultTarget, returnObject);
+                    returnValue = Utils.setResultTarget(synCtx, resultTarget, returnObject);
                 } else {
                     returnValue = !(returnObject != null && returnObject instanceof Boolean) || (Boolean) returnObject;
                 }

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
@@ -75,9 +75,6 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
     private static final QName INCLUDE_Q
             = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "include");
 
-    private static final QName INPUTS
-            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "inputs");
-
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
         ScriptMediator mediator;
@@ -120,7 +117,7 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
                 mediator.setResultTarget(targetAtt);
                 OMElement inputArgsElement = elem.getFirstChildWithName(INPUTS);
                 if (inputArgsElement != null) {
-                    List<InputArgument> inputArgsMap = getInputArguments(inputArgsElement);
+                    List<InputArgument> inputArgsMap = getInputArguments(inputArgsElement, "script");
                     mediator.setInputArgumentMap(inputArgsMap);
                 }
             }

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.synapse.mediators.bsf;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
@@ -29,7 +30,7 @@ import org.apache.synapse.config.xml.AbstractMediatorFactory;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.mediators.Value;
 import org.apache.synapse.config.xml.ValueFactory;
-import org.mozilla.javascript.Context;
+import org.apache.synapse.mediators.v2.ext.InputArgument;
 
 import javax.xml.namespace.QName;
 import java.util.Iterator;
@@ -74,6 +75,9 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
     private static final QName INCLUDE_Q
             = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "include");
 
+    private static final QName INPUTS
+            = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "inputs");
+
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
         ScriptMediator mediator;
@@ -111,6 +115,15 @@ public class ScriptMediatorFactory extends AbstractMediatorFactory {
             String functionName = (functionAtt == null ? null : functionAtt.getAttributeValue());
             mediator = new ScriptMediator(langAtt.getAttributeValue(),
                     includeKeysMap, generatedKey, functionName,classLoader);
+            String targetAtt = elem.getAttributeValue(RESULT_TARGET_Q);
+            if (StringUtils.isNotBlank(targetAtt)) {
+                mediator.setResultTarget(targetAtt);
+                OMElement inputArgsElement = elem.getFirstChildWithName(INPUTS);
+                if (inputArgsElement != null) {
+                    List<InputArgument> inputArgsMap = getInputArguments(inputArgsElement);
+                    mediator.setInputArgumentMap(inputArgsMap);
+                }
+            }
         } else {
             String language = langAtt.getAttributeValue();
             if (language.equals(JAVA_SCRIPT) &&

--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializer.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializer.java
@@ -20,8 +20,10 @@ package org.apache.synapse.mediators.bsf;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.config.xml.AbstractMediatorSerializer;
+import org.apache.synapse.config.xml.InputArgumentSerializer;
 import org.apache.synapse.config.xml.ValueSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.mediators.Value;
@@ -58,6 +60,11 @@ public class ScriptMediatorSerializer extends AbstractMediatorSerializer {
 
             if (!function.equals("mediate")) {
                 script.addAttribute(fac.createOMAttribute("function", nullNS, function));
+            }
+            if (StringUtils.isNotBlank(scriptMediator.getResultTarget())) {
+                // If result target is set, this is V2 script mediator
+                script.addAttribute(fac.createOMAttribute("result-target", nullNS, scriptMediator.getResultTarget()));
+                script.addChild(InputArgumentSerializer.serializeInputArguments(scriptMediator.getInputArgumentList()));
             }
         } else {
             script.addAttribute(fac.createOMAttribute("language", nullNS, language));

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializationTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/ScriptMediatorSerializationTest.java
@@ -63,4 +63,15 @@ public class ScriptMediatorSerializationTest extends AbstractTestCase {
         assertTrue(serialization(inputXml, mediatorFactory, scriptMediatorSerializer));
         assertTrue(serialization(inputXml, scriptMediatorSerializer));
     }
+
+    public void testV2ScriptMediator() throws XMLComparisonException {
+        String inputXml = "<script xmlns=\"http://ws.apache.org/ns/synapse\" language=\"js\" key=\"resources:js/test_math.js\" function=\"sum_js\" result-target=\"var1\">" +
+                "<inputs>" +
+                "<argument name=\"num1\" type=\"INTEGER\" expression=\"${payload.requestId}\" />" +
+                "<argument name=\"num2\" type=\"INTEGER\" value=\"20\" />" +
+                "</inputs>" +
+                "</script>";
+        assertTrue(serialization(inputXml, mediatorFactory, scriptMediatorSerializer));
+        assertTrue(serialization(inputXml, scriptMediatorSerializer));
+    }
 }


### PR DESCRIPTION
## Purpose

Improve Script mediator and class mediator to support inputs and outputs. The synapse XML config will have an `inputs` elements to define arguments.

```xml
<inputs>
        <argument name="num1" expression="${payload.requestId}" type="INTEGER"/>
        <argument name="num2" value="20" type="INTEGER"/>
</inputs>
```

The `result-target` attribute can be used to set the output from the Class or Script to Body, Variable or Skip

- result-target="body" Sets the output from the Class or Script to Body
- result-target="var1" Sets the output from the Class or Script to a variable called var1
- result-target="none" Skip the output. Need to be used when Class or Script won't return anything

1. Improved class mediator will be as follows,

Sample Java Class

```java
public class SampleMediator extends AbstractClassMediator {

    public int calculateSum(MessageContext context,
                                @Arg(name = "num1", type = ArgumentType.INTEGER) Integer num1,
                                @Arg(name = "num2", type = ArgumentType.INTEGER) Integer num2) {

        return num1 + num2;
    }
}
```

Synapse XML

```xml
<class name="org.example.SampleMediator" method="calculateSum" result-target="body">
    <inputs>
        <argument name="num1" expression="${payload.requestId}" type="INTEGER"/>
        <argument name="num2" value="20" type="INTEGER"/>
    </inputs>
</class>
```

2. Improved script mediator will be as follows,

Sample JS function

```js
function sum_js(mc, num1, num2) {    
    return num1 + num2;
}
```

Synapse XML

```xml
<script function="sum_js" key="resources:js/test_math.js" language="js" result-target="variable_name">
    <inputs>
        <argument name="num1" expression="${payload.requestId}" type="INTEGER"/>
        <argument name="num2" value="20" type="INTEGER"/>
    </inputs>
</script>
```