### PR TITLE
Stop deactivating the message processor when server shutting down

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/MessageProcessor.java
@@ -62,6 +62,12 @@ public interface MessageProcessor extends ManagedLifecycle, Nameable, SynapseArt
     boolean isDeactivated();
 
     /**
+     * This method is used to see if the server is shutting down.
+     * @return {@code true} if shutting down, {@code false} otherwise
+     */
+    boolean isServerShuttingDown();
+
+    /**
      * This method is used to set the associated message store of the message processor. Every message processor
      * has to be bound to a message store
      * @param messageStoreName Name of this message store.

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
 import org.apache.synapse.message.MessageConsumer;
 import org.apache.synapse.message.processor.MessageProcessorCleanupService;
 import org.apache.synapse.message.processor.MessageProcessorConstants;
@@ -97,6 +98,10 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 	private static final String SYMBOL_UNDERSCORE = "_";
 
     private static final String DEFAULT_TASK_SUFFIX = "0";
+
+	private static final String STATUS_SHUTTING_DOWN = "SHUTTING_DOWN";
+
+	private static final String CURRENT_SERVER_STATUS = "local_current.server.status";
 
     @Override
     public void init(SynapseEnvironment se) {
@@ -215,6 +220,11 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
     public boolean isDeactivated() {
 		return taskManager.isTaskDeactivated(TASK_PREFIX + name + SYMBOL_UNDERSCORE +
 		                                                           DEFAULT_TASK_SUFFIX);
+	}
+
+	public boolean isServerShuttingDown() {
+		return ((Axis2SynapseEnvironment)synapseEnvironment).getAxis2ConfigurationContext()
+				.getProperty(CURRENT_SERVER_STATUS) == STATUS_SHUTTING_DOWN;
 	}
 
     @Override


### PR DESCRIPTION
During server shutdown, transports like the HTTP listener may stop before message processing is completed. This can result in message delivery failures, especially when the target endpoint resides in the same runtime. To support graceful shutdown, we should avoid deactivating the message processor in such cases. Hence, we only deactivate the processor if the server is not in the shutdown state.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4287