### PR TITLE
Add REST method and full URL info to Log mediator message

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -33,6 +33,7 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.mediators.MediatorProperty;
 import org.apache.synapse.util.InlineExpressionUtil;
+import org.apache.synapse.util.logging.LoggingUtils;
 import org.apache.synapse.util.xpath.SynapseExpression;
 import org.jaxen.JaxenException;
 
@@ -114,6 +115,11 @@ public class LogMediator extends AbstractMediator {
             }
         }
 
+        if (this.getLogLevel() == MESSAGE_TEMPLATE) {
+            // Entry points info should be logged for audit logs only. Hence, the property "logEntryPointInfo"
+            // should be set at this point just before the audit logs and removed just after audit logs.
+            synCtx.setProperty(LoggingUtils.LOG_ENTRY_POINT_INFO, "true");
+        }
         switch (category) {
             case CATEGORY_INFO :
                 synLog.auditLog(getLogMessage(synCtx));
@@ -139,6 +145,7 @@ public class LogMediator extends AbstractMediator {
                 break;
         }
 
+        synCtx.getPropertyKeySet().remove(LoggingUtils.LOG_ENTRY_POINT_INFO);
         synLog.traceOrDebug("End : Log mediator");
 
         return true;

--- a/modules/core/src/main/java/org/apache/synapse/util/logging/LoggingUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/logging/LoggingUtils.java
@@ -20,7 +20,7 @@ package org.apache.synapse.util.logging;
 
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
-
+import org.apache.synapse.rest.RESTConstants;
 /**
  * Util class to get formatted logs for audit purposes.
  */
@@ -28,6 +28,7 @@ public class LoggingUtils {
 
     private static final String OPEN_BRACKETS = "{";
     private static final String CLOSE_BRACKETS = "}";
+    public static final String LOG_ENTRY_POINT_INFO = "logEntryPointInfo";
 
     private LoggingUtils() {
         // do nothing
@@ -42,7 +43,7 @@ public class LoggingUtils {
                 return getFormattedLog(SynapseConstants.PROXY_SERVICE_TYPE,
                                        artifactName.substring(SynapseConstants.PROXY_SERVICE_TYPE.length()), msg);
             } else if (artifactName.startsWith(SynapseConstants.FAIL_SAFE_MODE_API)) {
-                return getFormattedLog(SynapseConstants.FAIL_SAFE_MODE_API,
+                return getFormattedLogForAPI(synCtx, SynapseConstants.FAIL_SAFE_MODE_API,
                                        artifactName.substring(SynapseConstants.FAIL_SAFE_MODE_API.length()), msg);
             } else if (artifactName.startsWith(SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT)) {
                 return getFormattedLog(SynapseConstants.FAIL_SAFE_MODE_INBOUND_ENDPOINT, artifactName
@@ -51,6 +52,23 @@ public class LoggingUtils {
             return getFormattedString(artifactName, msg);
         }
         return msg.toString();
+    }
+
+    private static String getFormattedLogForAPI(MessageContext synCtx, String artifactType, Object artifactName,
+                                                Object msg) {
+        boolean logEntryPointInfo = Boolean.parseBoolean((String) synCtx.getProperty(LoggingUtils.LOG_ENTRY_POINT_INFO));
+        if (!logEntryPointInfo) {
+            return getFormattedLog(artifactType, artifactName, msg);
+        }
+        String name = artifactName != null ? artifactName.toString() : "";
+        String artifactInfo = artifactType.concat(":").concat(name);
+        String method = (String) synCtx.getProperty(RESTConstants.REST_METHOD);
+        String restFullRequestPath = (String) synCtx.getProperty(RESTConstants.REST_FULL_REQUEST_PATH);
+
+        String apiInfo = String.join(" ", artifactInfo, method != null ? method : "",
+                restFullRequestPath != null ? restFullRequestPath : "").trim();
+
+        return getFormattedString(apiInfo, msg);
     }
 
     public static String getFormattedLog(String artifactType, Object artifactName, Object msg) {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-micro-integrator/issues/3560

This PR adds the REST method and full URL info to the message printed from the Log mediator. 

Example: [2025-01-27 11:21:45,876]  INFO {LogMediator} - **{api:test:v1.0.0 GET /test/sample/path?queryParam=menu}** To:........