### PR TITLE
Add trust store configuration support for token endpoint connection in OAuth token endpoints

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ExternalTrustStoreConfigs.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ExternalTrustStoreConfigs.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com/).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.endpoints;
+
+import org.wso2.securevault.SecretResolver;
+
+/**
+ * This class represents a model for external trust store configurations which is used for the token endpoint connection
+ * in OAuth protected endpoints.
+ */
+public class ExternalTrustStoreConfigs {
+    private String trustStoreLocation;
+    private String trustStoreType;
+    private String trustStorePassword;
+    private boolean trustStoreEnabled;
+    private SecretResolver trustStorePasswordSecretResolver;
+
+    public void setTrustStoreEnabled(boolean trustStoreEnabled) {
+        this.trustStoreEnabled = trustStoreEnabled;
+    }
+
+    public void setTrustStoreLocation(String trustStoreLocation) {
+        this.trustStoreLocation = trustStoreLocation;
+    }
+
+    public void setTrustStoreType(String trustStoreType) {
+        this.trustStoreType = trustStoreType;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+        this.trustStorePassword = trustStorePassword;
+    }
+
+    public boolean isTrustStoreEnabled() {
+        return trustStoreEnabled;
+    }
+
+    public String getTrustStoreLocation() {
+        return trustStoreLocation;
+    }
+
+    public String getTrustStoreType() {
+        return trustStoreType;
+    }
+
+    public String getTrustStorePassword() {
+        return trustStorePassword;
+    }
+
+    public void setTrustStorePasswordSecretResolver(SecretResolver trustStorePasswordSecretResolver) {
+        this.trustStorePasswordSecretResolver = trustStorePasswordSecretResolver;
+    }
+
+    public SecretResolver getTrustStorePasswordSecretResolver() {
+        return trustStorePasswordSecretResolver;
+    }
+}

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/TrustStoreConfigs.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/TrustStoreConfigs.java
@@ -18,8 +18,6 @@
 
 package org.apache.synapse.endpoints;
 
-import org.wso2.securevault.SecretResolver;
-
 /**
  * This class represents a model for trust store configurations which is used for the token endpoint connection
  * in OAuth protected endpoints.
@@ -27,9 +25,8 @@ import org.wso2.securevault.SecretResolver;
 public class TrustStoreConfigs {
     private String trustStoreLocation;
     private String trustStoreType;
-    private String trustStorePassword;
+    private char[] trustStorePassword;
     private boolean trustStoreEnabled;
-    private SecretResolver trustStorePasswordSecretResolver;
 
     public void setTrustStoreEnabled(boolean trustStoreEnabled) {
         this.trustStoreEnabled = trustStoreEnabled;
@@ -43,7 +40,7 @@ public class TrustStoreConfigs {
         this.trustStoreType = trustStoreType;
     }
 
-    public void setTrustStorePassword(String trustStorePassword) {
+    public void setTrustStorePassword(char[] trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
     }
 
@@ -59,15 +56,7 @@ public class TrustStoreConfigs {
         return trustStoreType;
     }
 
-    public String getTrustStorePassword() {
+    public char[] getTrustStorePassword() {
         return trustStorePassword;
-    }
-
-    public void setTrustStorePasswordSecretResolver(SecretResolver trustStorePasswordSecretResolver) {
-        this.trustStorePasswordSecretResolver = trustStorePasswordSecretResolver;
-    }
-
-    public SecretResolver getTrustStorePasswordSecretResolver() {
-        return trustStorePasswordSecretResolver;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/TrustStoreConfigs.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/TrustStoreConfigs.java
@@ -21,10 +21,10 @@ package org.apache.synapse.endpoints;
 import org.wso2.securevault.SecretResolver;
 
 /**
- * This class represents a model for external trust store configurations which is used for the token endpoint connection
+ * This class represents a model for trust store configurations which is used for the token endpoint connection
  * in OAuth protected endpoints.
  */
