### PR TITLE
Fix Thread Pool Exhaustion, Enhance OAuth Timeout Handling, and Resolve Proxy Password Issue

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ProxyConfigs.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ProxyConfigs.java
@@ -18,6 +18,7 @@
 
 package org.apache.synapse.endpoints;
 
+import org.wso2.securevault.SecretResolver;
 /**
  * This class represents a model for proxy configurations which is used for the OAuth authentication of endpoints
  */
@@ -28,6 +29,7 @@ public class ProxyConfigs {
     private String proxyPassword;
     private String proxyProtocol;
     private boolean proxyEnabled;
+    private SecretResolver proxyPasswordSecretResolver;
 
     public void setProxyEnabled(boolean proxyEnabled) {
         this.proxyEnabled = proxyEnabled;
@@ -75,6 +77,14 @@ public class ProxyConfigs {
 
     public String getProxyProtocol() {
         return proxyProtocol;
+    }
+
+    public void setProxyPasswordSecretResolver(SecretResolver proxyPasswordSecretResolver) {
+        this.proxyPasswordSecretResolver = proxyPasswordSecretResolver;
+    }
+
+    public SecretResolver getProxyPasswordSecretResolver() {
+        return proxyPasswordSecretResolver;
     }
 }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -33,6 +33,7 @@ public class AuthConstants {
     public static final String OAUTH_CLIENT_ID = "clientId";
     public static final String OAUTH_CLIENT_SECRET = "clientSecret";
     public static final String OAUTH_AUTHENTICATION_MODE = "authMode";
+    public static final String USE_GLOBAL_PROXY_CONFIGS = "useGlobalProxyConfigs";
     public static final String OAUTH_USERNAME = "username";
     public static final String OAUTH_PASSWORD = "password";
     public static final String OAUTH_REFRESH_TOKEN = "refreshToken";
@@ -42,11 +43,13 @@ public class AuthConstants {
     public static final String CUSTOM_HEADER = "header";
     public static final String NAME = "name";
 
+    public static final String USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS = "useGlobalConnectionTimeoutConfigs";
     public static final String OAUTH_CONNECTION_TIMEOUT = "connectionTimeout";
-
     public static final String OAUTH_CONNECTION_REQUEST_TIMEOUT = "connectionRequestTimeout";
-
     public static final String OAUTH_SOCKET_TIMEOUT = "socketTimeout";
+    public static final String OAUTH_GLOBAL_CONNECTION_TIMEOUT = "synapse.endpoint.http.oauth.token.endpoint.global.connection.timeout";
+    public static final String OAUTH_GLOBAL_CONNECTION_REQUEST_TIMEOUT = "synapse.endpoint.http.oauth.token.endpoint.global.connection.request.timeout";
+    public static final String OAUTH_GLOBAL_SOCKET_TIMEOUT = "synapse.endpoint.http.oauth.token.endpoint.global.socket.timeout";
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER = "Bearer ";
@@ -93,6 +96,12 @@ public class AuthConstants {
     public static final String PROXY_USERNAME = "proxyUsername";
     public static final String PROXY_PASSWORD = "proxyPassword";
     public static final String OAUTH_PROXY_PROTOCOL = "proxyProtocol";
+    public static final String OAUTH_GLOBAL_PROXY_ENABLED = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.enabled";
+    public static final String OAUTH_GLOBAL_PROXY_HOST = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.host";
+    public static final String OAUTH_GLOBAL_PROXY_PORT = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.port";
+    public static final String OAUTH_GLOBAL_PROXY_USERNAME = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.username";
+    public static final String OAUTH_GLOBAL_PROXY_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.password";
+    public static final String OAUTH_GLOBAL_PROXY_PROTOCOL = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol";
 
     public static final String HTTPS_PROTOCOL = "https";
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -37,11 +37,13 @@ public class AuthorizationCodeHandler extends OAuthHandler {
     private final String refreshToken;
 
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret, String refreshToken,
-            String authMode, int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
-            TokenCacheProvider tokenCacheProvider, ProxyConfigs proxyConfigs) {
+                                    String authMode, boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                                    int connectionRequestTimeout, int socketTimeout,
+                                    TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                    ProxyConfigs proxyConfigs) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                tokenCacheProvider,proxyConfigs);
+        super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
         this.refreshToken = refreshToken;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -35,11 +35,13 @@ import java.util.Objects;
 public class ClientCredentialsHandler extends OAuthHandler {
 
     public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
-            int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
-            TokenCacheProvider tokenCacheProvider, ProxyConfigs proxyConfigs) {
+                                    boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                                    int connectionRequestTimeout, int socketTimeout,
+                                    TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                    ProxyConfigs proxyConfigs) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                tokenCacheProvider, proxyConfigs);
+        super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -51,26 +51,30 @@ public abstract class OAuthHandler implements AuthHandler {
     private Map<String, String> requestParametersMap;
     private Map<String, String> customHeadersMap;
     private final String authMode;
+    private final boolean useGlobalConnectionTimeoutConfigs;
     protected final int connectionTimeout;
     protected final int connectionRequestTimeout;
     protected final int socketTimeout;
     private final TokenCacheProvider tokenCacheProvider;
-
+    private final boolean useGlobalProxyConfigs;
     private ProxyConfigs proxyConfigs;
 
     protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
-            int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
-            TokenCacheProvider tokenCacheProvider, ProxyConfigs proxyConfigs) {
+                           boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                           int connectionRequestTimeout, int socketTimeout, TokenCacheProvider tokenCacheProvider,
+                           boolean useGlobalProxyConfigs, ProxyConfigs proxyConfigs) {
 
         this.id = OAuthUtils.getRandomOAuthHandlerID();
         this.tokenApiUrl = tokenApiUrl;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authMode = authMode;
+        this.useGlobalConnectionTimeoutConfigs = useGlobalConnectionTimeoutConfigs;
         this.connectionTimeout = connectionTimeout;
         this.connectionRequestTimeout = connectionRequestTimeout;
         this.socketTimeout = socketTimeout;
         this.tokenCacheProvider = tokenCacheProvider;
+        this.useGlobalProxyConfigs = useGlobalProxyConfigs;
         this.proxyConfigs = proxyConfigs;
     }
 
@@ -216,6 +220,10 @@ public abstract class OAuthHandler implements AuthHandler {
                 clientSecret));
         oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.TOKEN_API_URL,
                 tokenApiUrl));
