### PR TITLE
Fix PayloadFactory default template IllegalArgumentException when variable values contain dollar signs

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/transform/pfutils/TemplateProcessor.java
@@ -441,6 +441,7 @@ public abstract class TemplateProcessor {
         return jsonString.replaceAll(ESCAPE_DOUBLE_QUOTE_WITH_FIVE_BACK_SLASHES,
                 ESCAPE_DOUBLE_QUOTE_WITH_NINE_BACK_SLASHES)
                 .replaceAll(ESCAPE_DOLLAR_WITH_TEN_BACK_SLASHES, ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
+                .replaceAll("(?<!\\\\)\\$", ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)
                 .replaceAll("\\\\b", ESCAPE_BACKSPACE_WITH_EIGHT_BACK_SLASHES)
                 .replaceAll("\\\\f", ESCAPE_FORMFEED_WITH_EIGHT_BACK_SLASHES)
                 .replaceAll("\\\\n", ESCAPE_NEWLINE_WITH_EIGHT_BACK_SLASHES)


### PR DESCRIPTION
## Summary

- Fixes `java.lang.IllegalArgumentException: Illegal group reference` thrown by `RegexTemplateProcessor.replace()` when a PayloadFactory mediator's variable value contains `$` followed by digits (e.g., Java inner class names like `NativeWorkerPool$1` or stack traces).
- Also fixes silent data corruption where `$<digit>` patterns in variable values were incorrectly substituted with regex capture group back-references.
- Root cause: `escapeSpecialCharactersOfJson()` in `TemplateProcessor.java` did not escape bare `$` characters, unlike `escapeSpecialCharactersOfXml()` which already escapes them. Added `.replaceAll("(?<!\\\\)\\$", ESCAPE_DOLLAR_WITH_SIX_BACK_SLASHES)` to make the behavior consistent.

Fixes https://github.com/wso2/product-micro-integrator/issues/4623

## Test plan

- [ ] Verify `GET /test-dollar/error` returns HTTP 200 with the full stack trace including `NativeWorkerPool$1.run` without any `IllegalArgumentException` in logs.
- [ ] Verify variable values containing `$1`, `$2`, `\\$`, and plain `$` at end of string are all preserved literally in the response.
- [ ] Run existing `PayloadFactoryIntegrationSpecialCharactersAtPayloadFactoryTestCase` tests to ensure no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON special character escaping to properly handle dollar signs (`$`) that are not already escaped, preventing incorrect string representations in JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->