### PR TITLE
Include allowedResponseProperties when creating the client worker

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -534,7 +534,8 @@ public class TargetHandler implements NHttpClientEventHandler {
             }
 
             WorkerPool workerPool = targetConfiguration.getWorkerPool();
-            ClientWorker clientWorker = new ClientWorker(targetConfiguration, requestMsgContext, targetResponse);
+            ClientWorker clientWorker = new ClientWorker(targetConfiguration, requestMsgContext, targetResponse,
+                    allowedResponseProperties);
             conn.getContext().setAttribute(PassThroughConstants.CLIENT_WORKER_REFERENCE, clientWorker);
             workerPool.execute(clientWorker);
 


### PR DESCRIPTION
Pass the parameter `allowedResponseProperties` when creating the client worker to allow request message context properties to be passed to the response.

Related issue: https://github.com/wso2/api-manager/issues/3772