### PR TITLE
Trigger fault sequence for forceful connection closures

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -1080,7 +1080,7 @@ public class TargetHandler implements NHttpClientEventHandler {
                     PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
             targetErrorHandler.handleError(requestMsgCtx,
                     ErrorCodes.SND_IO_ERROR,
-                    "Error In Sender",
+                    "Error in Sender",
                     null,
                     state);
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -1075,7 +1075,7 @@ public class TargetHandler implements NHttpClientEventHandler {
         TargetContext.updateState(conn, ProtocolState.CLOSED);
         targetConfiguration.getConnections().shutdownConnection(conn, true);
         MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
-        if (requestMsgCtx != null) {
+        if (state != ProtocolState.RESPONSE_DONE && requestMsgCtx != null) {
             requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
                     PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
             targetErrorHandler.handleError(requestMsgCtx,

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -1058,8 +1058,32 @@ public class TargetHandler implements NHttpClientEventHandler {
         }
     }
 
+    /**
+     * Invoked when the backend terminates the outbound HTTP connection unexpectedly.
+     * Logs diagnostics, marks the connection CLOSED, shuts it down, and routes the error
+     * to the standard fault handler.
+     *
+     * @param  conn        the target {@link NHttpClientConnection} that ended input
+     * @throws IOException if an error occurs while closing the connection
+     */
     public void endOfInput(NHttpClientConnection conn) throws IOException {
-        conn.close();
+
+        ProtocolState state = TargetContext.getState(conn);
+        log.warn("Connection ended unexpectedly" +
+                ", " + getConnectionLoggingInfo(conn) +
+                ", State: "  + state + ".");
+        TargetContext.updateState(conn, ProtocolState.CLOSED);
+        targetConfiguration.getConnections().shutdownConnection(conn, true);
+        MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
+        if (requestMsgCtx != null) {
+            requestMsgCtx.setProperty(PassThroughConstants.INTERNAL_EXCEPTION_ORIGIN,
+                    PassThroughConstants.INTERNAL_ORIGIN_ERROR_HANDLER);
+            targetErrorHandler.handleError(requestMsgCtx,
+                    ErrorCodes.SND_IO_ERROR,
+                    "Error In Sender",
+                    null,
+                    state);
+        }
     }
 
     public void exception(NHttpClientConnection conn, Exception ex) {


### PR DESCRIPTION
## Purpose
To fix https://github.com/wso2/api-manager/issues/4414

## Approach
- Added the fix introduced by https://github.com/wso2/wso2-synapse/pull/2367. It was previously reverted due to an error log occuring randomly.
- Fixed the error log issue by skipping fault sequence for completed response states
- Note: Fix added with https://github.com/wso2/product-micro-integrator/pull/4433 has to be added again to fix the test failure

## Samples
N/A

### Testing
Used the following log patch and reproduced the initially reported issue:

```
diff --git a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
index 798086978..021f25bde 100644
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java
@@ -802,10 +802,12 @@ public class TargetHandler implements NHttpClientEventHandler {
         ProtocolState state = TargetContext.getState(conn);
         MessageContext requestMsgCtx = TargetContext.get(conn).getRequestMsgCtx();
         Map<String, String> logDetails = getLoggingInfo(conn, state, requestMsgCtx);
+        Object correlationId = conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
 
         boolean isFault = false;
-        if (log.isDebugEnabled()) {
-            log.debug("Connection closed by target host while in state " + state.name() + ". Response code : " + conn.getStatus());
+        if (log.isInfoEnabled()) {
+            log.info("Connection closed by target host while in state " + state.name() +
+                    ". Response code : " + conn.getStatus() + " correlation : " + correlationId);
         }
         if (state == ProtocolState.RESPONSE_DONE || state == ProtocolState.REQUEST_READY) {
             if (log.isDebugEnabled()) {
@@ -1105,7 +1107,7 @@ public class TargetHandler implements NHttpClientEventHandler {
         ProtocolState state = TargetContext.getState(conn);
         log.warn("Connection ended unexpectedly" +
                 ", " + getConnectionLoggingInfo(conn) +
-                ", State: "  + state + ".");
+                ", State: "  + state + "." + " correlation: " + conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID));
         
         // Notify pipes based on state to prevent thread hangs
         if (state == ProtocolState.REQUEST_HEAD || state == ProtocolState.REQUEST_BODY) {
```

Used following sequences:
[fault.xml](https://github.com/user-attachments/files/26203238/fault.xml)
[in.xml](https://github.com/user-attachments/files/26203239/in.xml)

Before the fix - forceful backend connection closures were triggering the Fault Sequence when the state is REQUEST_DONE, but not when the state is REQUEST_READY:
[before.txt](https://github.com/user-attachments/files/26203174/before.txt)

After the fix - forceful backend connection closures triggers the Fault Sequence in both REQUEST_DONE and REQUEST_READY states. (We do not trigger this if the state is RESPONSE_DONE)
[after.txt](https://github.com/user-attachments/files/26203229/after.txt)

Tested the flows in APIM multi-tenant scenario as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpectedly terminated backend connections: added state-aware end-of-input processing with richer diagnostics, explicit state transitions and metrics updates, more aggressive connection closure when needed, and automatic propagation of I/O errors to the error handler to reduce silent failures and improve observability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->