### PR TITLE
Fix variables and properties missing from tracing data in Axis2 error/fault path

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java
@@ -176,6 +176,43 @@ public class SpanTagger {
             }
         }
 
+        if (OpenTelemetryManagerHolder.isCollectingProperties()) {
+            if (openEventStatisticDataUnit.getContextPropertyMap() != null) {
+                span.setAttribute(TelemetryConstants.BEFORE_CONTEXT_PROPERTY_MAP_ATTRIBUTE_KEY,
+                        openEventStatisticDataUnit.getContextPropertyMap().toString());
+            }
+            if (closeEventStatisticDataUnit != null) {
+                if (closeEventStatisticDataUnit.getContextPropertyMap() != null) {
+                    span.setAttribute(TelemetryConstants.AFTER_CONTEXT_PROPERTY_MAP_ATTRIBUTE_KEY,
+                            closeEventStatisticDataUnit.getContextPropertyMap().toString());
+                }
+            } else if (openEventStatisticDataUnit.getContextPropertyMap() != null) {
+                span.setAttribute(TelemetryConstants.AFTER_CONTEXT_PROPERTY_MAP_ATTRIBUTE_KEY,
+                        openEventStatisticDataUnit.getContextPropertyMap().toString());
+            }
+            if (closeEventStatisticDataUnit != null &&
+                    closeEventStatisticDataUnit.getPropertyValue() != null) {
+                span.setAttribute(TelemetryConstants.PROPERTY_MEDIATOR_VALUE_ATTRIBUTE_KEY,
+                        closeEventStatisticDataUnit.getPropertyValue());
+            }
+        }
+
+        if (OpenTelemetryManagerHolder.isCollectingVariables()) {
+            if (openEventStatisticDataUnit.getContextVariableMap() != null) {
+                span.setAttribute(TelemetryConstants.BEFORE_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                        openEventStatisticDataUnit.getContextVariableMap().toString());
+            }
+            if (closeEventStatisticDataUnit != null) {
+                if (closeEventStatisticDataUnit.getContextVariableMap() != null) {
+                    span.setAttribute(TelemetryConstants.AFTER_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                            closeEventStatisticDataUnit.getContextVariableMap().toString());
+                }
+            } else if (openEventStatisticDataUnit.getContextVariableMap() != null) {
+                span.setAttribute(TelemetryConstants.AFTER_CONTEXT_VARIABLE_MAP_ATTRIBUTE_KEY,
+                        openEventStatisticDataUnit.getContextVariableMap().toString());
+            }
+        }
+
         if (openEventStatisticDataUnit.getComponentName() != null) {
             span.setAttribute(TelemetryConstants.COMPONENT_NAME_ATTRIBUTE_KEY,
                     openEventStatisticDataUnit.getComponentName());


### PR DESCRIPTION
## Summary

- The Axis2 overload of `SpanTagger.setSpanTags(SpanWrapper, org.apache.axis2.context.MessageContext)` only handled payloads; properties and variables were never added as span attributes regardless of configuration.
- Added `isCollectingProperties()` block to stamp `beforeContextPropertyMap` and `afterContextPropertyMap` attributes on spans finished via the Axis2 path.
- Added `isCollectingVariables()` block to stamp `beforeContextVariableMap` and `afterContextVariableMap` attributes on spans finished via the Axis2 path.
- This path is used by `SpanStore.finishSpan(SpanWrapper, Axis2MessageContext, ...)` which is called from `SpanHandler.handleCloseFlowForcefully()` in error/fault scenarios.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4214

## Affected File

- `modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/helpers/SpanTagger.java`

## Test plan

- [ ] Deploy an API with `stat.tracer.collect_mediation_variables = true` (no payloads, no properties)
- [ ] Trigger a fault/error scenario so `handleCloseFlowForcefully` is invoked
- [ ] Verify span attributes include `beforeContextVariableMap` / `afterContextVariableMap`
- [ ] Repeat for `stat.tracer.collect_mediation_properties = true`
- [ ] Verify normal (non-fault) flow continues to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenTelemetry span tagging now captures context properties and variables for enhanced visibility into message flows and distributed tracing. Provides more detailed monitoring insights and debugging capabilities with expanded context data in trace spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->