### PR TITLE
Fix incorrect timeout type when dynamic endpoint timeout expression is used

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/EndpointDefinition.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/EndpointDefinition.java
@@ -204,6 +204,7 @@ public class EndpointDefinition implements AspectConfigurable {
 
     public void setDynamicTimeoutExpression(SynapsePath expression) {
         this.dynamicTimeout = expression;
+        this.endpointTimeoutType = SynapseConstants.ENDPOINT_TIMEOUT_TYPE.ENDPOINT_TIMEOUT;
     }
 
     public SynapsePath getDynamicTimeoutExpression() {


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-micro-integrator/issues/4237

**Problem**
A misleading log message was observed where messages were reported as expiring due to a `GLOBAL_TIMEOUT`, even though the timeout was configured explicitly at the endpoint level using a dynamic expression.

Further debugging revealed that `callback.getTimeoutType()` returned `GLOBAL_TIMEOUT` instead of `ENDPOINT_TIMEOUT`.

**Root Cause**
In `EndpointDefinitionFactory`, when the timeout is defined using a static value, the timeout type is correctly set as `ENDPOINT_TIMEOUT`.
However, when a dynamic expression is used for configuring the timeout, the timeout type was not being set.

**Fix**
This update sets the timeout type to `ENDPOINT_TIMEOUT` even when a dynamic expression is used for the timeout configuration. This ensures correct behavior and accurate timeout classification during runtime.