### PR TITLE
Add explicit checks for function names

### DIFF
--- a/modules/core/src/main/antlr4/org/apache/synapse/util/synapse_expression/ExpressionLexer.g4
+++ b/modules/core/src/main/antlr4/org/apache/synapse/util/synapse_expression/ExpressionLexer.g4
@@ -44,6 +44,16 @@ QUOTE: '"' | '\'';
 BOOLEAN_LITERAL: 'true' | 'false';
 NUMBER: '-'? [0-9]+ ('.' [0-9]+)?;
 
+PARAM_ACCESS: 'queryParams' | 'pathParams' | 'functionParams';
+PROPERTY_ACCESS: 'axis2' | 'synapse';
+FUNCTIONS: 'length' | 'toUpper' | 'toLower' | 'subString' | 'startsWith' | 'endsWith' | 'contains' | 'trim' | 'replace'
+    | 'split' | 'indexOf' | 'now' | 'formatDateTime' | 'charAt' | 'abs' | 'ceil' | 'floor' | 'sqrt' | 'log' | 'pow'
+    | 'base64encode' | 'base64decode' | 'urlEncode' | 'urlDecode' | 'isString' | 'isNumber' | 'isArray' | 'isObject'
+    | 'string' | 'float' | 'boolean' | 'integer' | 'round' | 'exists' | 'xpath' | 'wso2-vault' | 'hashicorp-vault'
+    | 'not' | 'registry' | 'object' | 'array' ;
+
+SECONDARY_FUNCTIONS: 'property';
+
 
 STRING_LITERAL : ('"' (ESC | ~["\\])* '"' | '\'' (ESC | ~['\\])* '\'');
 

--- a/modules/core/src/main/antlr4/org/apache/synapse/util/synapse_expression/ExpressionParser.g4
+++ b/modules/core/src/main/antlr4/org/apache/synapse/util/synapse_expression/ExpressionParser.g4
@@ -50,6 +50,10 @@ keywords
     | DOT CONFIG
     | DOT PARAMS
     | DOT PROPERTY
+    | DOT PARAM_ACCESS
+    | DOT PROPERTY_ACCESS
+    | DOT FUNCTIONS
+    | DOT SECONDARY_FUNCTIONS
     ;
 
 configAccess
@@ -61,11 +65,11 @@ headerAccess
     ;
 
 parameterAccess
-    : PARAMS (DOT ID  propertyName)
+    : PARAMS (DOT PARAM_ACCESS  propertyName)
     ;
 
 propertyAccess
-    : PROPERTY (DOT ID  propertyName)
+    : PROPERTY (DOT PROPERTY_ACCESS  propertyName)
     ;
 
 propertyName
@@ -156,10 +160,10 @@ stringOrOperator
 
 
 functionCall
-    : ID LPAREN (expression (COMMA expression)*)? RPAREN functionCallSuffix?
+    : FUNCTIONS LPAREN (expression (COMMA expression)*)? RPAREN functionCallSuffix?
     ;
 
 functionCallSuffix
-    : DOT ID LPAREN (expression (COMMA expression)*)? RPAREN   // Method chaining
+    : DOT SECONDARY_FUNCTIONS LPAREN (expression (COMMA expression)*)? RPAREN   // Method chaining
     | jsonPathExpression
     ;

--- a/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/visitor/ExpressionVisitor.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/synapse/expression/visitor/ExpressionVisitor.java
@@ -166,8 +166,8 @@ public class ExpressionVisitor extends ExpressionParserBaseVisitor<ExpressionNod
                 parameterList.addArgument(visit(expressionContext));
             }
         }
-        if (ctx.ID() != null) {
-            String functionName = ctx.ID().getText();
+        if (ctx.FUNCTIONS() != null) {
+            String functionName = ctx.FUNCTIONS().getText();
             switch (functionName) {
                 case ExpressionConstants.LENGTH:
                     return new PredefinedFunctionNode(parameterList, ExpressionConstants.LENGTH);
@@ -247,9 +247,9 @@ public class ExpressionVisitor extends ExpressionParserBaseVisitor<ExpressionNod
                     return new PredefinedFunctionNode(parameterList, ExpressionConstants.NOT);
                 case ExpressionConstants.REGISTRY:
                     if (ctx.functionCallSuffix() != null) {
-                        if (ctx.functionCallSuffix().ID() != null &&
-                                ExpressionConstants.PROPERTY.equals(ctx.functionCallSuffix().ID().getText()) &&
-                                !ctx.functionCallSuffix().expression().isEmpty()) {
+                        if (ctx.functionCallSuffix().SECONDARY_FUNCTIONS() != null &&
+                                ExpressionConstants.PROPERTY.equals(ctx.functionCallSuffix().SECONDARY_FUNCTIONS()
+                                        .getText()) && !ctx.functionCallSuffix().expression().isEmpty()) {
                             parameterList.addArgument(visit(ctx.functionCallSuffix().expression(0)));
                             return new PredefinedFunctionNode(parameterList, ExpressionConstants.REGISTRY);
                         } else if (ctx.functionCallSuffix().jsonPathExpression() != null) {
@@ -531,8 +531,8 @@ public class ExpressionVisitor extends ExpressionParserBaseVisitor<ExpressionNod
             log.debug("Visiting property access: " + ctx.getText());
         }
         if (ctx.propertyName() != null) {
-            if (ctx.ID() != null) {
-                String scope = ctx.ID().getText();
+            if (ctx.PROPERTY_ACCESS() != null) {
+                String scope = ctx.PROPERTY_ACCESS().getText();
                 switch (scope) {
                     case ExpressionConstants.AXIS2:
                         return new HeadersAndPropertiesAccessNode(visit(ctx.propertyName()), ExpressionConstants.AXIS2);
@@ -550,8 +550,8 @@ public class ExpressionVisitor extends ExpressionParserBaseVisitor<ExpressionNod
             log.debug("Visiting parameter access: " + ctx.getText());
         }
         if (ctx.propertyName() != null) {
-            if (ctx.ID() != null) {
-                String scope = ctx.ID().getText();
+            if (ctx.PARAM_ACCESS() != null) {
+                String scope = ctx.PARAM_ACCESS().getText();
                 switch (scope) {
                     case ExpressionConstants.QUERY_PARAM:
                         return new HeadersAndPropertiesAccessNode(visit(ctx.propertyName()),


### PR DESCRIPTION


## Purpose
>Add explicit checks for function and param access expressions With this fix, it will throw errors for expressions with invalid function names in deployment time.
Fixes wso2/mi-vscode/issues/837