### PR TITLE
Improve LibClassLoader to load child first libraries

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/LibClassLoader.java
@@ -74,4 +74,24 @@ public class LibClassLoader extends URLClassLoader {
         }
     }
 
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        // Check if the class has already been loaded
+        Class<?> clazz = findLoadedClass(name);
+
+        if (clazz == null) {
+            try {
+                // Try to find the class in the current class loader
+                clazz = findClass(name);
+            } catch (ClassNotFoundException e) {
+                // If not found, delegate to parent class loader
+                clazz = super.loadClass(name, resolve);
+            }
+        }
+
+        if (resolve) {
+            resolveClass(clazz);
+        }
+        return clazz;
+    }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

By default URLClassLoaders load classes from parent first. But since we are dealing with connector dependencies, they need to be resolved from the child first.

