### PR TITLE
Remove INVOKE_MEDIATOR_ID property from message context

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/template/TemplateContext.java
@@ -124,6 +124,7 @@ public class TemplateContext {
         String mapping = EIPUtils.getTemplatePropertyMapping(fName, SynapseConstants.INVOKE_MEDIATOR_ID);
         Object propertyValue = synCtxt.getProperty(mapping);
         mappedValues.put(SynapseConstants.INVOKE_MEDIATOR_ID, propertyValue);
+        removeProperty(synCtxt, mapping);
     }
 
     private ResolvedInvokeParam getEvaluatedInvokeParam(MessageContext synCtx, String parameterName,


### PR DESCRIPTION
This commit removes the INVOKE_MEDIATOR_ID property from the message context's properties map. This change prevents a ClassCastException caused by attempting to cast the property value (a String) to a Value type.

fixes:https://github.com/wso2/product-micro-integrator/issues/4185