-public class ExternalTrustStoreConfigs {
+public class TrustStoreConfigs {
     private String trustStoreLocation;
     private String trustStoreType;
     private String trustStorePassword;

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -103,5 +103,16 @@ public class AuthConstants {
     public static final String OAUTH_GLOBAL_PROXY_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.password";
     public static final String OAUTH_GLOBAL_PROXY_PROTOCOL = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol";
 
+    // External trust store XML element names
+    public static final String EXTERNAL_TRUST_STORE_CONFIGS = "externalTrustStoreConfigs";
+    public static final String TRUST_STORE_LOCATION = "trustStoreLocation";
+    public static final String TRUST_STORE_TYPE = "trustStoreType";
+    public static final String TRUST_STORE_PASSWORD = "trustStorePassword";
+
+    // External trust store property names for synapse.properties
+    public static final String OAUTH_TRUST_STORE_LOCATION_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.location";
+    public static final String OAUTH_TRUST_STORE_TYPE_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.type";
+    public static final String OAUTH_TRUST_STORE_PASSWORD_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.password";
+
     public static final String HTTPS_PROTOCOL = "https";
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -103,12 +103,6 @@ public class AuthConstants {
     public static final String OAUTH_GLOBAL_PROXY_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.password";
     public static final String OAUTH_GLOBAL_PROXY_PROTOCOL = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol";
 
-    // External trust store XML element names
-    public static final String EXTERNAL_TRUST_STORE_CONFIGS = "externalTrustStoreConfigs";
-    public static final String TRUST_STORE_LOCATION = "trustStoreLocation";
-    public static final String TRUST_STORE_TYPE = "trustStoreType";
-    public static final String TRUST_STORE_PASSWORD = "trustStorePassword";
-
     // External trust store property names for synapse.properties
     public static final String OAUTH_TRUST_STORE_LOCATION_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.location";
     public static final String OAUTH_TRUST_STORE_TYPE_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.type";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -103,10 +103,10 @@ public class AuthConstants {
     public static final String OAUTH_GLOBAL_PROXY_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.password";
     public static final String OAUTH_GLOBAL_PROXY_PROTOCOL = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol";
 
-    // External trust store property names for synapse.properties
-    public static final String OAUTH_TRUST_STORE_LOCATION_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.location";
-    public static final String OAUTH_TRUST_STORE_TYPE_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.type";
-    public static final String OAUTH_TRUST_STORE_PASSWORD_PROPERTY = "synapse.endpoint.http.oauth.token.endpoint.external.trust.store.password";
+    // OAuth token endpoint truststore property names for synapse.properties
+    public static final String OAUTH_TOKEN_ENDPOINT_TRUST_STORE_LOCATION = "synapse.endpoint.http.oauth.token.endpoint.trust.store.location";
+    public static final String OAUTH_TOKEN_ENDPOINT_TRUST_STORE_TYPE = "synapse.endpoint.http.oauth.token.endpoint.trust.store.type";
+    public static final String OAUTH_TOKEN_ENDPOINT_TRUST_STORE_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.trust.store.password";
 
     public static final String HTTPS_PROTOCOL = "https";
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -37,6 +37,21 @@ public class AuthorizationCodeHandler extends OAuthHandler {
 
     private final String refreshToken;
 
+    /**
+     * Backward compatibility constructor without TrustStoreConfigs
+     * @deprecated Use constructor with TrustStoreConfigs parameter for enhanced SSLContext configuration support
+     */
+    @Deprecated
+    public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret, String refreshToken,
+                                    String authMode, boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                                    int connectionRequestTimeout, int socketTimeout,
+                                    TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                    ProxyConfigs proxyConfigs) {
+        this(tokenApiUrl, clientId, clientSecret, refreshToken, authMode, useGlobalConnectionTimeoutConfigs,
+                connectionTimeout, connectionRequestTimeout, socketTimeout, tokenCacheProvider, 
+                useGlobalProxyConfigs, proxyConfigs, null);
+    }
+
     public AuthorizationCodeHandler(String tokenApiUrl, String clientId, String clientSecret, String refreshToken,
                                     String authMode, boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -40,10 +41,11 @@ public class AuthorizationCodeHandler extends OAuthHandler {
                                     String authMode, boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,
                                     TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                    ProxyConfigs proxyConfigs) {
+                                    ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
-                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
+                externalTrustStoreConfigs);
         this.refreshToken = refreshToken;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/AuthorizationCodeHandler.java
@@ -23,7 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -41,11 +41,11 @@ public class AuthorizationCodeHandler extends OAuthHandler {
                                     String authMode, boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,
                                     TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                    ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
+                                    ProxyConfigs proxyConfigs, TrustStoreConfigs trustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
                 connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
-                externalTrustStoreConfigs);
+                trustStoreConfigs);
         this.refreshToken = refreshToken;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -35,6 +35,21 @@ import java.util.Objects;
  */
 public class ClientCredentialsHandler extends OAuthHandler {
 
+    /**
+     * Backward compatibility constructor without TrustStoreConfigs
+     * @deprecated Use constructor with TrustStoreConfigs parameter for enhanced SSL configuration support
+     */
+    @Deprecated
+    public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
+                                    boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                                    int connectionRequestTimeout, int socketTimeout,
+                                    TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                    ProxyConfigs proxyConfigs) {
+        this(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs,
+                connectionTimeout, connectionRequestTimeout, socketTimeout, tokenCacheProvider,
+                useGlobalProxyConfigs, proxyConfigs, null);
+    }
+
     public ClientCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
                                     boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -23,7 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -39,11 +39,11 @@ public class ClientCredentialsHandler extends OAuthHandler {
                                     boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,
                                     TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                    ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
+                                    ProxyConfigs proxyConfigs, TrustStoreConfigs trustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
                 connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
-                externalTrustStoreConfigs);
+                trustStoreConfigs);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/ClientCredentialsHandler.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -38,10 +39,11 @@ public class ClientCredentialsHandler extends OAuthHandler {
                                     boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                                     int connectionRequestTimeout, int socketTimeout,
                                     TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                    ProxyConfigs proxyConfigs) {
+                                    ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
-                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
+                externalTrustStoreConfigs);
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
@@ -386,7 +386,7 @@ public class OAuthClient {
     private static SSLContext getSSLContextFromTrustStore(TrustStoreConfigs trustStoreConfigs)
             throws AuthException {
         String trustStoreLocation = trustStoreConfigs.getTrustStoreLocation();
-        String trustStorePassword = trustStoreConfigs.getTrustStorePassword();
+        char[] trustStorePassword = trustStoreConfigs.getTrustStorePassword();
 
         if (trustStoreLocation == null || trustStorePassword == null) {
             throw new AuthException("Trust store configuration is incomplete");
@@ -401,8 +401,7 @@ public class OAuthClient {
         try (FileInputStream fis = new FileInputStream(trustStoreFile)) {
             trustStore = KeyStore.getInstance(trustStoreConfigs.getTrustStoreType());
             // Resolve trust store password from the secret resolver
-            trustStore.load(fis, MiscellaneousUtil.resolve(trustStorePassword,
-                    trustStoreConfigs.getTrustStorePasswordSecretResolver()).toCharArray());
+            trustStore.load(fis, trustStorePassword);
         } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
             throw new AuthException("Error loading trust store from location: " + trustStoreLocation, e);
         }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
@@ -49,6 +49,7 @@ import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -112,10 +113,34 @@ public class OAuthClient {
     /**
      * Method to generate the access token from an OAuth server
      *
-     * @param tokenApiUrl   The token url of the server
-     * @param payload       The payload of the request
-     * @param credentials   The encoded credentials
-     * @param proxyConfigs  The proxy configurations
+     * @param tokenApiUrl  The token url of the server
+     * @param payload      The payload of the request
+     * @param credentials  The encoded credentials
+     * @param proxyConfigs The proxy configurations
+     * @return accessToken String
+     * @throws AuthException In the event of an unexpected HTTP status code return from the server or access_token key
+     *                       missing in the response payload
+     * @throws IOException   In the event of a problem parsing the response from the server
+     * @deprecated Use method with TrustStoreConfigs parameter for enhanced SSL configuration support
+     */
+    @Deprecated
+    public static String generateToken(String tokenApiUrl, String payload, String credentials,
+                                       MessageContext messageContext, Map<String, String> customHeaders,
+                                       int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
+                                       ProxyConfigs proxyConfigs) throws AuthException, IOException {
+        // Use null TrustStoreConfigs to maintain backward compatibility
+        return generateToken(tokenApiUrl, payload, credentials, messageContext, customHeaders,
+                connectionTimeout, connectionRequestTimeout, socketTimeout, proxyConfigs, null);
+    }
+
+    /**
+     * Method to generate the access token from an OAuth server
+     *
+     * @param tokenApiUrl       The token url of the server
+     * @param payload           The payload of the request
+     * @param credentials       The encoded credentials
+     * @param proxyConfigs      The proxy configurations
+     * @param trustStoreConfigs The trust store configurations
      * @return accessToken String
      * @throws AuthException In the event of an unexpected HTTP status code return from the server or access_token key
      *                       missing in the response payload
@@ -411,6 +436,12 @@ public class OAuthClient {
         } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
             throw new AuthException("Error while creating SSL context from trust store configurations", e);
         }
+    }
+
+    public CloseableHttpClient getDefaultHttpClient() {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        builder.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
+        return builder.build();
     }
 
     private static SSLContext getSSLContextWithUrl(String urlPath, Map<RequestDescriptor, SSLContext> sslByHostMap,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthClient.java
@@ -20,10 +20,8 @@ package org.apache.synapse.endpoints.auth.oauth;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
-import org.apache.axis2.description.Parameter;
 import org.apache.axis2.description.TransportOutDescription;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.lang3.StringUtils;
@@ -51,7 +49,6 @@ import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -61,23 +58,21 @@ import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
 import org.apache.synapse.transport.http.conn.RequestDescriptor;
 import org.apache.synapse.transport.http.conn.SSLContextDetails;
 import org.apache.synapse.transport.nhttp.config.ClientConnFactoryBuilder;
-import org.apache.synapse.transport.nhttp.util.SecureVaultValueReader;
-import org.apache.synapse.util.xpath.KeyStoreManager;
-import org.wso2.securevault.SecretResolver;
-import org.wso2.securevault.SecretResolverFactory;
 import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
-import javax.xml.namespace.QName;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -87,11 +82,11 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.KeyStoreException;
+import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -104,9 +99,6 @@ public class OAuthClient {
     private static final Log log = LogFactory.getLog(OAuthClient.class);
 
     // Elements defined in key/trust store configuration
-    private static final String STORE_TYPE = "Type";
-    private static final String STORE_LOCATION = "Location";
-    private static final String STORE_PASSWORD = "Password";
     private static final String HTTP_CONNECTION = "http";
     private static final String HTTPS_CONNECTION = "https";
     private static final String ALL_HOSTS = "*";
@@ -131,14 +123,16 @@ public class OAuthClient {
      */
     public static String generateToken(String tokenApiUrl, String payload, String credentials,
                                        MessageContext messageContext, Map<String, String> customHeaders,
-                                       int connectionTimeout, int connectionRequestTimeout, int socketTimeout,  ProxyConfigs proxyConfigs) throws AuthException, IOException {
+                                       int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
+                                       ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs)
+            throws AuthException, IOException {
 
         if (log.isDebugEnabled()) {
             log.debug("Initializing token generation request: [token-endpoint] " + tokenApiUrl);
         }
 
         try (CloseableHttpClient httpClient = getSecureClient(tokenApiUrl, messageContext, connectionTimeout,
-                connectionRequestTimeout, socketTimeout, proxyConfigs)) {
+                connectionRequestTimeout, socketTimeout, proxyConfigs, externalTrustStoreConfigs)) {
             HttpPost httpPost = new HttpPost(tokenApiUrl);
             httpPost.setHeader(AuthConstants.CONTENT_TYPE_HEADER, AuthConstants.APPLICATION_X_WWW_FORM_URLENCODED);
             if (!(customHeaders == null || customHeaders.isEmpty())) {
@@ -168,6 +162,8 @@ public class OAuthClient {
                 throw new AuthException("Unable to connect to the OAuth token endpoint.");
             } catch (UnsupportedSchemeException e) {
                 throw new AuthException("Unsupported protocol used for the OAuth token endpoint.");
+            } catch (SSLHandshakeException e) {
+                throw new AuthException("SSL handshake failed while connecting to the OAuth token endpoint.");
             } finally {
                 httpPost.releaseConnection();
             }
@@ -226,66 +222,48 @@ public class OAuthClient {
      * @throws AuthException
      */
     private static CloseableHttpClient getSecureClient(String tokenUrl, MessageContext messageContext,
-            int connectionTimeout, int connectionRequestTimeout, int socketTimeout, ProxyConfigs proxyConfigs)
+                                                       int connectionTimeout, int connectionRequestTimeout,
+                                                       int socketTimeout, ProxyConfigs proxyConfigs,
+                                                       ExternalTrustStoreConfigs externalTrustStoreConfigs)
             throws AuthException {
 
+        SSLContext sslContext = getSSLContext(messageContext, tokenUrl, externalTrustStoreConfigs);
+        RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(connectionTimeout)
+                .setConnectionRequestTimeout(connectionRequestTimeout).setSocketTimeout(socketTimeout).build();
         if (proxyConfigs.isProxyEnabled()) {
-            return getSecureClientWithProxy(messageContext, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                    proxyConfigs);
+            return getSecureClientWithProxy(messageContext, proxyConfigs, sslContext, requestConfig);
         } else {
-            return getSecureClientWithoutProxy(tokenUrl, messageContext, connectionTimeout, connectionRequestTimeout,
-                    socketTimeout);
+            return getSecureClientWithoutProxy(sslContext, requestConfig);
         }
     }
 
-    private static CloseableHttpClient getSecureClientWithoutProxy(String tokenUrl, MessageContext messageContext,
-            int connectionTimeout, int connectionRequestTimeout, int socketTimeout) throws AuthException {
-        SSLContext sslContext;
-        ConfigurationContext configurationContext = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
-                .getConfigurationContext();
-        TransportOutDescription transportOut = configurationContext.getAxisConfiguration().getTransportOut("https");
-        try {
-            ClientConnFactoryBuilder clientConnFactoryBuilder = new ClientConnFactoryBuilder(transportOut,
-                    configurationContext).parseSSL();
-            sslContext = getSSLContextWithUrl(tokenUrl, clientConnFactoryBuilder.getSslByHostMap(),
-                    clientConnFactoryBuilder.getSSLContextDetails());
-        } catch (AxisFault e) {
-            throw new AuthException("Error while reading SSL configs. Using default Keystore and Truststore", e);
-        }
+    private static CloseableHttpClient getSecureClientWithoutProxy(SSLContext sslContext, RequestConfig requestConfig) {
         SSLConnectionSocketFactory sslConnectionFactory = new SSLConnectionSocketFactory(sslContext,
                 NoopHostnameVerifier.INSTANCE);
-        RequestConfig config = RequestConfig.custom().setConnectTimeout(connectionTimeout)
-                .setConnectionRequestTimeout(connectionRequestTimeout).setSocketTimeout(socketTimeout).build();
-        Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory> create()
+        Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
                 .register(HTTPS_CONNECTION, sslConnectionFactory)
                 .register(HTTP_CONNECTION, new PlainConnectionSocketFactory()).build();
 
         BasicHttpClientConnectionManager connManager = new BasicHttpClientConnectionManager(registry);
-        CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config)
+        return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig)
                 .setConnectionManager(connManager).setSSLSocketFactory(sslConnectionFactory).build();
-
-        return client;
     }
 
-    private static CloseableHttpClient getSecureClientWithProxy(MessageContext messageContext, int connectionTimeout,
-                                                                int connectionRequestTimeout, int socketTimeout,
-                                                                ProxyConfigs proxyConfigs) throws AuthException {
+    private static CloseableHttpClient getSecureClientWithProxy(MessageContext messageContext, ProxyConfigs proxyConfigs,
+                                                                SSLContext sslContext, RequestConfig requestConfig)
+            throws AuthException {
 
-        PoolingHttpClientConnectionManager pool = getPoolingHttpClientConnectionManager(
-                proxyConfigs.getProxyProtocol());
+        PoolingHttpClientConnectionManager pool = getPoolingHttpClientConnectionManager(proxyConfigs.getProxyProtocol(),
+                sslContext);
         pool.setMaxTotal(MAX_TOTAL_POOL_SIZE);
         pool.setDefaultMaxPerRoute(DEFAULT_MAX_PER_ROUTE);
 
-        RequestConfig params = RequestConfig.custom().build();
-        HttpClientBuilder clientBuilder = HttpClients.custom().setConnectionManager(pool)
-                .setDefaultRequestConfig(params);
+        HttpClientBuilder clientBuilder = HttpClients.custom().setConnectionManager(pool);
 
         HttpHost host = new HttpHost(proxyConfigs.getProxyHost(), Integer.parseInt(proxyConfigs.getProxyPort()),
                 proxyConfigs.getProxyProtocol());
         DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(host);
-        RequestConfig config = RequestConfig.custom().setConnectTimeout(connectionTimeout)
-                .setConnectionRequestTimeout(connectionRequestTimeout).setSocketTimeout(socketTimeout).build();
-        clientBuilder = clientBuilder.setRoutePlanner(routePlanner).setDefaultRequestConfig(config);
+        clientBuilder = clientBuilder.setRoutePlanner(routePlanner).setDefaultRequestConfig(requestConfig);
 
         if (StringUtils.isNotBlank(proxyConfigs.getProxyUsername()) && StringUtils.isNotBlank(
                 proxyConfigs.getProxyPassword())) {
@@ -312,15 +290,16 @@ public class OAuthClient {
         }
     }
 
-    private static PoolingHttpClientConnectionManager getPoolingHttpClientConnectionManager(String protocol)
+    private static PoolingHttpClientConnectionManager getPoolingHttpClientConnectionManager(String protocol,
+                                                                                            SSLContext sslContext)
             throws AuthException {
 
         PoolingHttpClientConnectionManager poolManager;
         if (AuthConstants.HTTPS_PROTOCOL.equals(protocol)) {
-            SSLConnectionSocketFactory socketFactory = createSocketFactory();
+            SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext, getHostnameVerifier());
             org.apache.http.config.Registry<ConnectionSocketFactory> socketFactoryRegistry =
-                    RegistryBuilder.<ConnectionSocketFactory> create()
-                    .register(AuthConstants.HTTPS_PROTOCOL, socketFactory).build();
+                    RegistryBuilder.<ConnectionSocketFactory>create()
+                            .register(AuthConstants.HTTPS_PROTOCOL, socketFactory).build();
             poolManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
         } else {
             poolManager = new PoolingHttpClientConnectionManager();
@@ -328,127 +307,111 @@ public class OAuthClient {
         return poolManager;
     }
 
-    private static SSLConnectionSocketFactory createSocketFactory() throws AuthException {
-        SSLContext sslContext;
+    /**
+     * Returns a HostnameVerifier instance based on the configured system property HOST_NAME_VERIFIER. The verifier
+     * determines how hostnames are validated during SSL/TLS handshake when establishing secure connections.
+     *
+     * @return the configured HostnameVerifier implementation
+     * @throws AuthException if an error occurs while creating the hostname verifier
+     */
+    private static HostnameVerifier getHostnameVerifier() throws AuthException {
+        HostnameVerifier hostnameVerifier;
+        String hostnameVerifierOption = System.getProperty(HOST_NAME_VERIFIER);
 
-        char[] trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword").toCharArray();
-        String trustStoreLocation = System.getProperty("javax.net.ssl.trustStore");
-        try {
-            KeyStore trustStore = KeyStoreManager.getKeyStore(trustStoreLocation, Arrays.toString(trustStorePassword),
-                    "JKS");
-            sslContext = SSLContexts.custom().loadTrustMaterial(trustStore).build();
+        if (ALLOW_ALL.equalsIgnoreCase(hostnameVerifierOption)) {
+            hostnameVerifier = SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
+        } else if (STRICT.equalsIgnoreCase(hostnameVerifierOption)) {
+            hostnameVerifier = SSLSocketFactory.STRICT_HOSTNAME_VERIFIER;
+        } else if (DEFAULT_AND_LOCALHOST.equalsIgnoreCase(hostnameVerifierOption)) {
+            hostnameVerifier = new HostnameVerifier() {
+                final String[] localhosts = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};
 
-            HostnameVerifier hostnameVerifier;
-            String hostnameVerifierOption = System.getProperty(HOST_NAME_VERIFIER);
+                @Override
+                public boolean verify(String urlHostName, SSLSession session) {
+                    return SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER.verify(urlHostName,
+                            session) || Arrays.asList(localhosts).contains(urlHostName);
+                }
+            };
+        } else {
+            hostnameVerifier = SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER;
+        }
+        return hostnameVerifier;
+    }
 
-            if (ALLOW_ALL.equalsIgnoreCase(hostnameVerifierOption)) {
-                hostnameVerifier = SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
-            } else if (STRICT.equalsIgnoreCase(hostnameVerifierOption)) {
-                hostnameVerifier = SSLSocketFactory.STRICT_HOSTNAME_VERIFIER;
-            } else if (DEFAULT_AND_LOCALHOST.equalsIgnoreCase(hostnameVerifierOption)) {
-                hostnameVerifier = new HostnameVerifier() {
-                    final String[] localhosts = { "::1", "127.0.0.1", "localhost", "localhost.localdomain" };
-
-                    @Override
-                    public boolean verify(String urlHostName, SSLSession session) {
-                        return SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER.verify(urlHostName,
-                                session) || Arrays.asList(localhosts).contains(urlHostName);
-                    }
-                };
-            } else {
-                hostnameVerifier = SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER;
+    /**
+     * Creates an SSLContext for secure connections when invoking the given token endpoint.
+     *
+     * The method first checks if an external trust store is enabled and configured through ExternalTrustStoreConfigs.
+     * If enabled, the SSL context will be created using the external trust store configuration. Otherwise, it falls
+     * back to the Axis2 transport configuration (from the provided MessageContext) to build an SSL context with
+     * host-specific or default SSL settings.
+     *
+     * @param messageContext the Synapse MessageContext used to retrieve the underlying Axis2 configuration for SSL if
+     *                       external trust store is not enabled.
+     * @param tokenUrl       the token endpoint URL. Used to determine the correct SSL context when multiple SSL
+     *                       configurations are available.
+     * @return an initialized SSLContext.
+     * @throws AuthException if SSL configuration cannot be loaded or if trust store settings are incomplete.
+     */
+    private static SSLContext getSSLContext(MessageContext messageContext, String tokenUrl,
+                                            ExternalTrustStoreConfigs externalTrustStoreConfigs) throws AuthException {
+        if (externalTrustStoreConfigs != null && externalTrustStoreConfigs.isTrustStoreEnabled()) {
+            return getSSLContextFromExternalTrustStore(externalTrustStoreConfigs);
+        } else {
+            ConfigurationContext configurationContext = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                    .getConfigurationContext();
+            TransportOutDescription transportOut = configurationContext.getAxisConfiguration().getTransportOut("https");
+            try {
+                ClientConnFactoryBuilder clientConnFactoryBuilder = new ClientConnFactoryBuilder(transportOut,
+                        configurationContext).parseSSL();
+                return getSSLContextWithUrl(tokenUrl, clientConnFactoryBuilder.getSslByHostMap(),
+                        clientConnFactoryBuilder.getSSLContextDetails());
+            } catch (AxisFault e) {
+                throw new AuthException("Error while reading SSL configs. Using default Keystore and Truststore", e);
             }
-
-            return new SSLConnectionSocketFactory(sslContext, hostnameVerifier);
-        } catch (NoSuchAlgorithmException e) {
-            throw new AuthException(e);
-        } catch (KeyStoreException e) {
-            throw new AuthException(e);
-        } catch (KeyManagementException e) {
-            throw new AuthException(e);
         }
     }
 
     /**
-     * Returns SSL Context for the token endpoint.
+     * Creates and returns an SSLContext using the given external trust store configurations.
      *
-     * @return SSLContext
-     * @throws AuthException
+     * This method loads the trust store from the provided location, initializes it with the specified type and
+     * password, and builds an SSLContext that trusts the certificates contained in it.
+     *
+     * @param externalTrustStoreConfigs the trust store configurations containing location, type, and password
+     * @return an initialized SSLContext based on the provided trust store
+     * @throws AuthException if the trust store configuration is incomplete, the trust store cannot be loaded, or the
+     *                       SSLContext cannot be created
      */
-    private SSLContext getSSLContext(MessageContext messageContext) throws AuthException {
-        ConfigurationContext configurationContext = ((Axis2MessageContext) messageContext).getAxis2MessageContext().
-                getConfigurationContext();
+    private static SSLContext getSSLContextFromExternalTrustStore(ExternalTrustStoreConfigs externalTrustStoreConfigs)
+            throws AuthException {
+        String trustStoreLocation = externalTrustStoreConfigs.getTrustStoreLocation();
+        String trustStorePassword = externalTrustStoreConfigs.getTrustStorePassword();
 
-        Parameter keystoreParameter = configurationContext.getAxisConfiguration().getTransportOut("https").
-                getParameter("keystore");
-
-        Parameter truststoreParameter = configurationContext.getAxisConfiguration().getTransportOut("https").
-                getParameter("truststore");
-
-        OMElement keystoreElem, truststoreElem;
-        if (keystoreParameter != null && truststoreParameter != null) {
-            keystoreElem = keystoreParameter.getParameterElement().getFirstElement();
-            truststoreElem = truststoreParameter.getParameterElement().getFirstElement();
-        } else {
-            throw new AuthException("Key Store and/or Trust Store parameters missing in Axis2 configuration");
+        if (trustStoreLocation == null || trustStorePassword == null) {
+            throw new AuthException("Trust store configuration is incomplete");
         }
 
-        SecretResolver resolver;
-        if (configurationContext != null && configurationContext.getAxisConfiguration() != null) {
-            resolver = configurationContext.getAxisConfiguration().getSecretResolver();
-        } else {
-            resolver = SecretResolverFactory.create(keystoreElem, false);
+        File trustStoreFile = new File(trustStoreLocation);
+        if (!trustStoreFile.exists() || !trustStoreFile.canRead()) {
+            throw new AuthException("Trust store file not found or not readable");
         }
 
-        String keystorePassword = SecureVaultValueReader.getSecureVaultValue(resolver,
-                keystoreElem.getFirstChildWithName(new QName(STORE_PASSWORD)));
+        final KeyStore trustStore;
+        try (FileInputStream fis = new FileInputStream(trustStoreFile)) {
+            trustStore = KeyStore.getInstance(externalTrustStoreConfigs.getTrustStoreType());
+            // Resolve trust store password from the secret resolver
+            trustStore.load(fis, MiscellaneousUtil.resolve(trustStorePassword,
+                    externalTrustStoreConfigs.getTrustStorePasswordSecretResolver()).toCharArray());
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new AuthException("Error loading trust store from location: " + trustStoreLocation, e);
+        }
 
-        KeyStore keyStore = getStore(keystoreElem, resolver);
-        KeyStore truststore = getStore(truststoreElem, resolver);
         try {
-            return SSLContexts.custom().loadKeyMaterial(keyStore, keystorePassword.toCharArray()).
-                    loadTrustMaterial(truststore).build();
-        } catch (GeneralSecurityException e) {
-            throw new AuthException(e);
+            return SSLContexts.custom().loadTrustMaterial(trustStore).build();
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            throw new AuthException("Error while creating SSL context from trust store configurations", e);
         }
-    }
-
-    /**
-     * Returns Trust Store for the provided Axis2 Configuration.
-     *
-     * @param storeElem OMElement
-     * @param resolver Secret Resolver
-     * @return Trust tStore
-     * @throws AuthException
-     */
-    private KeyStore getStore(OMElement storeElem, SecretResolver resolver) throws AuthException {
-        OMElement storeLocationElement = storeElem.getFirstChildWithName(new QName(STORE_LOCATION));
-        OMElement typeElement = storeElem.getFirstChildWithName(new QName(STORE_TYPE));
-        String storePassword = SecureVaultValueReader.getSecureVaultValue(resolver,
-                storeElem.getFirstChildWithName(new QName(STORE_PASSWORD)));
-
-        if (storeLocationElement == null || typeElement == null || storePassword == null) {
-            throw new AuthException("Missing parameters in the store");
-        }
-
-        String storeLocation = storeLocationElement.getText();
-        String type = typeElement.getText();
-
-        try (FileInputStream fis = new FileInputStream(storeLocation)) {
-            KeyStore trustStore = KeyStore.getInstance(type);
-            trustStore.load(fis, storePassword.toCharArray());
-            return trustStore;
-        } catch (GeneralSecurityException gse) {
-            throw new AuthException("Error loading Trust/Key store : " + storeLocation);
-        } catch (IOException ioe) {
-            throw new AuthException("Error opening Trust/Key store : " + storeLocation);
-        }
-    }
-
-    public CloseableHttpClient getDefaultHttpClient() {
-        HttpClientBuilder builder = HttpClientBuilder.create();
-        builder.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
-        return builder.build();
     }
 
     private static SSLContext getSSLContextWithUrl(String urlPath, Map<RequestDescriptor, SSLContext> sslByHostMap,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -59,7 +59,21 @@ public abstract class OAuthHandler implements AuthHandler {
     private final TokenCacheProvider tokenCacheProvider;
     private final boolean useGlobalProxyConfigs;
     private ProxyConfigs proxyConfigs;
-    private TrustStoreConfigs trustStoreConfigs;
+    private final TrustStoreConfigs trustStoreConfigs;
+
+    /**
+     * Backward compatibility constructor without TrustStoreConfigs
+     * @deprecated Use constructor with TrustStoreConfigs parameter for enhanced SSL configuration support
+     */
+    @Deprecated
+    protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
+                           boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
+                           int connectionRequestTimeout, int socketTimeout, TokenCacheProvider tokenCacheProvider,
+                           boolean useGlobalProxyConfigs, ProxyConfigs proxyConfigs) {
+        this(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs,
+                connectionTimeout, connectionRequestTimeout, socketTimeout, tokenCacheProvider,
+                useGlobalProxyConfigs, proxyConfigs, null);
+    }
 
     protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
                            boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -229,11 +229,6 @@ public abstract class OAuthHandler implements AuthHandler {
                 AuthConstants.USE_GLOBAL_CONNECTION_TIMEOUT_CONFIGS, String.valueOf(useGlobalConnectionTimeoutConfigs)));
         oauthCredentials.addChild(OAuthUtils.createOMElementWithValue(omFactory,
                 AuthConstants.USE_GLOBAL_PROXY_CONFIGS, String.valueOf(useGlobalProxyConfigs)));
-        if (externalTrustStoreConfigs.isTrustStoreEnabled()) {
-            OMElement externalTrustStoreElement = OAuthUtils.createOMExternalTrustStore(omFactory,
-                    externalTrustStoreConfigs);
-            oauthCredentials.addChild(externalTrustStoreElement);
-        }
         if (proxyConfigs.isProxyEnabled()) {
             OMElement proxyElement = OAuthUtils.createOMProxyConfigs(omFactory, proxyConfigs);
             oauthCredentials.addChild(proxyElement);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthHandler.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -59,13 +59,12 @@ public abstract class OAuthHandler implements AuthHandler {
     private final TokenCacheProvider tokenCacheProvider;
     private final boolean useGlobalProxyConfigs;
     private ProxyConfigs proxyConfigs;
-    private ExternalTrustStoreConfigs externalTrustStoreConfigs;
+    private TrustStoreConfigs trustStoreConfigs;
 
     protected OAuthHandler(String tokenApiUrl, String clientId, String clientSecret, String authMode,
                            boolean useGlobalConnectionTimeoutConfigs, int connectionTimeout,
                            int connectionRequestTimeout, int socketTimeout, TokenCacheProvider tokenCacheProvider,
-                           boolean useGlobalProxyConfigs, ProxyConfigs proxyConfigs,
-                           ExternalTrustStoreConfigs externalTrustStoreConfigs) {
+                           boolean useGlobalProxyConfigs, ProxyConfigs proxyConfigs, TrustStoreConfigs trustStoreConfigs) {
 
         this.id = OAuthUtils.getRandomOAuthHandlerID();
         this.tokenApiUrl = tokenApiUrl;
@@ -79,7 +78,7 @@ public abstract class OAuthHandler implements AuthHandler {
         this.tokenCacheProvider = tokenCacheProvider;
         this.useGlobalProxyConfigs = useGlobalProxyConfigs;
         this.proxyConfigs = proxyConfigs;
-        this.externalTrustStoreConfigs = externalTrustStoreConfigs;
+        this.trustStoreConfigs = trustStoreConfigs;
     }
 
     @Override
@@ -112,7 +111,7 @@ public abstract class OAuthHandler implements AuthHandler {
                                 buildTokenRequestPayload(messageContext), getEncodedCredentials(messageContext),
                                 messageContext, getResolvedCustomHeadersMap(customHeadersMap, messageContext),
                                 connectionTimeout, connectionRequestTimeout, socketTimeout, proxyConfigs,
-                                externalTrustStoreConfigs);
+                                trustStoreConfigs);
 
                         // Cache the newly generated token
                         tokenCacheProvider.putToken(getId(messageContext), token);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -43,6 +43,7 @@ import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -361,12 +362,10 @@ public class OAuthUtils {
             trustStoreConfigs.setTrustStoreEnabled(true);
             trustStoreConfigs.setTrustStoreLocation(trustStoreLocation);
             trustStoreConfigs.setTrustStoreType(trustStoreType != null ? trustStoreType : "JKS"); // Default to JKS
-            trustStoreConfigs.setTrustStorePassword(trustStorePassword);
-
-            // Set up the secret resolver for trust store password
-            trustStoreConfigs.setTrustStorePasswordSecretResolver(SecretResolverFactory.create(new Properties() {{
-                setProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_PASSWORD, trustStorePassword);
-            }}));
+            trustStoreConfigs.setTrustStorePassword(MiscellaneousUtil.resolve(trustStorePassword,
+                    SecretResolverFactory.create(new Properties() {{
+                        setProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_PASSWORD, trustStorePassword);
+                    }})).toCharArray());
 
             if (log.isDebugEnabled()) {
                 log.debug("Loaded trust store configurations from synapse.properties: location="

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -31,7 +31,7 @@ import org.apache.synapse.commons.resolvers.ResolverFactory;
 import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.config.xml.XMLConfigConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
@@ -149,7 +149,7 @@ public class OAuthUtils {
         AuthorizationCodeHandler handler = new AuthorizationCodeHandler(tokenApiUrl, clientId, clientSecret,
                 refreshToken, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout, connectionRequestTimeout,
                 socketTimeout, TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs, proxyConfigs,
-                getExternalTrustStoreConfigs());
+                getTrustStoreConfigs());
         if (hasRequestParameters(authCodeElement)) {
             Map<String, String> requestParameters = getRequestParameters(authCodeElement);
             if (requestParameters == null) {
@@ -203,7 +203,7 @@ public class OAuthUtils {
         }
         ClientCredentialsHandler handler = new ClientCredentialsHandler(tokenApiUrl, clientId, clientSecret, authMode,
                 useGlobalConnectionTimeoutConfigs, connectionTimeout, connectionRequestTimeout, socketTimeout,
-                TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs, proxyConfigs, getExternalTrustStoreConfigs());
+                TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs, proxyConfigs, getTrustStoreConfigs());
         if (hasRequestParameters(clientCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(clientCredentialsElement);
             if (requestParameters == null) {
@@ -260,7 +260,7 @@ public class OAuthUtils {
         PasswordCredentialsHandler handler = new PasswordCredentialsHandler(tokenApiUrl, clientId, clientSecret,
                 username, password, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
                 connectionRequestTimeout, socketTimeout, TokenCacheFactory.getTokenCache(), useGlobalProxyConfigs,
-                proxyConfigs, getExternalTrustStoreConfigs());
+                proxyConfigs, getTrustStoreConfigs());
         if (hasRequestParameters(passwordCredentialsElement)) {
             Map<String, String> requestParameters = getRequestParameters(passwordCredentialsElement);
             if (requestParameters == null) {
@@ -343,44 +343,44 @@ public class OAuthUtils {
     }
 
     /**
-     * Creates ExternalTrustStoreConfigs from synapse.properties file.
-     * If external trust store properties are not configured in synapse.properties, returns a disabled configuration.
+     * Creates TrustStoreConfigs from synapse.properties for OAuth token endpoint.
+     * If trust store properties are not configured in synapse.properties, returns a disabled configuration.
      *
-     * @return ExternalTrustStoreConfigs object with configurations from synapse.properties
+     * @return TrustStoreConfigs object with configurations from synapse.properties
      */
-    private static ExternalTrustStoreConfigs getExternalTrustStoreConfigs() {
+    private static TrustStoreConfigs getTrustStoreConfigs() {
 
-        ExternalTrustStoreConfigs externalTrustStoreConfigs = new ExternalTrustStoreConfigs();
+        TrustStoreConfigs trustStoreConfigs = new TrustStoreConfigs();
 
         Properties synapseProperties = SynapsePropertiesLoader.loadSynapseProperties();
-        String trustStoreLocation = synapseProperties.getProperty(AuthConstants.OAUTH_TRUST_STORE_LOCATION_PROPERTY);
-        String trustStoreType = synapseProperties.getProperty(AuthConstants.OAUTH_TRUST_STORE_TYPE_PROPERTY);
-        String trustStorePassword = synapseProperties.getProperty(AuthConstants.OAUTH_TRUST_STORE_PASSWORD_PROPERTY);
+        String trustStoreLocation = synapseProperties.getProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_LOCATION);
+        String trustStoreType = synapseProperties.getProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_TYPE);
+        String trustStorePassword = synapseProperties.getProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_PASSWORD);
 
         if (trustStoreLocation != null && trustStorePassword != null) {
-            externalTrustStoreConfigs.setTrustStoreEnabled(true);
-            externalTrustStoreConfigs.setTrustStoreLocation(trustStoreLocation);
-            externalTrustStoreConfigs.setTrustStoreType(trustStoreType != null ? trustStoreType : "JKS"); // Default to JKS
-            externalTrustStoreConfigs.setTrustStorePassword(trustStorePassword);
+            trustStoreConfigs.setTrustStoreEnabled(true);
+            trustStoreConfigs.setTrustStoreLocation(trustStoreLocation);
+            trustStoreConfigs.setTrustStoreType(trustStoreType != null ? trustStoreType : "JKS"); // Default to JKS
+            trustStoreConfigs.setTrustStorePassword(trustStorePassword);
 
             // Set up the secret resolver for trust store password
-            externalTrustStoreConfigs.setTrustStorePasswordSecretResolver(SecretResolverFactory.create(new Properties() {{
-                setProperty(AuthConstants.OAUTH_TRUST_STORE_PASSWORD_PROPERTY, trustStorePassword);
+            trustStoreConfigs.setTrustStorePasswordSecretResolver(SecretResolverFactory.create(new Properties() {{
+                setProperty(AuthConstants.OAUTH_TOKEN_ENDPOINT_TRUST_STORE_PASSWORD, trustStorePassword);
             }}));
 
             if (log.isDebugEnabled()) {
-                log.debug("Loaded external trust store configurations from synapse.properties: location="
-                        + trustStoreLocation + ", type=" + externalTrustStoreConfigs.getTrustStoreType());
+                log.debug("Loaded trust store configurations from synapse.properties: location="
+                        + trustStoreLocation + ", type=" + trustStoreConfigs.getTrustStoreType());
             }
         } else {
-            externalTrustStoreConfigs.setTrustStoreEnabled(false);
+            trustStoreConfigs.setTrustStoreEnabled(false);
 
             if (log.isDebugEnabled()) {
-                log.debug("External trust store is not configured in synapse.properties. External trust store will " +
-                        "be disabled.");
+                log.debug("Trust store is not configured in synapse.properties. Trust store will be disabled for OAuth" +
+                        "token endpoint.");
             }
         }
-        return externalTrustStoreConfigs;
+        return trustStoreConfigs;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -751,30 +751,4 @@ public class OAuthUtils {
 
         return proxyConfigsOM;
     }
-
-    /**
-     * Create an OMElement for external trust store configurations.
-     *
-     * @param omFactory                 OMFactory instance used to create OMElements.
-     * @param externalTrustStoreConfigs ExternalTrustStoreConfigs containing trust store configuration details.
-     * @return OMElement of external trust store configurations.
-     */
-    public static OMElement createOMExternalTrustStore(OMFactory omFactory, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
-        OMElement externalTrustStoreConfigsOM = omFactory.createOMElement(AuthConstants.EXTERNAL_TRUST_STORE_CONFIGS,
-                SynapseConstants.SYNAPSE_OMNAMESPACE);
-
-        OMElement trustStoreLocationOM = OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.TRUST_STORE_LOCATION,
-                externalTrustStoreConfigs.getTrustStoreLocation());
-        externalTrustStoreConfigsOM.addChild(trustStoreLocationOM);
-
-        OMElement trustStoreTypeOM = OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.TRUST_STORE_TYPE,
-                externalTrustStoreConfigs.getTrustStoreType());
-        externalTrustStoreConfigsOM.addChild(trustStoreTypeOM);
-
-        OMElement trustStorePasswordOM = OAuthUtils.createOMElementWithValue(omFactory, AuthConstants.TRUST_STORE_PASSWORD,
-                externalTrustStoreConfigs.getTrustStorePassword());
-        externalTrustStoreConfigsOM.addChild(trustStorePasswordOM);
-
-        return externalTrustStoreConfigsOM;
-    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -38,6 +38,21 @@ public class PasswordCredentialsHandler extends OAuthHandler {
     private final String username;
     private final String password;
 
+    /**
+     * Backward compatibility constructor without TrustStoreConfigs
+     * @deprecated Use constructor with TrustStoreConfigs parameter for enhanced SSL configuration support
+     */
+    @Deprecated
+    protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
+                                         String password, String authMode, boolean useGlobalConnectionTimeoutConfigs,
+                                         int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
+                                         TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
+                                         ProxyConfigs proxyConfigs) {
+        this(tokenApiUrl, clientId, clientSecret, username, password, authMode, useGlobalConnectionTimeoutConfigs,
+                connectionTimeout, connectionRequestTimeout, socketTimeout, tokenCacheProvider,
+                useGlobalProxyConfigs, proxyConfigs, null);
+    }
+
     protected PasswordCredentialsHandler(String tokenApiUrl, String clientId, String clientSecret, String username,
                                          String password, String authMode, boolean useGlobalConnectionTimeoutConfigs,
                                          int connectionTimeout, int connectionRequestTimeout, int socketTimeout,

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -23,6 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -41,10 +42,11 @@ public class PasswordCredentialsHandler extends OAuthHandler {
                                          String password, String authMode, boolean useGlobalConnectionTimeoutConfigs,
                                          int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
                                          TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                         ProxyConfigs proxyConfigs) {
+                                         ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
-                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs);
+                connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
+                externalTrustStoreConfigs);
         this.username = username;
         this.password = password;
     }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/PasswordCredentialsHandler.java
@@ -23,7 +23,7 @@ import org.apache.axiom.om.OMFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
 import org.apache.synapse.endpoints.auth.AuthException;
@@ -42,11 +42,11 @@ public class PasswordCredentialsHandler extends OAuthHandler {
                                          String password, String authMode, boolean useGlobalConnectionTimeoutConfigs,
                                          int connectionTimeout, int connectionRequestTimeout, int socketTimeout,
                                          TokenCacheProvider tokenCacheProvider, boolean useGlobalProxyConfigs,
-                                         ProxyConfigs proxyConfigs, ExternalTrustStoreConfigs externalTrustStoreConfigs) {
+                                         ProxyConfigs proxyConfigs, TrustStoreConfigs trustStoreConfigs) {
 
         super(tokenApiUrl, clientId, clientSecret, authMode, useGlobalConnectionTimeoutConfigs, connectionTimeout,
                 connectionRequestTimeout, socketTimeout, tokenCacheProvider, useGlobalProxyConfigs, proxyConfigs,
-                externalTrustStoreConfigs);
+                trustStoreConfigs);
         this.username = username;
         this.password = password;
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
@@ -38,6 +38,7 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.transport.passthru.PassThroughHttpSender;
@@ -112,7 +113,7 @@ public class OAuthClientTest extends TestCase {
         SynapseEnvironment synapseEnvironment = new Axis2SynapseEnvironment(synapseConfiguration);
         String token = OAuthClient.generateToken("https://localhost:8280/token1/1.0.0", "body", "credentials",
                 new Axis2MessageContext(messageContext, new SynapseConfiguration(), synapseEnvironment), null, -1, -1,
-                -1, new ProxyConfigs());
+                -1, new ProxyConfigs(), new ExternalTrustStoreConfigs());
 
         assertEquals("abc123", token);
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthClientTest.java
@@ -38,7 +38,7 @@ import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.mediators.TestUtils;
 import org.apache.synapse.transport.passthru.PassThroughHttpSender;
@@ -113,7 +113,7 @@ public class OAuthClientTest extends TestCase {
         SynapseEnvironment synapseEnvironment = new Axis2SynapseEnvironment(synapseConfiguration);
         String token = OAuthClient.generateToken("https://localhost:8280/token1/1.0.0", "body", "credentials",
                 new Axis2MessageContext(messageContext, new SynapseConfiguration(), synapseEnvironment), null, -1, -1,
-                -1, new ProxyConfigs(), new ExternalTrustStoreConfigs());
+                -1, new ProxyConfigs(), new TrustStoreConfigs());
 
         assertEquals("abc123", token);
     }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
@@ -36,6 +36,7 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
+import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
 import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
@@ -306,7 +307,7 @@ public class OAuthUtilsTest {
                     new AuthorizationCodeHandler("oauth_server_url", "client_id", "client_secret",
                             "refresh_token", "header", false,
                             -1, -1, -1, TokenCache.getInstance(),
-                            false, new ProxyConfigs());
+                            false, new ProxyConfigs(), new ExternalTrustStoreConfigs());
 
             OAuthConfiguredHTTPEndpoint httpEndpoint = new OAuthConfiguredHTTPEndpoint(oAuthHandler);
 

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtilsTest.java
@@ -36,7 +36,7 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
-import org.apache.synapse.endpoints.ExternalTrustStoreConfigs;
+import org.apache.synapse.endpoints.TrustStoreConfigs;
 import org.apache.synapse.endpoints.OAuthConfiguredHTTPEndpoint;
 import org.apache.synapse.endpoints.ProxyConfigs;
 import org.apache.synapse.endpoints.auth.AuthConstants;
@@ -307,7 +307,7 @@ public class OAuthUtilsTest {
                     new AuthorizationCodeHandler("oauth_server_url", "client_id", "client_secret",
                             "refresh_token", "header", false,
                             -1, -1, -1, TokenCache.getInstance(),
-                            false, new ProxyConfigs(), new ExternalTrustStoreConfigs());
+                            false, new ProxyConfigs(), new TrustStoreConfigs());
 
             OAuthConfiguredHTTPEndpoint httpEndpoint = new OAuthConfiguredHTTPEndpoint(oAuthHandler);
 


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/4239

### Overview
This PR introduces support for configuring trust stores for OAuth token endpoint connections in WSO2 Synapse. This enhancement allows users to specify custom trust store configurations independently from the main Axis2 transport configurations, providing more flexibility in managing SSL certificates for token endpoint connection in OAuth-protected endpoints.

### Changes Made

#### New Components Added:
1. **`TrustStoreConfigs`** - Model class for trust store configurations
   - Properties for trust store location, type, password, and enablement status
   - SecretResolver integration for secure password handling

#### Enhanced Components:
2. **`AuthConstants`** - Added new property constants for trust store configuration:
   - `synapse.endpoint.http.oauth.token.endpoint.trust.store.location`
   - `synapse.endpoint.http.oauth.token.endpoint.trust.store.type`
   - `synapse.endpoint.http.oauth.token.endpoint.trust.store.password`

3. **`OAuthClient`** - Major refactoring for SSL context management:
   - Introduced `getSSLContext()` method that prioritizes trust store over Axis2 configs
   - Added `getSSLContextFromTrustStore()` for creating SSL context from trust store
   - Refactored proxy and non-proxy client creation methods for better code organization
   - Enhanced error handling and validation for trust store configurations

### Key Features:
- **Flexible Configuration**: Trust store can be enabled/disabled through `synapse.properties`
- **Security**: Integrated with WSO2 SecureVault for encrypted password storage
- **Backward Compatibility**: Falls back to existing Axis2 transport configurations when trust store is not configured
- **Error Handling**: Comprehensive validation and error reporting for trust store configurations

### Configuration Properties:
Users can now configure the following properties in `synapse.properties`:
```properties
synapse.endpoint.http.oauth.token.endpoint.trust.store.location=/path/to/truststore.jks
synapse.endpoint.http.oauth.token.endpoint.trust.store.type=JKS
synapse.endpoint.http.oauth.token.endpoint.trust.store.password=truststore_password