### PR TITLE
Add option to continue the parent flow without waiting for aggregation in Foreach mediator V2

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorFactory.java
@@ -66,6 +66,7 @@ public class ForEachMediatorFactory extends AbstractMediatorFactory {
     private static final QName RESULT_TARGET_Q = new QName("result-target");
     private static final QName RESULT_TYPE_Q = new QName("result-type");
     private static final QName ATT_COUNTER_VARIABLE = new QName("counter-variable");
+    private static final QName ATT_CONTINUE_WITHOUT_AGGREGATION  = new QName("continue-without-aggregation");
 
     public QName getTagQName() {
         return FOREACH_Q;
@@ -155,20 +156,26 @@ public class ForEachMediatorFactory extends AbstractMediatorFactory {
         }
         mediator.setParallelExecution(asynchronousExe);
 
-        OMAttribute resultTargetAttr = elem.getAttribute(RESULT_TARGET_Q);
-        if (resultTargetAttr != null && StringUtils.isNotBlank(resultTargetAttr.getAttributeValue())) {
-            OMAttribute contentTypeAttr = elem.getAttribute(RESULT_TYPE_Q);
-            if (contentTypeAttr == null || StringUtils.isBlank(contentTypeAttr.getAttributeValue())) {
-                handleException("The 'result-type' attribute is required when the 'result-target' attribute is present");
-            } else {
-                if ("JSON".equals(contentTypeAttr.getAttributeValue())) {
-                    mediator.setContentType(ForEachMediatorV2.JSON_TYPE);
-                } else if ("XML".equals(contentTypeAttr.getAttributeValue())) {
-                    mediator.setContentType(ForEachMediatorV2.XML_TYPE);
+        String continueWithoutAggregationAttr = elem.getAttributeValue(ATT_CONTINUE_WITHOUT_AGGREGATION);
+        // If the continue-without-aggregation attribute is set to true, the mediator will not wait for the aggregation
+        if ("true".equalsIgnoreCase(continueWithoutAggregationAttr)) {
+            mediator.setContinueWithoutAggregation(true);
+        } else {
+            OMAttribute resultTargetAttr = elem.getAttribute(RESULT_TARGET_Q);
+            if (resultTargetAttr != null && StringUtils.isNotBlank(resultTargetAttr.getAttributeValue())) {
+                OMAttribute contentTypeAttr = elem.getAttribute(RESULT_TYPE_Q);
+                if (contentTypeAttr == null || StringUtils.isBlank(contentTypeAttr.getAttributeValue())) {
+                    handleException("The 'result-type' attribute is required when the 'result-target' attribute is present");
                 } else {
-                    handleException("The 'result-type' attribute should be either 'JSON' or 'XML'");
+                    if ("JSON".equals(contentTypeAttr.getAttributeValue())) {
+                        mediator.setContentType(ForEachMediatorV2.JSON_TYPE);
+                    } else if ("XML".equals(contentTypeAttr.getAttributeValue())) {
+                        mediator.setContentType(ForEachMediatorV2.XML_TYPE);
+                    } else {
+                        handleException("The 'result-type' attribute should be either 'JSON' or 'XML'");
+                    }
+                    mediator.setResultTarget(resultTargetAttr.getAttributeValue());
                 }
-                mediator.setResultTarget(resultTargetAttr.getAttributeValue());
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ForEachMediatorSerializer.java
@@ -81,17 +81,22 @@ public class ForEachMediatorSerializer extends AbstractMediatorSerializer {
 
             if (forEachMediatorV2.getCollectionExpression() != null) {
                 SynapsePathSerializer.serializePath(forEachMediatorV2.getCollectionExpression(),
-                        forEachElem, "collection");
+                        forEachMediatorV2.getCollectionExpression().getExpression(), forEachElem, "collection");
             } else {
                 handleException("Missing collection of the ForEach which is required.");
             }
             forEachElem.addAttribute(fac.createOMAttribute(
                     "parallel-execution", nullNS, Boolean.toString(forEachMediatorV2.getParallelExecution())));
-            if (forEachMediatorV2.getResultTarget() != null) {
+            if (forEachMediatorV2.isContinueWithoutAggregation()) {
                 forEachElem.addAttribute(fac.createOMAttribute(
-                        "result-target", nullNS, forEachMediatorV2.getResultTarget()));
-                forEachElem.addAttribute(fac.createOMAttribute(
-                        "result-type", nullNS, forEachMediatorV2.getContentType()));
+                        "continue-without-aggregation", nullNS, "true"));
+            } else {
+                if (forEachMediatorV2.getResultTarget() != null) {
+                    forEachElem.addAttribute(fac.createOMAttribute(
+                            "result-target", nullNS, forEachMediatorV2.getResultTarget()));
+                    forEachElem.addAttribute(fac.createOMAttribute(
+                            "result-type", nullNS, forEachMediatorV2.getContentType()));
+                }
             }
             if (forEachMediatorV2.getCounterVariable() != null) {
                 forEachElem.addAttribute(fac.createOMAttribute(

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/ForEachMediatorSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/ForEachMediatorSerializationTest.java
@@ -57,4 +57,17 @@ public class ForEachMediatorSerializationTest extends AbstractTestCase {
         assertTrue(serialization(inputXml, foreachMediatorFactory, foreachMediatorSerializer));
         assertTrue(serialization(inputXml, foreachMediatorSerializer));
     }
+
+    public void testForEachMediatorV2_continueWithoutAggregation() throws Exception {
+        String inputXML = "<foreach collection=\"${payload.array}\" parallel-execution=\"true\" " +
+                "continue-without-aggregation=\"true\" xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<sequence>" +
+                "<log>" +
+                "<message>Processing payload ${payload}</message>" +
+                "</log>" +
+                "</sequence>" +
+                "</foreach>";
+        assertTrue(serialization(inputXML, foreachMediatorFactory, foreachMediatorSerializer));
+        assertTrue(serialization(inputXML, foreachMediatorSerializer));
+    }
 }


### PR DESCRIPTION
## Purpose

Add option to continue parent flow without waiting for aggregation in Foreach mediator V2

A new attribute `continue-without-aggregation` will be introduced to continue the parent flow without waiting for aggregation. Default value is `false`.

```xml
<foreach collection="${payload.products}" parallel-execution="true" continue-without-aggregation="true">
    <sequence>
        <log category="INFO">
            <message>Processing payload ${payload}</message>
        </log>
        <call>
            <endpoint key="Mocky"/>
        </call>
    </sequence>
</foreach>
```

Fixes: https://github.com/wso2/product-micro-integrator/issues/3922