### PR TITLE
Add Replay Transaction Capture Support for Pass-through HTTP Transport

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDataWriter.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDataWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.http.conn;
+
+import java.io.IOException;
+
+/**
+ * Defines the contract for writing replay data within the HTTP transport layer.
+ * <p>
+ * Implementations of this interface handle the persistence of replay records—such as
+ * request data into various storage mediums, which may include file systems,
+ * in-memory buffers, or other destinations.
+ * </p>
+ *
+ * <p>
+ * This interface acts as an extension point so that custom data writers can be plugged in
+ * without altering the core replay dispatching mechanism.
+ * </p>
+ *
+ * @see ReplayRecord for structure details of replay data.
+ */
+public interface ReplayDataWriter {
+
+    /**
+     * Writes a replay record containing message data and associated metadata.
+     * Implementations are responsible for defining how and where the record
+     * is persisted.
+     *
+     * @param replayRecord the {@link ReplayRecord} instance to be written
+     * @throws IOException if any I/O error occurs during the write operation
+     */
+    void write(ReplayRecord replayRecord) throws IOException;
+
+    /**
+     * Closes this writer and releases any underlying system resources such as
+     * file streams or buffers.
+     * <p>This method is called during transport shutdown to ensure proper
+     * resource cleanup.</p>
+     *
+     * @throws IOException if an error occurs while closing underlying resources
+     */
+    void close() throws IOException;
+}
+

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
@@ -45,7 +45,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ReplayDispatcher {
     private static final Log log = LogFactory.getLog(ReplayDispatcher.class);
     private static volatile ReplayDispatcher instance;
-    private volatile boolean running = true;
     // Counter tracking the number of dropped replay records due to queue overflow
     private final AtomicLong droppedCount = new AtomicLong(0);
     // Writer instance that handles actual replay data persistence
@@ -175,7 +174,7 @@ public class ReplayDispatcher {
     /**
      * Starts the background thread pool which asynchronously writes buffered replay records using
      * the configured ReplayDataWriter.
-     * The worker threads run until running is set to false and the queue is drained.
+     * The worker threads run until the queue is drained.
      */
     private void startReplayWorker() {
         // ExecutorService managing a configurable pool of worker threads for asynchronously processing replay records
@@ -193,7 +192,7 @@ public class ReplayDispatcher {
 
         for (int i = 0; i < ReplayDispatcher.CORE_POOL_SIZE; i++) {
             replayWorkerThreadPool.submit(() -> {
-                while (running || !replayQueue.isEmpty()) {
+                while (!replayQueue.isEmpty()) {
                     ReplayRecord replayRecord = replayQueue.poll();
                     if (replayRecord != null) {
                         try {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
@@ -55,7 +55,7 @@ public class ReplayDispatcher {
     private static final Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);
     // Maximum size of the replay record queue
     private static final int REPLAY_MAX_BUFFER_SIZE = Integer.parseInt(
-            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_MAX_BUFFER_SIZE_KEY, "1000"));
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_MAX_BUFFER_SIZE_KEY, "10000"));
     // Frequency at which dropped message logs are emitted
     private static final int REPLAY_LOG_DROP_FREQUENCY = Integer.parseInt(
             MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_LOG_DROP_FREQUENCY_KEY, "100"));

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayDispatcher.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.http.conn;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Singleton manager class responsible for buffering replay data and asynchronously writing it
+ * to a configured ReplayDataWriter.
+ * A dedicated background thread consumes records from the queue and writes them using the
+ * ReplayDataWriter implementation configured dynamically through properties.
+ * This class is thread-safe and supports graceful shutdown by closing the writer and stopping the background thread.
+ */
+public class ReplayDispatcher {
+    private static final Log log = LogFactory.getLog(ReplayDispatcher.class);
+    private static volatile ReplayDispatcher instance;
+    private volatile boolean running = true;
+    // Counter tracking the number of dropped replay records due to queue overflow
+    private final AtomicLong droppedCount = new AtomicLong(0);
+    // Writer instance that handles actual replay data persistence
+    private final ReplayDataWriter replayDataWriter;
+    private static final String PROPERTY_FILE = "passthru-http.properties";
+    // Loaded configuration properties
+    private static final Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);
+    // Maximum size of the replay record queue
+    private static final int REPLAY_MAX_BUFFER_SIZE = Integer.parseInt(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_MAX_BUFFER_SIZE_KEY, "1000"));
+    // Frequency at which dropped message logs are emitted
+    private static final int REPLAY_LOG_DROP_FREQUENCY = Integer.parseInt(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_LOG_DROP_FREQUENCY_KEY, "100"));
+    // Poll interval in milliseconds for replay queue when empty
+    private static final int REPLAY_BUFFER_POLL_INTERVAL = Integer.parseInt(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_BUFFER_POLL_INTERVAL_MS_KEY, "50"));
+    // Core number of threads to keep in the pool, even if idle;
+    private static final int CORE_POOL_SIZE = Integer.parseInt(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_WORKER_CORE_POOL_SIZE_KEY, "4"));
+    // Maximum number of threads allowed in the pool
+    private static final int MAX_POOL_SIZE = Integer.parseInt(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_WORKER_MAX_POOL_SIZE_KEY, "8"));
+    // Time in milliseconds that excess idle threads (beyond core size) will wait before terminating
+    private static final long KEEP_ALIVE_TIME_MILLIS = Long.parseLong(
+            MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_WORKER_KEEP_ALIVE_TIME_MS_KEY, "30000"));
+
+    private final BlockingQueue<ReplayRecord> replayQueue = new LinkedBlockingQueue<>(REPLAY_MAX_BUFFER_SIZE);
+
+    /**
+     * Private constructor for singleton. Initializes the replay writer and starts the background worker thread.
+     *
+     * @param replayDataWriter an implementation of ReplayDataWriter used for persisting replay records
+     */
+    private ReplayDispatcher(ReplayDataWriter replayDataWriter) {
+        this.replayDataWriter = replayDataWriter;
+        log.info("Initializing OverflowBufferManager with buffer size: " + REPLAY_MAX_BUFFER_SIZE);
+        startReplayWorker();
+    }
+
+    /**
+     * Returns the singleton instance of the ReplayDispatcher, creating it if necessary.
+     * Dynamically instantiates the writer class configured via properties. Throws an
+     * IllegalStateException for missing or invalid configuration.
+     *
+     * @return singleton instance of this dispatcher
+     */
+    public static ReplayDispatcher getInstance() {
+        if (instance == null) {
+            synchronized (ReplayDispatcher.class) {
+                if (instance == null) {
+                    try {
+                        String writerClassName = MiscellaneousUtil.getProperty(props,
+                                PassThroughConstants.REPLAY_TRANSACTION_WRITER_CLASS_KEY, null);
+
+                        if (writerClassName == null || writerClassName.isEmpty()) {
+                            throw new IllegalStateException(
+                                    "Required config '" + PassThroughConstants.REPLAY_TRANSACTION_WRITER_CLASS_KEY
+                                            + "' missing");
+                        }
+                        // Dynamically load and instantiate writer
+                        Class<?> writerClass = Class.forName(writerClassName);
+                        if (!ReplayDataWriter.class.isAssignableFrom(writerClass)) {
+                            throw new IllegalStateException(
+                                    "Configured class " + writerClassName + " does not implement ReplayDataWriter");
+                        }
+                        ReplayDataWriter writerInstance;
+                        try {
+                            writerInstance = (ReplayDataWriter) writerClass.getConstructor().newInstance();
+                        } catch (Exception e) {
+                            log.fatal("Failed to instantiate ReplayDataWriter with no-arg constructor", e);
+                            throw new IllegalStateException("Failed to instantiate ReplayDataWriter", e);
+                        }
+                        instance = new ReplayDispatcher(writerInstance);
+                        log.info("ReplayDispatcher initialized with custom writer class: " + writerClassName);
+                    } catch (Exception e) {
+                        log.fatal("Failed to initialize ReplayDispatcher dynamically", e);
+                        throw new IllegalStateException("Failed to initialize ReplayDispatcher", e);
+                    }
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Adds a replay record to the internal buffer queue for later asynchronous writing.
+     * If the queue is full, drops the message and logs drop occurrences at configured frequency.
+     *
+     * @param messageId unique identifier of the message
+     * @param metadata  metadata map describing contextual information of the message
+     * @param data      raw byte array of the message content
+     */
+    public void addReplayRecord(String messageId, Map<String, Object> metadata, byte[] data) {
+        boolean accepted = replayQueue.offer(new ReplayRecord(messageId, metadata, data));
+        if (!accepted) {
+            long dropped = droppedCount.incrementAndGet();
+            if (dropped % REPLAY_LOG_DROP_FREQUENCY == 0) {
+                log.warn("Replay buffer overflow: dropped " + dropped + " messages so far; " +
+                        "Latest dropped messageID: " + messageId);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Replay buffer overflow: dropped message with ID: " + messageId);
+                }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Buffer accepted message with ID: " + messageId + ". Current buffer size: "
+                        + replayQueue.size());
+            }
+        }
+    }
+
+    /**
+     * Convenience method to wrap data in ByteBuffer and delegate to addReplayRecord(String, byte[], Map).
+     *
+     * @param dataBuffer    byte buffer containing the raw message data
+     * @param byteWritten   number of bytes written to the buffer
+     * @param messageId     unique message identifier
+     * @param metadata      metadata map for contextual information
+     */
+    public void addReplayRecord(ByteBuffer dataBuffer, int byteWritten, String messageId, Map<String, Object> metadata) {
+        byte[] data = new byte[byteWritten];
+        dataBuffer.get(data);
+        addReplayRecord(messageId, metadata, data);
+    }
+
+    /**
+     * Starts the background thread pool which asynchronously writes buffered replay records using
+     * the configured ReplayDataWriter.
+     * The worker threads run until running is set to false and the queue is drained.
+     */
+    private void startReplayWorker() {
+        // ExecutorService managing a configurable pool of worker threads for asynchronously processing replay records
+        ExecutorService replayWorkerThreadPool = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE,
+                KEEP_ALIVE_TIME_MILLIS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), new ThreadFactory() {
+            private final AtomicLong threadIndex = new AtomicLong(1);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r, "ReplayTransaction-Writer-" + threadIndex.getAndIncrement());
+                thread.setDaemon(true);
+                return thread;
+            }
+        });
+
+        for (int i = 0; i < ReplayDispatcher.CORE_POOL_SIZE; i++) {
+            replayWorkerThreadPool.submit(() -> {
+                while (running || !replayQueue.isEmpty()) {
+                    ReplayRecord replayRecord = replayQueue.poll();
+                    if (replayRecord != null) {
+                        try {
+                            replayDataWriter.write(replayRecord);
+                            if (log.isDebugEnabled()) {
+                                log.debug("Successfully wrote buffer data for messageID: " + replayRecord.getMessageId());
+                            }
+                        } catch (IOException e) {
+                            log.error("Failed to write buffered data for messageID: " + replayRecord.getMessageId(), e);
+                        }
+                    } else {
+                        // No data, prevent tight spinning
+                        try {
+                            Thread.sleep(REPLAY_BUFFER_POLL_INTERVAL);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            if (log.isDebugEnabled()) {
+                                log.debug("ReplayTransaction-BufferDataWriter thread interrupted during sleep");
+                            }
+                            // Exit loop if interrupted while stopping
+                            break;
+                        }
+                    }
+                }
+                try {
+                    replayDataWriter.close();
+                    log.info("ReplayTransaction-BufferDataWriter closed BufferDataWriter cleanly");
+                } catch (IOException e) {
+                    log.error("Failed to close BufferDataWriter during thread termination", e);
+                }
+            });
+        }
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayIOSession.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayIOSession.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.http.conn;
+
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.nio.reactor.IOSession;
+import org.apache.http.nio.reactor.SessionBufferStatus;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.TargetContext;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SelectionKey;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ReplayIOSession implements IOSession {
+
+    private static AtomicLong COUNT = new AtomicLong(0);
+    private final Log log;
+    private final IOSession session;
+    private final ByteChannel channel;
+    private final String id;
+
+    public ReplayIOSession(
+            final IOSession session, final String id) {
+        super();
+        if (session == null) {
+            throw new IllegalArgumentException("I/O session may not be null");
+        }
+        this.session = session;
+        this.channel = new ReplayIOSession.ReplayByteChannel();
+        this.id = id + "-" + COUNT.incrementAndGet();
+        this.log = LogFactory.getLog(session.getClass());
+    }
+
+    public int getStatus() {
+        return this.session.getStatus();
+    }
+
+    public ByteChannel channel() {
+        return this.channel;
+    }
+
+    public SocketAddress getLocalAddress() {
+        return this.session.getLocalAddress();
+    }
+
+    public SocketAddress getRemoteAddress() {
+        return this.session.getRemoteAddress();
+    }
+
+    public int getEventMask() {
+        return this.session.getEventMask();
+    }
+
+    private static String formatOps(int ops) {
+        StringBuffer buffer = new StringBuffer(6);
+        buffer.append('[');
+        if ((ops & SelectionKey.OP_READ) > 0) {
+            buffer.append('r');
+        }
+        if ((ops & SelectionKey.OP_WRITE) > 0) {
+            buffer.append('w');
+        }
+        if ((ops & SelectionKey.OP_ACCEPT) > 0) {
+            buffer.append('a');
+        }
+        if ((ops & SelectionKey.OP_CONNECT) > 0) {
+            buffer.append('c');
+        }
+        buffer.append(']');
+        return buffer.toString();
+    }
+
+    public void setEventMask(int ops) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Set event mask "
+                    + formatOps(ops));
+        }
+        this.session.setEventMask(ops);
+    }
+
+    public void setEvent(int op) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Set event "
+                    + formatOps(op));
+        }
+        this.session.setEvent(op);
+    }
+
+    public void clearEvent(int op) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Clear event "
+                    + formatOps(op));
+        }
+        this.session.clearEvent(op);
+    }
+
+    public void close() {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Close");
+        }
+        this.session.close();
+    }
+
+    public boolean isClosed() {
+        return this.session.isClosed();
+    }
+
+    public void shutdown() {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Shutdown");
+        }
+        this.session.shutdown();
+    }
+
+    public int getSocketTimeout() {
+        return this.session.getSocketTimeout();
+    }
+
+    public void setSocketTimeout(int timeout) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Set timeout "
+                    + timeout);
+        }
+        this.session.setSocketTimeout(timeout);
+    }
+
+    public void setBufferStatus(final SessionBufferStatus status) {
+        this.session.setBufferStatus(status);
+    }
+
+    public boolean hasBufferedInput() {
+        return this.session.hasBufferedInput();
+    }
+
+    public boolean hasBufferedOutput() {
+        return this.session.hasBufferedOutput();
+    }
+
+    public Object getAttribute(final String name) {
+        return this.session.getAttribute(name);
+    }
+
+    public void setAttribute(final String name, final Object obj) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Set attribute "
+                    + name);
+        }
+        this.session.setAttribute(name, obj);
+    }
+
+    public Object removeAttribute(final String name) {
+        if (this.log.isDebugEnabled()) {
+            this.log.debug("I/O session " + this.id + " " + this.session + ": Remove attribute "
+                    + name);
+        }
+        return this.session.removeAttribute(name);
+    }
+
+    class ReplayByteChannel implements ByteChannel {
+
+        public int read(final ByteBuffer dst) throws IOException {
+
+            int bytesRead = session.channel().read(dst);
+            if (log.isDebugEnabled()) {
+                log.debug("I/O session " + id + " " + session + ": " + bytesRead + " bytes read");
+            }
+            return bytesRead;
+        }
+
+        public int write(final ByteBuffer src) throws IOException {
+            int byteWritten = session.channel().write(src);
+            if (log.isDebugEnabled()) {
+                log.debug("I/O session " + id + " " + session + ": " + byteWritten + " bytes written");
+            }
+            // Retrieve request context associated with this session
+            Object request = session.getAttribute("CONNECTION_INFORMATION");
+            if (!(request instanceof TargetContext)) {
+                log.warn("Unexpected connection type in session attribute: " + (request == null ?
+                        "null" :
+                        request.getClass()));
+                return byteWritten;
+            }
+            // Extract the MessageContext from the target connection
+            MessageContext mc = ((TargetContext) request).getRequestMsgCtx();
+            // Skip recording for methods not in allowed write list
+            String httpMethod = (String) mc.getProperty("HTTP_METHOD");
+            if (!isAllowedWriteMethod(httpMethod)) {
+                return byteWritten;
+            }
+            // Generate or fallback to UNKNOWN message ID for traceability
+            String messageID = (mc.getMessageID() != null) ? mc.getMessageID() : "UNKNOWN";
+
+            // Read boolean flag to check if replay is enabled per API or resource
+            Boolean enabled = (Boolean) mc.getProperty("ENABLE_REPLAY_TRANSACTION");
+            boolean isReplayEnabled = enabled != null && enabled;
+            if (!isReplayEnabled) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Replay transaction disabled for message ID: " + messageID);
+                }
+                return byteWritten;
+            }
+            // Duplicate and segment ByteBuffer to isolate written data
+            ByteBuffer copyBuffer = src.duplicate();
+            int currentPos = copyBuffer.position();
+            copyBuffer.limit(currentPos);
+            copyBuffer.position(currentPos - byteWritten);
+
+            // Handle chunk order tracking
+            Integer chunkOrder = (Integer) mc.getProperty(PassThroughConstants.CHUNK_ORDER_PROPERTY);
+            if (chunkOrder == null) {
+                // First chunk, initialize to 1
+                chunkOrder = 1;
+            } else {
+                // Increment for subsequent chunks
+                chunkOrder++;
+            }
+            // Set or update chunk order in the message context
+            mc.setProperty(PassThroughConstants.CHUNK_ORDER_PROPERTY, chunkOrder);
+
+            // Efficiently gather all MessageContext properties into a local metadata map.
+            // getProperties() does not return all properties due to AbstractContext implementation,
+            // hence properties are explicitly retrieved by iterating over property names.
+            Map<String, Object> metadata = new HashMap<>();
+            for (Iterator<String> it = mc.getPropertyNames(); it.hasNext(); ) {
+                String key = it.next();
+                Object value = mc.getProperty(key);
+                if (value != null) {
+                    metadata.put(key, value);
+                }
+            }
+            // Dispatch replay record for asynchronous persistence or processing
+            ReplayDispatcher.getInstance().addReplayRecord(copyBuffer, byteWritten, messageID, metadata);
+            return byteWritten;
+        }
+
+        /**
+         * Checks whether the given HTTP method is permitted for write operations during replay capture.
+         *
+         * @param method HTTP method name (case-insensitive)
+         * @return true if the method is allowed for replay write operations; false otherwise
+         */
+        private boolean isAllowedWriteMethod(String method) {
+            if (method == null) return false;
+            return PassThroughConstants.ALLOWED_WRITE_METHODS.contains(method.toUpperCase());
+        }
+
+        public void close() throws IOException {
+            if (log.isDebugEnabled()) {
+                log.debug("I/O session " + id + " " + session + ": Channel close");
+            }
+            session.channel().close();
+        }
+
+        public boolean isOpen() {
+            return session.channel().isOpen();
+        }
+
+    }
+
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayRecord.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/ReplayRecord.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.transport.http.conn;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents a single replay record that encapsulates message content and
+ * associated metadata for replay purposes.
+ *
+ * @see ReplayDataWriter for writing and persisting replay records.
+ */
+public class ReplayRecord {
+
+    /** Unique identifier for this message record. */
+    private final String messageId;
+
+    /** Metadata key-value pairs describing contextual properties of the replayed message. */
+    private final Map<String, Object> metadata;
+
+    /** Raw binary representation of the message content (headers, payload, etc.). */
+    private final byte[] data;
+
+    /**
+     * Constructs a new replay record instance containing the unique message ID,
+     * metadata, and raw data of the message.
+     *
+     * @param messageId a unique identifier for the replayed message; may not be null
+     * @param metadata  map containing message context metadata; may be null if not applicable
+     * @param data      byte array containing the message payload; may be null or empty
+     */
+    public ReplayRecord(String messageId, Map<String, Object> metadata, byte[] data) {
+        this.messageId = messageId;
+        this.data = (data != null) ? data.clone() : null;  // clone for data safety
+
+        if (metadata != null) {
+            // Wrap map unmodifiable to prevent changes from this instance,
+            // but does not protect if original metadata map is mutated externally
+            this.metadata = Collections.unmodifiableMap(metadata);
+        } else {
+            this.metadata = Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Returns the unique identifier associated with this replay record.
+     *
+     * @return message ID string
+     */
+    public String getMessageId() {
+        return messageId;
+    }
+
+    /**
+     * Returns metadata associated with this record.
+     * The metadata includes contextual information such as API name, version,
+     * transport headers, or other attributes recorded at replay capture time.
+     *
+     * @return metadata map, or null if no metadata is available
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Returns the raw binary message data contained in this record.
+     *
+     * @return byte array of message data, or null if not set
+     */
+    public byte[] getData() {
+        return data != null ? data.clone() : null;
+    }
+}

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -16,6 +16,11 @@
 
 package org.apache.synapse.transport.passthru;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class PassThroughConstants {
 
     public static final int DEFAULT_IO_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
@@ -277,4 +282,33 @@ public class PassThroughConstants {
     public static final String CORRELATION_DEFAULT_HEADER = "activityid";
     public static final String TRANSPORT_LATENCY_LOGGER = "transport-latency";
     public static final String TRANSPORT_IN_URL = "TransportInURL";
+
+    /**
+     * Transaction replay configuration properties
+     */
+
+    // Configuration key to enable or disable replay transactions in pass-through transport
+    public static final String REPLAY_TXN_ENABLED_KEY = "pass.through.transport.enableReplayTransaction";
+    // Configuration key for frequency of logging dropped replay messages when the buffer overflows
+    public static final String REPLAY_LOG_DROP_FREQUENCY_KEY = "pass.through.transport.replay.buffer.log.drop.frequency";
+    // Configuration key defining max size of the replay transaction buffer queue
+    public static final String REPLAY_MAX_BUFFER_SIZE_KEY = "pass.through.transport.replay.transaction.max.buffer.size";
+    // Configuration key for polling interval (in milliseconds) for replay transaction buffer thread
+    public static final String REPLAY_BUFFER_POLL_INTERVAL_MS_KEY = "pass.through.transport.replay.transaction.buffer.poll.interval.ms";
+    // Configuration key specifying the fully qualified class name of the ReplayDataWriter implementation
+    public static final String REPLAY_TRANSACTION_WRITER_CLASS_KEY = "pass.through.transport.replay.transaction.writer.class";
+    // Core number of threads to keep in the pool consistently during idle periods
+    public static final String REPLAY_WORKER_CORE_POOL_SIZE_KEY = "pass.through.transport.replay.worker.core.pool.size";
+    // Maximum number of threads allowed in the pool to handle peak loads
+    public static final String REPLAY_WORKER_MAX_POOL_SIZE_KEY = "pass.through.transport.replay.worker.max.pool.size";
+    // Idle timeout in milliseconds after which threads above core size are terminated
+    public static final String REPLAY_WORKER_KEEP_ALIVE_TIME_MS_KEY = "pass.through.transport.replay.worker.keep.alive.time.ms";
+    // Allowed HTTP methods for replay writes.
+    // Arrays.asList creates a fixed-size list of elements,
+    // HashSet provides fast O(1) lookup for membership checks,
+    // Collections.unmodifiableSet wraps to ensure immutability for thread safety and consistency,
+    // this combination balances initialization simplicity, read performance, and memory efficiency.
+    public static final Set<String> ALLOWED_WRITE_METHODS =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("POST", "PUT", "PATCH", "DELETE")));
+    public static final String CHUNK_ORDER_PROPERTY = "CHUNK_ORDER";
 }


### PR DESCRIPTION
### Description
This PR adds the capability to capture and replay HTTP transactions in the WSO2 Pass-through HTTP transport layer. The feature enables buffering HTTP request data along with metadata and asynchronously writing the replay records via a pluggable writer component.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/4421

#### Key Functionality:
Replay Transaction Integration

- Adds replay-aware I/O handling within the HTTP transport layer to capture outgoing message content from the client pipe.
- Replay is enabled per message through a dynamic property and recorded with metadata derived from the MessageContext.
- Introduces ReplayDispatcher — a singleton manager responsible for buffering replay records and writing them asynchronously using configurable worker threads.
- Defines the ReplayDataWriter interface as an extension point for custom replay storage mechanisms (e.g., file writer, DB, telemetry sink).

#### Major Code Additions:

- `ReplayIOSession.java`
Wraps existing I/O sessions and intercepts write operations to extract message data for replay recording.
- `ReplayDispatcher.java`
Buffers replay records in a configurable queue and writes them asynchronously with overflow handling and thread‑safe shutdown support.
- `ReplayDataWriter.java`
Interface defining a generic persistence contract for replay records, enabling custom outputs such as files or external systems.
- `ReplayRecord.java`
Immutable holder for the message ID, metadata, and payload of each replay transaction.

<img width="2846" height="1498" alt="image" src="https://github.com/user-attachments/assets/7e676301-0e54-4fb2-8c26-295c14d75350" />


#### Key Highlights:

- Replay transaction enablement controlled via `deployment.toml` configuration to allow on/off toggling.
- Buffer and queue messages for asynchronous persistence with configurable size and polling intervals.
- Custom pluggable replay data writer supports extensibility.
- Handles buffer overflow by dropping excess records safely with controlled logging.
- Can be dynamically enabled or disabled per API/resource using a mediation policy.
---
#### Deployment Configuration
Add replay configuration under `[transport.http]` in `deployment.toml`:
```toml
[transport.http]
pass_through_transport_enableReplayTransaction=true
pass_through_transport_replay_buffer_log_drop_frequency=100
pass_through_transport_replay_transaction_max_buffer_size=10000
pass_through_transport_replay_transaction_buffer_poll_interval_ms=50
pass_through_transport_replay_transaction_writer_class="<FULLY_QUALIFIED_CLASS_NAME>"
pass_through_transport_replay_worker_core_pool_size=4
pass_through_transport_replay_worker_max_pool_size=8
pass_through_transport_replay_worker_keep_alive_time_ms=30000
```
Replace `<FULLY_QUALIFIED_CLASS_NAME>` with a custom writer class such as `"org.wso2.carbon.test.CustomFileReplayWriter"` for own implementation.

#### Maven Bundle Sample (pom.xml)
Lightweight template for custom writer bundle:
```xml
<project>
  <groupId>org.wso2.carbon.test</groupId>
  <artifactId>org.wso2.carbon.test</artifactId>
  <version>1.0-SNAPSHOT</version>
  <packaging>bundle</packaging>

  <build>
    <plugins>
      <plugin>
        <groupId>org.apache.felix</groupId>
        <artifactId>maven-bundle-plugin</artifactId>
      </plugin>
      <!-- Additional config -->
    </plugins>
  </build>

  <dependencies>
    <dependency>
      <groupId>org.apache.synapse</groupId>
      <artifactId>synapse-core</artifactId>
      <scope>provided</scope>
    </dependency>
    <!-- Add other dependencies if required -->
  </dependencies>
</project>
```

#### Usage - Enable/Disable Per API or Resource
Add the following mediation policy to selectively enable the replay feature on APIs or resources as needed:
```xml
<sequence xmlns="http://ws.apache.org/ns/synapse" name="ReplayEnablePolicy">
  <property name="ENABLE_REPLAY_TRANSACTION" value="true" scope="axis2" type="BOOLEAN"/>
</sequence>
```

Attach this as a policy to API/resource flows where replay recording is required.

#### Additional File Changes
Default property values and toml property mappings will be added to the `default.json` and `key-mapping.json` files.

----
Combined, these changes introduce a replay transaction framework inside the HTTP transport layer, offering:

- Fine‑grained configuration control.
- Asynchronous, non‑blocking persistence.
- Extensibility through pluggable writer interfaces.
- Safe, bounded buffering to avoid resource contention.

This feature enhances observability and troubleshooting within the API Gateway runtime, enabling detailed traffic replay without impacting request latency or throughput.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP transaction replay capability with configurable enablement and runtime settings.
  * Configurable replay parameters: buffer size, poll interval, drop/log frequency, and worker pool sizing.
  * Introduced an extensible persistence API for replay data and an in-memory dispatcher to buffer and persist records asynchronously.
  * Replay capture integrated into the I/O path for POST, PUT, PATCH, and DELETE, and replay records are immutable and safe to share.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->