### PR TITLE
Add secure vault support for JDBC message store configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jdbc/JDBCMessageStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jdbc/JDBCMessageStore.java
@@ -88,6 +88,7 @@ public class JDBCMessageStore extends AbstractMessageStore {
             logger.debug("Initializing Datasource and Properties");
         }
         jdbcConfiguration = new JDBCConfiguration();
+        jdbcConfiguration.setSynapseEnvironment(synapseEnvironment);
         jdbcConfiguration.buildDataSource(parameters);
 
 //        JDBCMessageConverter.setSynapseEnvironment(synapseEnvironment);


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-micro-integrator/issues/4240

## Purpose

This PR adds support for resolving encrypted passwords in JDBC Message Store configurations using the `wso2:vault-lookup(...)` function. This enhancement allows users to externalize credentials securely via environment variables or other dynamic secret providers, aligning JDBC message store behavior with other components like RabbitMQ store.

## Background

Currently, secret resolution is not supported in JDBC Message Store configurations. As a result, users are forced to hardcode credentials or use static secrets via `deployment.toml`. 

## Implementation Details

- Enhanced `JDBCMessageStore` to evaluate vault lookup expressions in the `username/password` property.
- Ensured backward compatibility: if no vault expression is detected, the password is used as-is.

## Sample Usage

```xml
<messageStore name="MyStore" class="org.apache.synapse.message.store.impl.jdbc.JDBCMessageStore">
    <parameter name="driver">com.mysql.cj.jdbc.Driver</parameter>
    <parameter name="url">jdbc:mysql://localhost:3306/testdb</parameter>
    <parameter name="user">{wso2:vault-lookup('JDBC_USR'}</parameter>
    <parameter name="password">{wso2:vault-lookup('JDBC_PASS'}</parameter>
</messageStore>
```
