### PR TITLE
Add Support for Resources in Unit Tests for MI 4.4.0

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/Constants.java
@@ -52,6 +52,7 @@ public class Constants {
     static final String LOCAL_REGISTRY_TYPE = "local";
     static final String GOVERNANCE_REGISTRY_TYPE = "gov";
     static final String CONFIGURATION_REGISTRY_TYPE = "conf";
+    static final String RESOURCES_REGISTRY_TYPE = "resources";
 
     //connector resource key word constants
     static final String CONNECTOR_RESOURCES = "connector-resources";

--- a/modules/core/src/main/java/org/apache/synapse/unittest/UnitTestMockRegistry.java
+++ b/modules/core/src/main/java/org/apache/synapse/unittest/UnitTestMockRegistry.java
@@ -62,6 +62,7 @@ public class UnitTestMockRegistry extends AbstractRegistry {
     private static final String LOCAL_REGISTRY_PATH = "/_system/local";
     private static final String CONFIGURATION_REGISTRY_PATH = "/_system/config";
     private static final String GOVERNANCE_REGISTRY_PATH = "/_system/governance";
+    private static final String RESOURCES_REGISTRY_PATH = "/_system/governance/mi-resources";
     private static final String FILE = "http://wso2.org/projects/esb/registry/types/file";
 
     private static UnitTestMockRegistry initializeRegistry = new UnitTestMockRegistry();
@@ -164,8 +165,10 @@ public class UnitTestMockRegistry extends AbstractRegistry {
             resourcePath = LOCAL_REGISTRY_PATH + entryPath;
         } else if (entryType.equals(Constants.CONFIGURATION_REGISTRY_TYPE)) {
             resourcePath = CONFIGURATION_REGISTRY_PATH + entryPath;
-        } else if (entryType.equals(Constants.GOVERNANCE_REGISTRY_TYPE)) {
+        } else if (entryType.equals(Constants.GOVERNANCE_REGISTRY_TYPE )) {
             resourcePath = GOVERNANCE_REGISTRY_PATH + entryPath;
+        } else if (entryType.equals(Constants.RESOURCES_REGISTRY_TYPE )) {
+            resourcePath = RESOURCES_REGISTRY_PATH + entryPath;
         } else {
             return null;
         }


### PR DESCRIPTION
This adds support for Resources for Uni Tests in MI Runtime Version 4.4.0, where registry resources are not in either 'gov' or 'conf' folder but rather just inside the 'resources' directory.