### PR TITLE
Fix Call mediator endpoint key-expression not working with new ${...} syntax

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointFactory.java
@@ -23,7 +23,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.FactoryUtils;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.ResolvingEndpoint;
-import org.apache.synapse.config.xml.SynapseXPathFactory;
+import org.apache.synapse.config.xml.SynapsePathFactory;
 import org.apache.axiom.om.OMElement;
 import org.jaxen.JaxenException;
 
@@ -55,7 +55,7 @@ public class ResolvingEndpointFactory extends EndpointFactory {
         }
         try {
             resolvingEndpoint.setKeyExpression(
-                    SynapseXPathFactory.getSynapseXPath(epConfig, ATTR_KEY_EXPRESSION));
+                    SynapsePathFactory.getSynapsePath(epConfig, ATTR_KEY_EXPRESSION));
         } catch (JaxenException e) {
             handleException("Couldn't build the ResolvingEndpoint, unable to set " +
                     "the key-expression XPath", e);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializer.java
@@ -24,7 +24,8 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.ResolvingEndpoint;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.config.xml.SynapseXPathSerializer;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.config.xml.SynapsePathSerializer;
 
 /**
  * 
@@ -41,8 +42,8 @@ public class ResolvingEndpointSerializer extends EndpointSerializer {
         OMElement endpointElement = fac.createOMElement("endpoint", SynapseConstants.SYNAPSE_OMNAMESPACE);
 
         ResolvingEndpoint resolvingEndpoint = (ResolvingEndpoint) endpoint;
-        SynapseXPathSerializer.serializeXPath(resolvingEndpoint.getKeyExpression(),
-                endpointElement, "key-expression");
+        SynapsePath keyExpr = resolvingEndpoint.getKeyExpression();
+        SynapsePathSerializer.serializePath(keyExpr, keyExpr.getExpression(), endpointElement, "key-expression");
         if (resolvingEndpoint.getName() != null && !resolvingEndpoint.isAnonymous()) {
             endpointElement.addAttribute("name", resolvingEndpoint.getName(), null);
         }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
@@ -27,7 +27,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector
 import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.config.xml.FactoryUtils;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -40,7 +40,7 @@ import org.json.JSONObject;
  */
 public class ResolvingEndpoint extends AbstractEndpoint {
 
-    private SynapseXPath keyExpression = null;
+    private SynapsePath keyExpression = null;
     private String artifactIdentifier = null;
 
     public void send(MessageContext synCtx) {
@@ -123,11 +123,11 @@ public class ResolvingEndpoint extends AbstractEndpoint {
         return null;
     }
 
-    public SynapseXPath getKeyExpression() {
+    public SynapsePath getKeyExpression() {
         return keyExpression;
     }
 
-    public void setKeyExpression(SynapseXPath keyExpression) {
+    public void setKeyExpression(SynapsePath keyExpression) {
         this.keyExpression = keyExpression;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -54,7 +54,7 @@ import org.apache.synapse.endpoints.auth.oauth.MessageCache;
 import org.apache.synapse.endpoints.auth.oauth.OAuthUtils;
 import org.apache.synapse.util.MediatorPropertyUtils;
 import org.apache.synapse.util.MessageHelper;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.config.xml.SynapsePath;
 
 import javax.xml.namespace.QName;
 import java.io.PrintWriter;
@@ -124,7 +124,7 @@ public class BlockingMsgSender {
         //If the Endpoint is a resolving endpoint, real endpoint details are required to
         // get the correct endpoint definition
         if (endpoint instanceof ResolvingEndpoint) {
-            SynapseXPath keyExpression = ((ResolvingEndpoint) endpoint).getKeyExpression();
+            SynapsePath keyExpression = ((ResolvingEndpoint) endpoint).getKeyExpression();
             String key = keyExpression.stringValueOf(synapseInMsgCtx);
             endpoint = ((ResolvingEndpoint) endpoint).loadAndInitEndpoint(((Axis2MessageContext) synapseInMsgCtx).
                     getAxis2MessageContext().getConfigurationContext(), key);


### PR DESCRIPTION
## Summary

- Fixes `ResolvingEndpointFactory` to use `SynapsePathFactory.getSynapsePath()` instead of `SynapseXPathFactory.getSynapseXPath()`, enabling correct detection and handling of the new `${...}` SIEL expression syntax.
- Updates `ResolvingEndpoint` field, getter, and setter from `SynapseXPath` to the `SynapsePath` base type.
- Updates `ResolvingEndpointSerializer` to use `SynapsePathSerializer.serializePath()` for correct round-trip serialization of both legacy XPath and new expression syntax.
- Updates `BlockingMsgSender` to use the `SynapsePath` base type when reading `keyExpression` from a `ResolvingEndpoint`.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4574

## Test plan

- [ ] Deploy a proxy/template containing `<call><endpoint key-expression="${params.functionParams.Endpoint}"/></call>` and verify it deploys without errors.
- [ ] Verify legacy `$func:` and `$url:` XPath-style key-expressions still work (no regression).
- [ ] Verify `BlockingMsgSender` correctly resolves the endpoint when using the new `${...}` expression syntax.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal expression evaluation mechanisms for endpoint key resolution. Standardized implementation patterns across endpoint creation, serialization, and message handling components to ensure consistent processing of key expressions throughout the system. These infrastructure improvements enhance code maintainability, system consistency, and long-term supportability without affecting external functionality or runtime behavior of endpoint resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->