### PR TITLE
Handle no entity body requests in when processing connector response

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -729,6 +729,7 @@ public final class SynapseConstants {
     public static final String RESPONSE_VARIABLE = "responseVariable";
     public static final String OVERWRITE_BODY = "overwriteBody";
     public static final String ORIGINAL_PAYLOAD = "ORIGINAL_PAYLOAD";
+    public static final String BEFORE_INVOKE_TEMPLATE = "BEFORE_INVOKE_TEMPLATE";
 
     public static final String DEFAULT_ERROR_TYPE = "ANY";
     public static final String ERROR_STATS_REPORTED = "ERROR_STATS_REPORTED";

--- a/modules/core/src/main/java/org/apache/synapse/data/connector/DefaultConnectorResponse.java
+++ b/modules/core/src/main/java/org/apache/synapse/data/connector/DefaultConnectorResponse.java
@@ -39,7 +39,9 @@ public class DefaultConnectorResponse implements ConnectorResponse {
 
     @Override
     public void setHeaders(Map<String, Object> headers) {
-        this.headers = headers;
+        if (headers != null) {
+            this.headers = headers;
+        }
     }
 
     @Override
@@ -49,7 +51,9 @@ public class DefaultConnectorResponse implements ConnectorResponse {
 
     @Override
     public void setAttributes(Map<String, Object> attributes) {
-        this.attributes = attributes;
+        if (attributes != null) {
+            this.attributes = attributes;
+        }
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -122,6 +122,7 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
     public static final String IS_TARGET_AVAILABLE = "IS_TARGET_AVAILABLE";
     public static final String ORIGINAL_TRANSPORT_HEADERS = "_ORIGINAL_TRANSPORT_HEADERS";
     public static final String ORIGINAL_CONTENT_TYPE = "_ORIGINAL_CONTENT_TYPE";
+    public static final String ORIGINAL_NO_ENTITY_BODY = "_ORIGINAL_NO_ENTITY_BODY";
 
     public static final String JSON_TYPE = "application/json";
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

When GET/DELETE requests with no message body is sent, there is no need to enrich the payload. This PR also has some improvements related to handling null values in the ConnectorResponse.