### PR TITLE
Update the server worker thread name

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -182,7 +182,7 @@ public class PassThroughConstants {
     public static final String SYNAPSE_PASSTHROUGH_S2SLATENCY_ADVANCE_VIEW = "synapse.passthrough.s2slatency_view.enable_advanced_view";
     public static final String PASSTHROUGH_LATENCY_VIEW = "PassthroughLatencyView";
     public static final String PASSTHROUGH_S2SLATENCY_VIEW = "PassthroughS2SLatencyView";
-    public static final String PASSTHOUGH_HTTP_SERVER_WORKER = "PassthroughHttpServerWorker";
+    public static final String PASSTHOUGH_HTTP_SERVER_WORKER = "PassThroughMessageProcessor";
 
     public static final String MESSAGE_OUTPUT_FORMAT = "MESSAGE_OUTPUT_FORMAT";
 	


### PR DESCRIPTION
## Purpose
Update the server worker thread naming convention to accurately reflect the currently used worker threads on a WSO2 MI instance when monitored via MBeans.

## Approach
I have updated the server worker thread name to align with the registered MBean and the corresponding worker thread name.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4134


