### PR TITLE
Code cleanup regarding endpoint deploying and handling certificates in local entry deployer

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/deployers/LocalEntryDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/LocalEntryDeployer.java
@@ -123,27 +123,21 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
 
             //Set the car name
             ep.setArtifactContainerName(customLogContent);
-            if (ep != null) {
-                ep.setFileName((new File(fileName)).getName());
-                if (log.isDebugEnabled()) {
-                    log.debug("Endpoint named '" + ep.getName() + "' has been built from the http connection file " +
-                            fileName);
-                }
-                ep.init(getSynapseEnvironment());
-                if (log.isDebugEnabled()) {
-                    log.debug("Initialized the endpoint : " + ep.getName());
-                }
-                getSynapseConfiguration().addEndpoint(ep.getName(), ep);
-                if (log.isDebugEnabled()) {
-                    log.debug("Endpoint Deployment from the http connection file : " + fileName + " : Completed");
-                }
-                log.info("Endpoint named '" + ep.getName() + "' has been deployed from the http connection file : " +
+            ep.setFileName((new File(fileName)).getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Endpoint named '" + ep.getName() + "' has been built from the http connection file " +
                         fileName);
-            } else {
-                handleSynapseArtifactDeploymentError(
-                        "Endpoint Deployment Failed. The artifact " + "described in the http connection file " +
-                                fileName + " has filed to describe an Endpoint");
             }
+            ep.init(getSynapseEnvironment());
+            if (log.isDebugEnabled()) {
+                log.debug("Initialized the endpoint : " + ep.getName());
+            }
+            getSynapseConfiguration().addEndpoint(ep.getName(), ep);
+            if (log.isDebugEnabled()) {
+                log.debug("Endpoint Deployment from the http connection file : " + fileName + " : Completed");
+            }
+            log.info("Endpoint named '" + ep.getName() + "' has been deployed from the http connection file : " +
+                    fileName);
         } catch (Exception e) {
             handleSynapseArtifactDeploymentError(
                     "Endpoint Deployment from the http connection file : " + fileName + " : Failed.", e);

--- a/modules/core/src/main/java/org/apache/synapse/deployers/LocalEntryDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/LocalEntryDeployer.java
@@ -108,9 +108,8 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
 
     private void deployEndpointsForHTTPConnection(OMElement artifactConfig, String fileName, Properties properties) {
 
-        OMElement httpInitElement =
-                artifactConfig.getFirstChildWithName(
-                        new QName(SynapseConstants.SYNAPSE_NAMESPACE, HTTP_CONNECTION_IDENTIFIER));
+        OMElement httpInitElement = artifactConfig.getFirstChildWithName(
+                new QName(SynapseConstants.SYNAPSE_NAMESPACE, HTTP_CONNECTION_IDENTIFIER));
         if (httpInitElement != null) {
             OMElement generatedEndpointElement = HTTPConnectionUtils.generateHTTPEndpointOMElement(httpInitElement);
             deployHTTPEndpointForElement(generatedEndpointElement, fileName, properties);
@@ -127,8 +126,8 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
             if (ep != null) {
                 ep.setFileName((new File(fileName)).getName());
                 if (log.isDebugEnabled()) {
-                    log.debug("Endpoint named '" + ep.getName()
-                            + "' has been built from the http connection file " + fileName);
+                    log.debug("Endpoint named '" + ep.getName() + "' has been built from the http connection file " +
+                            fileName);
                 }
                 ep.init(getSynapseEnvironment());
                 if (log.isDebugEnabled()) {
@@ -138,22 +137,23 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
                 if (log.isDebugEnabled()) {
                     log.debug("Endpoint Deployment from the http connection file : " + fileName + " : Completed");
                 }
-                log.info("Endpoint named '" + ep.getName()
-                        + "' has been deployed from the http connection file : " + fileName);
+                log.info("Endpoint named '" + ep.getName() + "' has been deployed from the http connection file : " +
+                        fileName);
             } else {
-                handleSynapseArtifactDeploymentError("Endpoint Deployment Failed. The artifact " +
-                        "described in the http connection file " + fileName + " has filed to describe an Endpoint");
+                handleSynapseArtifactDeploymentError(
+                        "Endpoint Deployment Failed. The artifact " + "described in the http connection file " +
+                                fileName + " has filed to describe an Endpoint");
             }
         } catch (Exception e) {
-            handleSynapseArtifactDeploymentError("Endpoint Deployment from the http connection file : "
-                    + fileName + " : Failed.", e);
+            handleSynapseArtifactDeploymentError(
+                    "Endpoint Deployment from the http connection file : " + fileName + " : Failed.", e);
         }
     }
 
     private void handleSSLSenderCertificates(OMElement element) throws DeploymentException {
 
-        OMElement httpInitElement =
-                element.getFirstChildWithName(new QName(SynapseConstants.SYNAPSE_NAMESPACE, HTTP_CONNECTION_IDENTIFIER));
+        OMElement httpInitElement = element.getFirstChildWithName(
+                new QName(SynapseConstants.SYNAPSE_NAMESPACE, HTTP_CONNECTION_IDENTIFIER));
         if (httpInitElement != null) {
             Iterator childElementIterator = httpInitElement.getChildElements();
             while (childElementIterator.hasNext()) {
@@ -168,21 +168,25 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
         }
     }
 
-    private void loadCertificateFileToSSLSenderTrustStore(String certificateFileResourceKey) throws DeploymentException {
+    private void loadCertificateFileToSSLSenderTrustStore(String certificateFileResourceKey)
+            throws DeploymentException {
 
-        String certificateFilePath = getSynapseConfiguration().getRegistry().getRegistryEntry(certificateFileResourceKey).getName();
+        String certificateFilePath =
+                getSynapseConfiguration().getRegistry().getRegistryEntry(certificateFileResourceKey).getName();
         File certificateFile = new File(certificateFilePath);
         String certificateAlias = certificateFile.getName().split("\\.")[0];
         SslSenderTrustStoreHolder sslSenderTrustStoreHolder = SslSenderTrustStoreHolder.getInstance();
         if (sslSenderTrustStoreHolder.isValid()) {
-            try (FileInputStream certificateFileInputStream = FileUtils.openInputStream(new File(certificateFilePath))) {
+            try (FileInputStream certificateFileInputStream = FileUtils.openInputStream(
+                    new File(certificateFilePath))) {
                 KeyStore sslSenderTrustStore = sslSenderTrustStoreHolder.getKeyStore();
 
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 Certificate certificate = certificateFactory.generateCertificate(certificateFileInputStream);
                 sslSenderTrustStore.setCertificateEntry(certificateAlias, certificate);
 
-                try (FileOutputStream fileOutputStream = new FileOutputStream(sslSenderTrustStoreHolder.getLocation())) {
+                try (FileOutputStream fileOutputStream = new FileOutputStream(
+                        sslSenderTrustStoreHolder.getLocation())) {
                     sslSenderTrustStore.store(fileOutputStream, sslSenderTrustStoreHolder.getPassword().toCharArray());
                 }
             } catch (CertificateException | IOException | KeyStoreException | NoSuchAlgorithmException e) {
@@ -192,18 +196,18 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
     }
 
     private void loadUpdatedSSL() throws DeploymentException {
+
         SslSenderTrustStoreHolder sslSenderTrustStoreHolder = SslSenderTrustStoreHolder.getInstance();
         KeyStore sslSenderTrustStore = sslSenderTrustStoreHolder.getKeyStore();
         if (sslSenderTrustStoreHolder.isValid()) {
-            try (
-                    FileInputStream fileInputStream = new FileInputStream(sslSenderTrustStoreHolder.getLocation());
-                    InputStream bufferedInputStream = IOUtils.toBufferedInputStream(fileInputStream)
-            ) {
+            try (FileInputStream fileInputStream = new FileInputStream(sslSenderTrustStoreHolder.getLocation());
+                 InputStream bufferedInputStream = IOUtils.toBufferedInputStream(fileInputStream)) {
                 sslSenderTrustStore.load(bufferedInputStream, sslSenderTrustStoreHolder.getPassword().toCharArray());
                 sslSenderTrustStoreHolder.setKeyStore(sslSenderTrustStore);
                 KeyStoreReloaderHolder.getInstance().reloadAllKeyStores();
             } catch (IOException | CertificateException | NoSuchAlgorithmException e) {
-                throw new DeploymentException("Failed to load updated SSL configuration from the trust store at: " + sslSenderTrustStoreHolder.getLocation(), e);
+                throw new DeploymentException("Failed to load updated SSL configuration from the trust store at: " +
+                        sslSenderTrustStoreHolder.getLocation(), e);
             }
         }
     }
@@ -215,9 +219,11 @@ public class LocalEntryDeployer extends AbstractSynapseArtifactDeployer {
      * @return the transformed element value
      */
     private String getTransformedElementValue(String elementValue) {
+
         String transformedElementValue = elementValue.trim();
         if (transformedElementValue.startsWith(RESOURCES_IDENTIFIER)) {
-            transformedElementValue = transformedElementValue.replace(RESOURCES_IDENTIFIER, CONVERTED_RESOURCES_IDENTIFIER);
+            transformedElementValue =
+                    transformedElementValue.replace(RESOURCES_IDENTIFIER, CONVERTED_RESOURCES_IDENTIFIER);
         }
         return transformedElementValue;
     }

--- a/modules/core/src/main/java/org/apache/synapse/util/HTTPConnectionUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/HTTPConnectionUtils.java
@@ -72,8 +72,8 @@ public class HTTPConnectionUtils {
         endpoint.addChild(http);
 
         if (StringUtils.isNotEmpty(connectionElements.get(SynapseConstants.MISCELLANEOUS_PROPERTIES))) {
-            List<OMElement> miscellaneousProperties = generateMiscellaneousPropertiesElement(
-                    factory, synapseNS, connectionElements.get(SynapseConstants.MISCELLANEOUS_PROPERTIES));
+            List<OMElement> miscellaneousProperties = generateMiscellaneousPropertiesElement(factory, synapseNS,
+                    connectionElements.get(SynapseConstants.MISCELLANEOUS_PROPERTIES));
             for (OMElement property : miscellaneousProperties) {
                 endpoint.addChild(property);
             }
@@ -94,15 +94,14 @@ public class HTTPConnectionUtils {
      * @param http               the OMElement representing the HTTP endpoint
      * @param connectionElements the map containing the HTTP connection parameters
      */
-    private static void populateEnableSecurityElement(OMFactory factory, OMNamespace synapseNS,
-                                                      OMElement http, Map<String, String> connectionElements) {
+    private static void populateEnableSecurityElement(OMFactory factory, OMNamespace synapseNS, OMElement http,
+                                                      Map<String, String> connectionElements) {
 
         if (SynapseConstants.ENABLE.equalsIgnoreCase(
                 connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_SECURITY_OPTION))) {
             OMElement enableSecurity = factory.createOMElement(SynapseConstants.ENABLE_SECURITY, synapseNS);
-            if (SynapseConstants.ENABLE.equalsIgnoreCase(
-                    connectionElements.get(
-                            SynapseConstants.QUALITY_OF_SERVICE_SECURITY_INBOUND_OUTBOUND_POLICY_OPTION))) {
+            if (SynapseConstants.ENABLE.equalsIgnoreCase(connectionElements.get(
+                    SynapseConstants.QUALITY_OF_SERVICE_SECURITY_INBOUND_OUTBOUND_POLICY_OPTION))) {
                 if (StringUtils.isNotEmpty(
                         connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_SECURITY_INBOUND_POLICY_KEY))) {
                     enableSecurity.addAttribute(SynapseConstants.INBOUND_POLICY,
@@ -140,12 +139,11 @@ public class HTTPConnectionUtils {
         if (SynapseConstants.ENABLE.equalsIgnoreCase(
                 connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_OPTION))) {
             OMElement enableAddressing = factory.createOMElement(SynapseConstants.ENABLE_ADDRESSING, synapseNS);
-            if (SynapseConstants.ENABLE.equalsIgnoreCase(connectionElements.get(
-                    SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_SEPARATE_LISTENER))) {
+            if (SynapseConstants.ENABLE.equalsIgnoreCase(
+                    connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_SEPARATE_LISTENER))) {
                 enableAddressing.addAttribute(SynapseConstants.SEPARATE_LISTENER, "true", null);
             }
-            if (StringUtils.isNotEmpty(connectionElements.get(
-                    SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_VERSION))) {
+            if (StringUtils.isNotEmpty(connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_VERSION))) {
                 enableAddressing.addAttribute(SynapseConstants.VERSION,
                         connectionElements.get(SynapseConstants.QUALITY_OF_SERVICE_ADDRESS_VERSION), null);
             }
@@ -162,8 +160,8 @@ public class HTTPConnectionUtils {
      * @param http               the OMElement representing the HTTP endpoint
      * @param connectionElements the map containing the HTTP connection parameters
      */
-    private static void populateAuthenticationElement(OMFactory factory, OMNamespace synapseNS,
-                                                      OMElement http, Map<String, String> connectionElements) {
+    private static void populateAuthenticationElement(OMFactory factory, OMNamespace synapseNS, OMElement http,
+                                                      Map<String, String> connectionElements) {
 
         if (StringUtils.isNotEmpty(connectionElements.get(SynapseConstants.AUTH_TYPE))) {
             if (SynapseConstants.BASIC_AUTH.equalsIgnoreCase(connectionElements.get(SynapseConstants.AUTH_TYPE))) {
@@ -315,8 +313,8 @@ public class HTTPConnectionUtils {
      * @param httpEndpointElement the OMElement representing the HTTP endpoint
      * @param connectionElements  the map containing the HTTP connection parameters
      */
-    private static void populateTimeoutElement(OMFactory factory, OMNamespace synapseNS,
-                                               OMElement httpEndpointElement, Map<String, String> connectionElements) {
+    private static void populateTimeoutElement(OMFactory factory, OMNamespace synapseNS, OMElement httpEndpointElement,
+                                               Map<String, String> connectionElements) {
 
         if (StringUtils.isNotEmpty(connectionElements.get(SynapseConstants.TIMEOUT_DURATION)) ||
                 StringUtils.isNotEmpty(connectionElements.get(SynapseConstants.TIMEOUT_ACTION))) {
@@ -385,8 +383,7 @@ public class HTTPConnectionUtils {
     private static OMElement generateOAuthPasswordCredentialsElement(OMFactory factory, OMNamespace synapseNS,
                                                                      String username, String password, String clientId,
                                                                      String clientSecret, String tokenUrl,
-                                                                     String authMode,
-                                                                     String oauthAdditionalProperties,
+                                                                     String authMode, String oauthAdditionalProperties,
                                                                      String connectionTimeout,
                                                                      String connectionRequestTimeout,
                                                                      String socketTimeout) {
@@ -406,8 +403,8 @@ public class HTTPConnectionUtils {
         passwordCredentials.addChild(clientSecretElement);
         passwordCredentials.addChild(tokenUrlElement);
         passwordCredentials.addChild(authModeElement);
-        handleOAuthTimeouts(
-                factory, synapseNS, passwordCredentials, connectionTimeout, connectionRequestTimeout, socketTimeout);
+        handleOAuthTimeouts(factory, synapseNS, passwordCredentials, connectionTimeout, connectionRequestTimeout,
+                socketTimeout);
 
         if (StringUtils.isNotEmpty(oauthAdditionalProperties)) {
             OMElement additionalProperties =
@@ -453,7 +450,8 @@ public class HTTPConnectionUtils {
         clientCredentials.addChild(oauthClientSecret);
         clientCredentials.addChild(oauthTokenUrl);
         clientCredentials.addChild(authorizationMode);
-        handleOAuthTimeouts(factory, synapseNS, clientCredentials, connectionTimeout, connectionRequestTimeout, socketTimeout);
+        handleOAuthTimeouts(factory, synapseNS, clientCredentials, connectionTimeout, connectionRequestTimeout,
+                socketTimeout);
 
         if (StringUtils.isNotEmpty(oauthAdditionalProperties)) {
             OMElement additionalProperties =
@@ -478,11 +476,13 @@ public class HTTPConnectionUtils {
                                             String socketTimeout) {
 
         if (StringUtils.isNotEmpty(connectionTimeout)) {
-            OMElement connectionTimeoutElement = generateOAuthConnectionTimeoutElement(factory, synapseNS, connectionTimeout);
+            OMElement connectionTimeoutElement =
+                    generateOAuthConnectionTimeoutElement(factory, synapseNS, connectionTimeout);
             targetOAuthElement.addChild(connectionTimeoutElement);
         }
         if (StringUtils.isNotEmpty(connectionRequestTimeout)) {
-            OMElement connectionRequestTimeoutElement = generateOAuthConnectionRequestTimeoutElement(factory, synapseNS, connectionRequestTimeout);
+            OMElement connectionRequestTimeoutElement =
+                    generateOAuthConnectionRequestTimeoutElement(factory, synapseNS, connectionRequestTimeout);
             targetOAuthElement.addChild(connectionRequestTimeoutElement);
         }
         if (StringUtils.isNotEmpty(socketTimeout)) {
@@ -494,12 +494,13 @@ public class HTTPConnectionUtils {
     /**
      * Generates an OMElement representing the OAuth socket timeout.
      *
-     * @param factory           the OMFactory used to create OMElements
-     * @param synapseNS         the OMNamespace for the Synapse configuration
-     * @param socketTimeout     the socket timeout
+     * @param factory       the OMFactory used to create OMElements
+     * @param synapseNS     the OMNamespace for the Synapse configuration
+     * @param socketTimeout the socket timeout
      * @return the OMElement representing the OAuth socket timeout
      */
-    private static OMElement generateOAuthSocketTimeoutElement(OMFactory factory, OMNamespace synapseNS, String socketTimeout) {
+    private static OMElement generateOAuthSocketTimeoutElement(OMFactory factory, OMNamespace synapseNS,
+                                                               String socketTimeout) {
 
         OMElement oauthSocketTimeout = factory.createOMElement(SynapseConstants.SOCKET_TIMEOUT, synapseNS);
         oauthSocketTimeout.setText(socketTimeout);
@@ -509,14 +510,16 @@ public class HTTPConnectionUtils {
     /**
      * Generates an OMElement representing the OAuth connection request timeout.
      *
-     * @param factory                the OMFactory used to create OMElements
-     * @param synapseNS              the OMNamespace for the Synapse configuration
+     * @param factory                  the OMFactory used to create OMElements
+     * @param synapseNS                the OMNamespace for the Synapse configuration
      * @param connectionRequestTimeout the connection request timeout
      * @return the OMElement representing the OAuth connection request timeout
      */
-    private static OMElement generateOAuthConnectionRequestTimeoutElement(OMFactory factory, OMNamespace synapseNS, String connectionRequestTimeout) {
+    private static OMElement generateOAuthConnectionRequestTimeoutElement(OMFactory factory, OMNamespace synapseNS,
+                                                                          String connectionRequestTimeout) {
 
-        OMElement oauthConnectionRequestTimeout = factory.createOMElement(SynapseConstants.CONNECTION_REQUEST_TIMEOUT, synapseNS);
+        OMElement oauthConnectionRequestTimeout =
+                factory.createOMElement(SynapseConstants.CONNECTION_REQUEST_TIMEOUT, synapseNS);
         oauthConnectionRequestTimeout.setText(connectionRequestTimeout);
         return oauthConnectionRequestTimeout;
     }
@@ -573,7 +576,8 @@ public class HTTPConnectionUtils {
         authorizationCode.addChild(oauthClientSecret);
         authorizationCode.addChild(oauthTokenUrl);
         authorizationCode.addChild(authorizationMode);
-        handleOAuthTimeouts(factory, synapseNS, authorizationCode, connectionTimeout, connectionRequestTimeout, socketTimeout);
+        handleOAuthTimeouts(factory, synapseNS, authorizationCode, connectionTimeout, connectionRequestTimeout,
+                socketTimeout);
 
         if (StringUtils.isNotEmpty(oauthAdditionalProperties)) {
             OMElement additionalProperties =

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloader.java
@@ -22,18 +22,18 @@ import org.apache.axis2.description.ParameterInclude;
 
 public class KeyStoreReloader {
 
-    private IKeyStoreLoader keyStoreLoader;
-    private ParameterInclude transportOutDescription;
+    private final IKeyStoreLoader keyStoreLoader;
+    private final ParameterInclude transportOutDescription;
 
     public KeyStoreReloader(IKeyStoreLoader keyStoreLoader, ParameterInclude transportOutDescription) {
 
         this.keyStoreLoader = keyStoreLoader;
         this.transportOutDescription = transportOutDescription;
 
-        registerListener(transportOutDescription);
+        registerListener();
     }
 
-    private void registerListener(ParameterInclude transportOutDescription) {
+    private void registerListener() {
 
         KeyStoreReloaderHolder.getInstance().addKeyStoreLoader(this);
     }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/dynamicconfigurations/KeyStoreReloaderHolder.java
@@ -24,8 +24,8 @@ import java.util.List;
 
 public class KeyStoreReloaderHolder {
 
-    private static KeyStoreReloaderHolder instance = new KeyStoreReloaderHolder();
-    private List<KeyStoreReloader> keyStoreLoaders;
+    private final static KeyStoreReloaderHolder instance = new KeyStoreReloaderHolder();
+    private final List<KeyStoreReloader> keyStoreLoaders;
 
     private KeyStoreReloaderHolder() {
         keyStoreLoaders = new ArrayList<>();


### PR DESCRIPTION
## Purpose
Introduce following changes:
- wrap lines at 120 characters in `LocalEntryDeployer` and `HTTPConnectionUtils`.
- convert immutable variables to final in `KeyStoreReloader` and `KeyStoreReloaderHolder`
- remove identified redundant null check