### PR TITLE
Adjust logging level for producer initialization failures in RabbitMQ Store

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQStore.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/RabbitMQStore.java
@@ -126,10 +126,16 @@ public class RabbitMQStore extends AbstractMessageStore {
                 declareExchange(channel, exchangeName, queueName, routingKey);
                 log.info(nameString() + ". Initialized... ");
             } catch (TimeoutException | IOException e) {
-                log.error(nameString() + ". Initialization failed...", e);
+                log.warn(nameString() + " - Producer channel initialization failed. Will retry connecting  during "
+                        + "message publishing. Cause: " + e.getMessage());
+                if (log.isDebugEnabled()) {
+                    log.debug(nameString() + " - Initialization failed...:", e);
+                }
             }
         } else {
-            log.error(nameString() + ". Initialization failed...");
+            log.warn(nameString() + " - Producer connection not available at startup. " +
+                    "Will retry connecting during message publishing.");
+
         }
         channel = createChannel(producerConnection);
     }


### PR DESCRIPTION
RabbitMQStore previously logged recoverable connection and channel initialization failures as errors during server startup. Since these failures are non-fatal and the store retries during message publishing, logging them as errors was misleading and unnecessarily alarming.

This change downgrades such logs to WARN level with concise cause messages, and adds detailed DEBUG logs with full stack traces for troubleshooting when needed.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4258

