### PR TITLE
Update dependency versions for JSON processing and HTTP libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1534,7 +1534,7 @@
       <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
       <qfj.version>1.5.3</qfj.version>
        <quickfixj.version>2.3.1</quickfixj.version>
-      <org.bouncycastle.version>1.78.1.wso2v1</org.bouncycastle.version>
+      <org.bouncycastle.version>1.81.0.wso2v1</org.bouncycastle.version>
       <imp.pkg.version.wso2.bouncycastle>[1.52.0,2.0.0)</imp.pkg.version.wso2.bouncycastle>
        <httpcore.version>4.4.16</httpcore.version>
       <httpcore.wso2.version>${httpcore.version}.wso2v1</httpcore.wso2.version>


### PR DESCRIPTION
This PR updates several key dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**JSON Processing Libraries:**
- **net.minidev.accessors-smart**: `2.5.2` → `2.6.0`
- **json-smart**: `2.5.2` → `2.6.0`

**HTTP Libraries:**
- **okhttp.wso2**: `4.12.0.wso2v2` → `4.12.0.wso2v4`
- **okio.wso2**: `3.9.0.wso2v2` → `3.16.0.wso2v1`

**Security Libraries:**
- **bouncycastle**: `1.78.1.wso2v1` → `1.81.0.wso2v1`

Related Issue : https://github.com/wso2/api-manager/issues/3870