### PR TITLE
Improve LibClassLoader to recursively add jars to classpath

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/ClassMediatorDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ClassMediatorDeployer.java
@@ -30,6 +30,7 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.libraries.LibClassLoader;
 
 import java.io.File;
+import java.net.MalformedURLException;
 
 public class ClassMediatorDeployer extends AbstractDeployer {
 
@@ -67,7 +68,11 @@ public class ClassMediatorDeployer extends AbstractDeployer {
         log.info("Deploying library from file : " + mediatorPath);
         ClassLoader classLoader = deploymentFileData.getClassLoader();
         if (classLoader instanceof LibClassLoader) {
-            classLoader = Utils.getClassLoader(classLoader, mediatorPath, false);
+            try {
+                ((LibClassLoader) deploymentFileData.getClassLoader()).addURL(new File(mediatorPath).toURI().toURL());
+            } catch (MalformedURLException e) {
+                throw new DeploymentException("Error adding URL to lib class loader", e);
+            }
         } else {
             classLoader = Utils.getClassLoader(ClassMediatorDeployer.class.getClassLoader(), mediatorPath, false);
         }

--- a/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
@@ -19,8 +19,11 @@
 
 package org.apache.synapse.libraries;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URLClassLoader;
 import java.net.URL;
+import java.util.ArrayList;
 
 public class LibClassLoader extends URLClassLoader {
 
@@ -32,6 +35,43 @@ public class LibClassLoader extends URLClassLoader {
     public void addURL(URL url) {
 
         super.addURL(url);
+    }
+
+    /**
+     * If a path of a jar is given, this method will add the jar to the classpath
+     * If the path is a directory, it will add all the jars in the directory to the classpath
+     *
+     * @param path directory to be added
+     * @throws MalformedURLException
+     */
+    public void addToClassPath(String path) throws MalformedURLException {
+
+        File file = new File(path);
+        ArrayList urls = new ArrayList();
+        urls.add(file.toURL());
+        File libfiles = new File(file, "lib");
+        if (!addFiles(urls, libfiles)) {
+            libfiles = new File(file, "Lib");
+            addFiles(urls, libfiles);
+        }
+        for (int i = 0; i < urls.size(); ++i) {
+            super.addURL((URL) urls.get(i));
+        }
+    }
+
+    private static boolean addFiles(ArrayList urls, final File libFiles) throws MalformedURLException {
+
+        if (libFiles.exists() && libFiles.isDirectory()) {
+            File[] files = libFiles.listFiles();
+            for (int i = 0; i < files.length; ++i) {
+                if (files[i].getName().endsWith(".jar")) {
+                    urls.add(files[i].toURL());
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
@@ -64,7 +64,7 @@ public class LibClassLoader extends URLClassLoader {
         if (libFiles.exists() && libFiles.isDirectory()) {
             File[] files = libFiles.listFiles();
             for (int i = 0; i < files.length; ++i) {
-                if (files[i].getName().endsWith(".jar")) {
+                if (!files[i].isDirectory() && files[i].getName().endsWith(".jar")) {
                     urls.add(files[i].toURL());
                 }
             }

--- a/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
@@ -78,7 +78,14 @@ public class LibDeployerUtils {
             try {
                 ClassLoader libLoader;
                 if (classLoader != null) {
-                    libLoader = Utils.getClassLoader(classLoader, extractPath, false);
+                    libLoader = classLoader;
+                    if (classLoader instanceof LibClassLoader) {
+                        try {
+                            ((LibClassLoader) classLoader).addToClassPath(extractPath);
+                        } catch (MalformedURLException e) {
+                            throw new DeploymentException("Error while adding URL to the classloader", e);
+                        }
+                    }
                 } else {
                     libLoader = Utils.getClassLoader(LibDeployerUtils.class.getClassLoader(),
                             extractPath, false);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This is to improve the deployment of connectors which have libs inside them. Connectors like CSV module, have other libs within the zip (inside "lib" directory). When Utils.getClassLoader is called, the libs are recursively added to the classpath. But since we need to reuse the LibClassLoader when adding multiple connector dependencies to the CApp, an improvement has been made to LibClassLoader to resemble https://github.com/wso2/wso2-axis2/blob/v1.6.1-wso2v102/modules/kernel/src/org/apache/axis2/deployment/util/Utils.java#L341