### PR TITLE
Downgrade bouncycastle version to identify a test root cause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1534,7 +1534,7 @@
       <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
       <qfj.version>1.5.3</qfj.version>
        <quickfixj.version>2.3.1</quickfixj.version>
-      <org.bouncycastle.version>1.81.0.wso2v1</org.bouncycastle.version>
+      <org.bouncycastle.version>1.78.1.wso2v1</org.bouncycastle.version>
       <imp.pkg.version.wso2.bouncycastle>[1.52.0,2.0.0)</imp.pkg.version.wso2.bouncycastle>
        <httpcore.version>4.4.16</httpcore.version>
       <httpcore.wso2.version>${httpcore.version}.wso2v1</httpcore.wso2.version>


### PR DESCRIPTION
## Purpose
This PR reverts the BouncyCastle update done by https://github.com/wso2/wso2-synapse/pull/2382. 

This is done to analyze the root cause of the test failures observed in the MI public build, which cannot be reproduced in the local environment. We suspect that the BouncyCastle update may be reason to these failures.