### PR TITLE
Introduce a new attribute to log mediator to print full log message

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/LogMediatorFactory.java
@@ -57,6 +57,7 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
     private static final QName ATT_CATEGORY = new QName("category");
     protected static final QName ELEMENT_MESSAGE_Q
             = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "message");
+    private static final QName ATT_LOG_FULL_PAYLOAD = new QName("logFullPayload");
 
     public QName getTagQName() {
         return LOG_Q;
@@ -84,9 +85,12 @@ public class LogMediatorFactory extends AbstractMediatorFactory  {
             }
         }
 
+        OMAttribute logFullPayload = elem.getAttribute(ATT_LOG_FULL_PAYLOAD);
         // Set the high level set of properties to be logged (i.e. log level)
         OMAttribute level = elem.getAttribute(ATT_LEVEL);
-        if (level != null) {
+        if (logFullPayload != null && Boolean.parseBoolean(logFullPayload.getAttributeValue())) {
+            logMediator.setLogLevel(LogMediator.FULL);
+        } else if (level != null) {
             String levelstr = level.getAttributeValue();
             if (SIMPLE.equals(levelstr)) {
                 logMediator.setLogLevel(LogMediator.SIMPLE);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Eg: 

```
<log logFullPayload="true">
                <message>Received request for current weather</message>
                <property name="message" value="Received request for current weather"/>
            </log>
```

This will print the log as below.
```
[2025-02-06 16:45:19,372]  INFO {LogMediator} - {api:WeatherIntegration} Received request for current weather, To: /weather/current, MessageID: urn:uuid:b04e389b-e86b-4675-b1ea-66fbbb69a677, correlation_id: b04e389b-e86b-4675-b1ea-66fbbb69a677, Direction: request, message = Received request for current weather, Payload: [
  {
    "orderId": 1,
    "name": "T-shirt",
    "units": 2,
    "pricePerUnit": 10
  },
  {
    "orderId": 2,
    "name": "Jacket",
    "units": 4,
    "pricePerUnit": 5
  }
]
```
