### PR TITLE
Rename SourceHandler threading view threadNamePrefix

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -183,6 +183,7 @@ public class PassThroughConstants {
     public static final String PASSTHROUGH_LATENCY_VIEW = "PassthroughLatencyView";
     public static final String PASSTHROUGH_S2SLATENCY_VIEW = "PassthroughS2SLatencyView";
     public static final String PASSTHOUGH_HTTP_SERVER_WORKER = "PassthroughHttpServerWorker";
+    public static final String PASSTHROUGH_MESSAGE_PROCESSOR = "PassThroughMessageProcessor";
 
     public static final String MESSAGE_OUTPUT_FORMAT = "MESSAGE_OUTPUT_FORMAT";
 	

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -132,7 +132,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                                                scheme.isSSL(), strNamePostfix, enableAdvancedForLatencyView);
             this.s2sLatencyView = new LatencyView(PassThroughConstants.PASSTHROUGH_S2SLATENCY_VIEW, scheme.isSSL(),
                                                   strNamePostfix, enableAdvancedForS2SView);
-            this.threadingView = new ThreadingView(PassThroughConstants.PASSTHOUGH_HTTP_SERVER_WORKER, true, 50);
+            this.threadingView = new ThreadingView(PassThroughConstants.PASSTHROUGH_MESSAGE_PROCESSOR, true, 50);
         }
 
         Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);


### PR DESCRIPTION
This pull request introduces a new constant in the `PassThroughConstants` class and updates its usage in the `SourceHandler` class to fix issue with name inconsistency in jmx ThreadingView


fixes: https://github.com/wso2/product-micro-integrator/issues/4134