+        oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
+                AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS, String.valueOf(useGlobalConnectionTimeoutConfigs)));
+        oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
+                AuthConstants.USE_GLOBAL_PROXY_CONFIGS, String.valueOf(useGlobalProxyConfigs)));
         if (proxyConfigs.isProxyEnabled()) {
             OMElement proxyElement = OAuthUtils.createOMProxyConfigs(omFactory, proxyConfigs);
             oauthCredentials.addChild(proxyElement);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -95,23 +95,25 @@ public abstract class OAuthHandler implements AuthHandler {
         // Check if the token is already cached
         String token = tokenCacheProvider.getToken(getId(messageContext));
 
-        synchronized (getId(messageContext).intern()) {
-            if (StringUtils.isEmpty(token)) {
-                // If no token found, generate a new one
-                try {
-                    token = OAuthClient.generateToken(OAuthUtils.resolveExpression(tokenApiUrl, messageContext),
-                            buildTokenRequestPayload(messageContext), getEncodedCredentials(messageContext),
-                            messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext),
-                            connectionTimeout, connectionRequestTimeout, socketTimeout, proxyConfigs);
+        if (StringUtils.isEmpty(token)) {
+            synchronized (getId(messageContext).intern()) {
+                token = tokenCacheProvider.getToken(getId(messageContext));
+                if (StringUtils.isEmpty(token)) {
+                    try {
+                        token = OAuthClient.generateToken(OAuthUtils.resolveExpression(tokenApiUrl, messageContext),
+                                buildTokenRequestPayload(messageContext), getEncodedCredentials(messageContext),
+                                messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext),
+                                connectionTimeout, connectionRequestTimeout, socketTimeout, proxyConfigs);
 
-                    // Cache the newly generated token
-                    tokenCacheProvider.putToken(getId(messageContext), token);
-                } catch (IOException e) {
-                    throw new AuthException("Error generating token", e);
+                        // Cache the newly generated token
+                        tokenCacheProvider.putToken(getId(messageContext), token);
+                    } catch (IOException e) {
+                        throw new AuthException("Error generating token", e);
+                    }
                 }
             }
-            return token;
         }
+        return token;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.commons.resolvers.ResolverFactory;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -121,24 +123,30 @@ public class OAuthUtils {
         String refreshToken = getChildValue(authCodeElement, AuthConstants.OAUTH_REFRESH_TOKEN);
         String tokenApiUrl = getChildValue(authCodeElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(authCodeElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        boolean useGlobalConnectionTimeoutConfigs = Boolean.parseBoolean(getChildValue(authCodeElement,
+                AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS));
+        boolean useGlobalProxyConfigs = Boolean.parseBoolean(getChildValue(authCodeElement,
+                AuthConstants.USE_GLOBAL_PROXY_CONFIGS));
 
         ProxyConfigs proxyConfigs = getProxyConfigs(authCodeElement);
         if (proxyConfigs == null) {
             return null;
         }
 
-        int connectionTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
-        int connectionRequestTimeout = getOauthTimeouts(authCodeElement,
-                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
-        int socketTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
+        int connectionTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(authCodeElement, AuthConstants.OAUTH_SOCKET_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_SOCKET_TIMEOUT);
 
         if (clientId == null || clientSecret == null || refreshToken == null || tokenApiUrl == null) {
             log.error("Invalid AuthorizationCode configuration");
             return null;
         }
         AuthorizationCodeHandler handler = new AuthorizationCodeHandler(tokenApiUrl, clientId, clientSecret,
-                refreshToken, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                TokenCacheFactory.getTokenCache(), proxyConfigs);
+                refreshToken, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout, connectionRequestTimeout,
+                socketTimeout, TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs, proxyConfigs);
         if (hasRequestParameters(authCodeElement)) {
             Map<String, String> requestParameters = getRequestParameters(authCodeElement);
             if (requestParameters == null) {
@@ -169,23 +177,30 @@ public class OAuthUtils {
         String clientSecret = getChildValue(clientCredentialsElement, AuthConstants.OAUTH_CLIENT_SECRET);
         String tokenApiUrl = getChildValue(clientCredentialsElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(clientCredentialsElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        boolean useGlobalConnectionTimeoutConfigs = Boolean.parseBoolean(getChildValue(clientCredentialsElement,
+                AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS));
+        boolean useGlobalProxyConfigs = Boolean.parseBoolean(getChildValue(clientCredentialsElement,
+                AuthConstants.USE_GLOBAL_PROXY_CONFIGS));
 
         ProxyConfigs proxyConfigs = getProxyConfigs(clientCredentialsElement);
         if (proxyConfigs == null) {
             return null;
         }
 
-        int connectionTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
-        int connectionRequestTimeout = getOauthTimeouts(clientCredentialsElement,
-                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
-        int socketTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
+        int connectionTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(clientCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_SOCKET_TIMEOUT);
 
         if (clientId == null || clientSecret == null || tokenApiUrl == null) {
             log.error("Invalid ClientCredentials configuration");
             return null;
         }
         ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret, authMode,
-                connectionTimeout, connectionRequestTimeout, socketTimeout, TokenCacheFactory.getTokenCache(), proxyConfigs);
+                useGlobalConnectionTimeoutConfigs, connectionTimeout, connectionRequestTimeout, socketTimeout,
+                TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs, proxyConfigs);
         if (hasRequestParameters(clientCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(clientCredentialsElement);
             if (requestParameters == null) {
@@ -218,24 +233,31 @@ public class OAuthUtils {
         String password = getChildValue(passwordCredentialsElement, AuthConstants.OAUTH_PASSWORD);
         String tokenApiUrl = getChildValue(passwordCredentialsElement, AuthConstants.TOKEN_API_URL);
         String authMode = getChildValue(passwordCredentialsElement, AuthConstants.OAUTH_AUTHENTICATION_MODE);
+        boolean useGlobalConnectionTimeoutConfigs = Boolean.parseBoolean(getChildValue(passwordCredentialsElement,
+                AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS));
+        boolean useGlobalProxyConfigs = Boolean.parseBoolean(getChildValue(passwordCredentialsElement,
+                AuthConstants.USE_GLOBAL_PROXY_CONFIGS));
 
         ProxyConfigs proxyConfigs = getProxyConfigs(passwordCredentialsElement);
         if (proxyConfigs == null) {
             return null;
         }
 
-        int connectionTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT);
-        int connectionRequestTimeout = getOauthTimeouts(passwordCredentialsElement,
-                AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT);
-        int socketTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT);
+        int connectionTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_CONNECTION_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_TIMEOUT);
+        int connectionRequestTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_CONNECTION_REQUEST_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_CONNECTION_REQUEST_TIMEOUT);
+        int socketTimeout = getOauthTimeouts(passwordCredentialsElement, AuthConstants.OAUTH_SOCKET_TIMEOUT,
+                AuthConstants.OAUTH_GLOBAL_SOCKET_TIMEOUT);
 
         if (username == null || password == null || tokenApiUrl == null || clientId == null || clientSecret == null) {
             log.error("Invalid PasswordCredentials configuration");
             return null;
         }
         PasswordCredentialsHandler handler = new PasswordCredentialsHandler(tokenApiUrl, clientId, clientSecret,
-                username, password, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                TokenCacheFactory.getTokenCache(), proxyConfigs);
+                username, password, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
+                connectionRequestTimeout, socketTimeout, TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs,
+                proxyConfigs);
         if (hasRequestParameters(passwordCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(passwordCredentialsElement);
             if (requestParameters == null) {
@@ -264,35 +286,48 @@ public class OAuthUtils {
         ProxyConfigs proxyConfigs = new ProxyConfigs();
         OMElement proxyConfigsOM = grantTypeOMElement.getFirstChildWithName(
                 new QName(SynapseConstants.SYNAPSE_NAMESPACE, AuthConstants.PROXY_CONFIGS));
-        if (proxyConfigsOM == null || proxyConfigsOM.getFirstElement() == null) {
-            //proxyConfigs Element is not available or it has no child elements
-            proxyConfigs.setProxyEnabled(false);
-        } else {
+        if (proxyConfigsOM != null && proxyConfigsOM.getFirstElement() != null) {
+            // If proxy is defined at the endpoint level
             proxyConfigs.setProxyEnabled(true);
             proxyConfigs.setProxyHost(getChildValue(proxyConfigsOM, AuthConstants.PROXY_HOST));
             proxyConfigs.setProxyPort(getChildValue(proxyConfigsOM, AuthConstants.PROXY_PORT));
             proxyConfigs.setProxyUsername(getChildValue(proxyConfigsOM, AuthConstants.PROXY_USERNAME));
             proxyConfigs.setProxyPassword(getChildValue(proxyConfigsOM, AuthConstants.PROXY_PASSWORD));
             proxyConfigs.setProxyProtocol(getChildValue(proxyConfigsOM, AuthConstants.OAUTH_PROXY_PROTOCOL));
-
-            if (StringUtils.isEmpty(proxyConfigs.getProxyHost())) {
-                log.error(
-                        "'proxyHost' is not set for the proxy configurations. So error occurred while getting the " +
-                                "related Oauth handler.");
-                return null;
+        } else {
+            Properties synapseProperties = SynapsePropertiesLoader.loadSynapseProperties();
+            if (Boolean.parseBoolean(getChildValue(grantTypeOMElement, AuthConstants.USE_GLOBAL_PROXY_CONFIGS))
+                    && Boolean.parseBoolean(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_ENABLED))) {
+                // If proxy is not defined at the endpoint level but is defined globally
+                proxyConfigs.setProxyEnabled(true);
+                proxyConfigs.setProxyHost(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_HOST));
+                proxyConfigs.setProxyPort(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PORT));
+                proxyConfigs.setProxyUsername(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME));
+                proxyConfigs.setProxyPassword(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PASSWORD));
+                proxyConfigs.setProxyProtocol(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PROTOCOL));
+            } else {
+                // If proxy is not defined at the endpoint level or globally
+                proxyConfigs.setProxyEnabled(false);
+                return proxyConfigs;
             }
-            if (StringUtils.isEmpty(proxyConfigs.getProxyPort())) {
-                log.error(
-                        "'proxyPort' is not set for the proxy configurations. So error occurred while getting the " +
-                                "related Oauth handler.");
-                return null;
-            }
-            if (StringUtils.isEmpty(proxyConfigs.getProxyProtocol())) {
-                log.error(
-                        "'proxyProtocol' is not set for the proxy configurations. So error occurred while getting the" +
-                                " related Oauth handler.");
-                return null;
-            }
+        }
+        if (StringUtils.isEmpty(proxyConfigs.getProxyHost())) {
+            log.error(
+                    "'proxyHost' is not set for the proxy configurations. So error occurred while getting the " +
+                            "related Oauth handler.");
+            return null;
+        }
+        if (StringUtils.isEmpty(proxyConfigs.getProxyPort())) {
+            log.error(
+                    "'proxyPort' is not set for the proxy configurations. So error occurred while getting the " +
+                            "related Oauth handler.");
+            return null;
+        }
+        if (StringUtils.isEmpty(proxyConfigs.getProxyProtocol())) {
+            log.error(
+                    "'proxyProtocol' is not set for the proxy configurations. So error occurred while getting the" +
+                            " related Oauth handler.");
+            return null;
         }
         return proxyConfigs;
     }
@@ -414,10 +449,16 @@ public class OAuthUtils {
         return null;
     }
 
-    public static int getOauthTimeouts(OMElement parentElement, String childName) {
+    public static int getOauthTimeouts(OMElement parentElement, String childName, String globalPropertyName) {
         String value = getChildValue(parentElement, childName);
+        if (value == null && Boolean.parseBoolean(getChildValue(parentElement,
+                AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS))) {
+            // If the value is not defined at the endpoint level, check whether it is defined globally
+            value = SynapsePropertiesLoader.loadSynapseProperties().getProperty(globalPropertyName);
+        }
         try {
             if (value == null) {
+                // If the value is not defined at the endpoint level or globally, the default value is used
                 return -1;
             } else {
                 return Integer.parseInt(value);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -41,6 +41,7 @@ import org.apache.synapse.util.xpath.SynapseExpression;
 import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
+import org.wso2.securevault.SecretResolverFactory;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -291,9 +292,9 @@ public class OAuthUtils {
             proxyConfigs.setProxyEnabled(true);
             proxyConfigs.setProxyHost(getChildValue(proxyConfigsOM, AuthConstants.PROXY_HOST));
             proxyConfigs.setProxyPort(getChildValue(proxyConfigsOM, AuthConstants.PROXY_PORT));
+            proxyConfigs.setProxyProtocol(getChildValue(proxyConfigsOM, AuthConstants.OAUTH_PROXY_PROTOCOL));
             proxyConfigs.setProxyUsername(getChildValue(proxyConfigsOM, AuthConstants.PROXY_USERNAME));
             proxyConfigs.setProxyPassword(getChildValue(proxyConfigsOM, AuthConstants.PROXY_PASSWORD));
-            proxyConfigs.setProxyProtocol(getChildValue(proxyConfigsOM, AuthConstants.OAUTH_PROXY_PROTOCOL));
         } else {
             Properties synapseProperties = SynapsePropertiesLoader.loadSynapseProperties();
             if (Boolean.parseBoolean(getChildValue(grantTypeOMElement, AuthConstants.USE_GLOBAL_PROXY_CONFIGS))
@@ -302,9 +303,16 @@ public class OAuthUtils {
                 proxyConfigs.setProxyEnabled(true);
                 proxyConfigs.setProxyHost(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_HOST));
                 proxyConfigs.setProxyPort(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PORT));
-                proxyConfigs.setProxyUsername(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME));
-                proxyConfigs.setProxyPassword(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PASSWORD));
                 proxyConfigs.setProxyProtocol(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PROTOCOL));
+                if (StringUtils.isNotBlank(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME)) &&
+                        StringUtils.isNotBlank(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PASSWORD))) {
+                    proxyConfigs.setProxyUsername(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME));
+                    proxyConfigs.setProxyPassword(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PASSWORD));
+                    proxyConfigs.setProxyPasswordSecretResolver(SecretResolverFactory.create(new Properties() {{
+                        setProperty(AuthConstants.PROXY_PASSWORD, synapseProperties.getProperty(AuthConstants
+                                .OAUTH_GLOBAL_PROXY_PASSWORD));
+                    }}));
+                }
             } else {
                 // If proxy is not defined at the endpoint level or globally
                 proxyConfigs.setProxyEnabled(false);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -38,11 +38,13 @@ public class PasswordCredentialsHandler extends OAuthHandler {
     private final String password;
 
     protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
-            String password, String authMode, int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
-            TokenCacheProvider tokenCacheProvider, ProxyConfigs proxyConfigs) {
+                                         String password, String authMode, boolean useGlobalConnectionTimeoutConfigs,
+                                         int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
+                                         TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                         ProxyConfigs proxyConfigs) {
 
-        super(tokenApiUrl, clientId, clientSecret, authMode, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                tokenCacheProvider, proxyConfigs);
+        super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
         this.username = username;
         this.password = password;
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
@@ -304,8 +304,9 @@ public class OAuthUtilsTest {
 
             OAuthHandler oAuthHandler =
                     new AuthorizationCodeHandler("oauth_server_url", "client_id", "client_secret",
-                            "refresh_token", "header", -1, -1,
-                            -1, TokenCache.getInstance(), new ProxyConfigs());
+                            "refresh_token", "header", false,
+                            -1, -1, -1, TokenCache.getInstance(),
+                            false, new ProxyConfigs());
 
             OAuthConfiguredHTTPEndpoint httpEndpoint = new OAuthConfiguredHTTPEndpoint(oAuthHandler);
 


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3590

- This PR fixes thread pool exhaustion by checking for a valid token before acquiring the lock. This prevents multiple threads from blocking while waiting for a token, improving concurrency and reducing contention.(Related PR https://github.com/wso2-support/wso2-synapse/pull/2436)

- This PR introduces several changes to improve the handling of proxy and connection timeout configurations in the OAuth authentication process. The changes primarily involve adding support for global configurations and ensuring that these settings are properly loaded and utilized when not specified at the endpoint level.(Related PR https://github.com/wso2-support/wso2-synapse/pull/2447)

### The following configurations have been added for the synapse.properties

```
# Global connection timeouts for token endpoint connection
synapse.endpoint.http.oauth.token.endpoint.global.connection.timeout=3000
synapse.endpoint.http.oauth.token.endpoint.global.connection.request.timeout=3000
synapse.endpoint.http.oauth.token.endpoint.global.socket.timeout=3000

# Global proxy configs for token endpoint connection
synapse.endpoint.http.oauth.token.endpoint.global.proxy.enabled=true
synapse.endpoint.http.oauth.token.endpoint.global.proxy.host=localhost
synapse.endpoint.http.oauth.token.endpoint.global.proxy.port=1234
synapse.endpoint.http.oauth.token.endpoint.global.proxy.username=admin
synapse.endpoint.http.oauth.token.endpoint.global.proxy.password=admin
synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol=http
```
### The following configurations have been added for the endpoint
```
<useGlobalConnectionTimeoutConfigs>true</useGlobalConnectionTimeoutConfigs>
<useGlobalProxyConfigs>false</useGlobalProxyConfigs>
```

- This PR also fixes the issue where the proxy password is not resolved when Secure Vault is enabled.
