### PR TITLE
Trigger fault sequence for forceful connection closures

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -1058,8 +1058,32 @@ public class TargetHandler implements NHttpClientEventHandler {
         }
     }
 
+    /**
+     * Invoked when the backend terminates the outbound HTTP connection unexpectedly.
+     * Logs diagnostics, marks the connection CLOSED, shuts it down, and routes the error
+     * to the standard fault handler.
+     *
+     * @param  conn        the target {@link NHttpClientConnection} that ended input
+     * @throws IOException if an error occurs while closing the connection
+     */
     public void endOfInput(NHttpClientConnection conn) throws IOException {
-        conn.close();
+
+        ProtocolState state = TargetContext.getState(conn);
+        log.warn("Connection ended unexpectedly" +
+                ", " + getConnectionLoggingInfo(conn) +
+                ", State: "  + state + ".");
+        TargetContext.updateState(conn, ProtocolState.CLOSED);
+        targetConfiguration.getConnections().shutdownConnection(conn, true);
+        MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
+        if (requestMsgCtx != null) {
+            requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                    PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
+            targetErrorHandler.handleError(requestMsgCtx,
+                    ErrorCodes.SND_IO_ERROR,
+                    "Error In Sender",
+                    null,
+                    state);
+        }
     }
 
     public void exception(NHttpClientConnection conn, Exception ex) {


### PR DESCRIPTION
$subject

The `endOfInput()` method is triggered when the backend service closes the connection unexpectedly without completing the proper connection termination flow. With this update, instead of merely closing the connection, the method now immediately triggers the fault sequence. It logs the event, updates the connection state to `CLOSED`, shuts down the connection, and initiate the fault sequence.