### PR TITLE
Fix OpenTelemetry service name not read from synapse properties

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/OTLPTelemetryManager.java
@@ -138,9 +138,12 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
             metricExporter = metricExporterBuilder.build();
         }
 
+        String serviceName = SynapsePropertiesLoader.getPropertyValue(
+                TelemetryConstants.OPENTELEMETRY_SERVICE_NAME, TelemetryConstants.DEFAULT_SERVICE_NAME);
+
         sdkTracerProvider = SdkTracerProvider.builder()
                 .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
-                .setResource(Resource.getDefault().merge(TelemetryUtil.getTracerProviderResource(TelemetryConstants.SERVICE_NAME)))
+                .setResource(Resource.getDefault().merge(TelemetryUtil.getTracerProviderResource(serviceName)))
                 .build();
 
         int metricIntervalSeconds = getMetricIntervalSeconds();
@@ -150,7 +153,7 @@ public class OTLPTelemetryManager implements OpenTelemetryManager {
                         .setInterval(Duration.ofSeconds(metricIntervalSeconds))
                         .build())
                 .setResource(Resource.getDefault()
-                        .merge(TelemetryUtil.getTracerProviderResource(TelemetryConstants.SERVICE_NAME)))
+                        .merge(TelemetryUtil.getTracerProviderResource(serviceName)))
                 .build();
 
         openTelemetry = OpenTelemetrySdk.builder()

--- a/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstants.java
@@ -71,9 +71,13 @@ public class TelemetryConstants {
             ".opentelemetry.management.OTLPTelemetryManager";
     public static final String DEFAULT_OPENTELEMETRY_URL_FOR_HTTP = "http://localhost:4318";
     public static final String DEFAULT_OPENTELEMETRY_URL_FOR_GRPC = "http://localhost:4317";
+    public static final String OPENTELEMETRY_SERVICE_NAME = "opentelemetry.service.name";
     public static final String USER_DEFINED_NAME = System.getenv("SERVICE_NAME");
-    public static final String SERVICE_NAME =
+    public static final String DEFAULT_SERVICE_NAME =
             USER_DEFINED_NAME != null && !USER_DEFINED_NAME.isEmpty() ? USER_DEFINED_NAME : "WSO2-SYNAPSE";
+    /** @deprecated Use {@link #DEFAULT_SERVICE_NAME} instead */
+    @Deprecated
+    public static final String SERVICE_NAME = DEFAULT_SERVICE_NAME;
     public static final String OPENTELEMETRY_INSTRUMENTATION_NAME = "org.wso2.synapse.tracing.telemetry";
     public static final String DEFAULT_ZIPKIN_HOST = "localhost";
     public static final String DEFAULT_ZIPKIN_PORT = "9411";

--- a/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstantsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryConstantsTest.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for constants defined in {@link TelemetryConstants} that are relevant
+ * to issue #4200 (configurable Jaeger / OpenTelemetry service name).
+ *
+ * <p>These tests guard:
+ * <ul>
+ *   <li>The synapse-property key used to look up the configured service name
+ *       ({@code OPENTELEMETRY_SERVICE_NAME}).</li>
+ *   <li>The fallback value ({@code DEFAULT_SERVICE_NAME}) when no property is set.</li>
+ *   <li>Backward compatibility of the deprecated {@code SERVICE_NAME} constant.</li>
+ * </ul>
+ */
+public class TelemetryConstantsTest {
+
+    /**
+     * The synapse property key used in both {@code OTLPTelemetryManager} and the
+     * key-mappings config-tool must be exactly {@code "opentelemetry.service.name"}.
+     * A typo here would silently prevent the configured value from being picked up.
+     */
+    @Test
+    public void testOpentelemetryServiceNamePropertyKey() {
+        Assert.assertEquals(
+                "OPENTELEMETRY_SERVICE_NAME must equal 'opentelemetry.service.name'",
+                "opentelemetry.service.name",
+                TelemetryConstants.OPENTELEMETRY_SERVICE_NAME);
+    }
+
+    /**
+     * {@code DEFAULT_SERVICE_NAME} must never be null — it is used as the fallback
+     * value passed to {@code SynapsePropertiesLoader.getPropertyValue()} and later
+     * to {@code TelemetryUtil.getTracerProviderResource()}.
+     */
+    @Test
+    public void testDefaultServiceName_isNotNull() {
+        Assert.assertNotNull(
+                "DEFAULT_SERVICE_NAME must not be null",
+                TelemetryConstants.DEFAULT_SERVICE_NAME);
+    }
+
+    /**
+     * When the {@code SERVICE_NAME} environment variable is absent (normal CI / test
+     * environment), {@code DEFAULT_SERVICE_NAME} must fall back to {@code "WSO2-SYNAPSE"}.
+     * This matches the value shipped in {@code default.json} and documented in the
+     * server configuration templates.
+     */
+    @Test
+    public void testDefaultServiceName_fallsBackToHardcodedValue_whenEnvVarAbsent() {
+        String envServiceName = System.getenv("SERVICE_NAME");
+        if (envServiceName == null || envServiceName.isEmpty()) {
+            Assert.assertEquals(
+                    "DEFAULT_SERVICE_NAME must be 'WSO2-SYNAPSE' when the SERVICE_NAME env var is not set",
+                    "WSO2-SYNAPSE",
+                    TelemetryConstants.DEFAULT_SERVICE_NAME);
+        } else {
+            // If the env var IS set, the constant should reflect it.
+            Assert.assertEquals(
+                    "DEFAULT_SERVICE_NAME must equal the SERVICE_NAME env var when it is set",
+                    envServiceName,
+                    TelemetryConstants.DEFAULT_SERVICE_NAME);
+        }
+    }
+
+    /**
+     * The deprecated {@code SERVICE_NAME} constant must equal {@code DEFAULT_SERVICE_NAME}
+     * so that any existing callers that have not yet been migrated continue to receive
+     * the same value.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedServiceName_equalsDefaultServiceName() {
+        Assert.assertEquals(
+                "Deprecated SERVICE_NAME must equal DEFAULT_SERVICE_NAME for backwards compatibility",
+                TelemetryConstants.DEFAULT_SERVICE_NAME,
+                TelemetryConstants.SERVICE_NAME);
+    }
+
+    /**
+     * Verify that the set of other foundational telemetry constants have not been
+     * accidentally removed or renamed.  These are referenced throughout the codebase
+     * and changing them would break the OpenTelemetry configuration flow.
+     */
+    @Test
+    public void testEssentialConstantsArePresent() {
+        Assert.assertEquals("opentelemetry.enable", TelemetryConstants.OPENTELEMETRY_ENABLE);
+        Assert.assertEquals("opentelemetry.host", TelemetryConstants.OPENTELEMETRY_HOST);
+        Assert.assertEquals("opentelemetry.port", TelemetryConstants.OPENTELEMETRY_PORT);
+        Assert.assertEquals("opentelemetry.protocol", TelemetryConstants.OPENTELEMETRY_PROTOCOL);
+        Assert.assertEquals("opentelemetry.url", TelemetryConstants.OPENTELEMETRY_URL);
+        Assert.assertEquals("http", TelemetryConstants.HTTP_PROTOCOL);
+        Assert.assertEquals("grpc", TelemetryConstants.GRPC_PROTOCOL);
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryUtilTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/aspects/flow/statistics/tracing/opentelemetry/management/TelemetryUtilTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management;
+
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ServiceAttributes;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TelemetryUtil} — specifically verifying that
+ * {@link TelemetryUtil#getTracerProviderResource(String)} correctly embeds the
+ * provided service name into the returned OpenTelemetry {@link Resource}.
+ *
+ * <p>Relates to issue #4200: when a user configures {@code service_name} in
+ * {@code deployment.toml}, the value must eventually reach the OpenTelemetry SDK
+ * as the {@code service.name} resource attribute.  The method under test is the
+ * last step in that chain (called by {@code OTLPTelemetryManager.init()}).
+ */
+public class TelemetryUtilTest {
+
+    /**
+     * A custom service name propagated through the configuration chain must appear
+     * verbatim as the {@code service.name} attribute in the built resource.
+     * This is the primary regression test for issue #4200.
+     */
+    @Test
+    public void testGetTracerProviderResource_setsCustomServiceName() {
+        String customServiceName = "custom-test-service";
+        Resource resource = TelemetryUtil.getTracerProviderResource(customServiceName);
+
+        Assert.assertNotNull("Resource must not be null", resource);
+        String actualServiceName = resource.getAttribute(ServiceAttributes.SERVICE_NAME);
+        Assert.assertEquals(
+                "SERVICE_NAME attribute in the resource must match the value passed to getTracerProviderResource()",
+                customServiceName, actualServiceName);
+    }
+
+    /**
+     * When the default service name constant is passed (simulating the fallback
+     * path when no {@code opentelemetry.service.name} synapse property is set),
+     * the resource must carry {@code WSO2-SYNAPSE} as the service name.
+     */
+    @Test
+    public void testGetTracerProviderResource_setsDefaultServiceName() {
+        String defaultServiceName = TelemetryConstants.DEFAULT_SERVICE_NAME;
+        Resource resource = TelemetryUtil.getTracerProviderResource(defaultServiceName);
+
+        Assert.assertNotNull("Resource must not be null", resource);
+        String actualServiceName = resource.getAttribute(ServiceAttributes.SERVICE_NAME);
+        Assert.assertEquals(
+                "SERVICE_NAME attribute must equal the default service name constant",
+                defaultServiceName, actualServiceName);
+    }
+
+    /**
+     * The resource returned by {@code getTracerProviderResource()} must not be null
+     * regardless of the service name value supplied, including an empty string.
+     */
+    @Test
+    public void testGetTracerProviderResource_returnsNonNullForEmptyServiceName() {
+        Resource resource = TelemetryUtil.getTracerProviderResource("");
+
+        Assert.assertNotNull("Resource must not be null even when service name is empty", resource);
+        String actualServiceName = resource.getAttribute(ServiceAttributes.SERVICE_NAME);
+        Assert.assertEquals("SERVICE_NAME attribute must equal the empty string passed in",
+                "", actualServiceName);
+    }
+
+    /**
+     * Service names that contain special characters, mixed case, or hyphens must be
+     * preserved exactly as provided — no normalisation or trimming should occur.
+     */
+    @Test
+    public void testGetTracerProviderResource_preservesServiceNameExactly() {
+        String[] serviceNames = {
+                "wso2-synapse",        // lowercase variant (Grafana dashboard default)
+                "WSO2-SYNAPSE",        // uppercase default
+                "My Service 123",      // spaces and mixed case
+                "service_with_under",  // underscores
+        };
+
+        for (String name : serviceNames) {
+            Resource resource = TelemetryUtil.getTracerProviderResource(name);
+            Assert.assertNotNull("Resource must not be null for name: " + name, resource);
+            Assert.assertEquals(
+                    "SERVICE_NAME attribute must be preserved exactly for input: " + name,
+                    name, resource.getAttribute(ServiceAttributes.SERVICE_NAME));
+        }
+    }
+
+    /**
+     * Two successive calls with different service names must each return their own
+     * resource with the correct service name — {@code getTracerProviderResource()}
+     * must not cache or share state between invocations.
+     */
+    @Test
+    public void testGetTracerProviderResource_isStateless() {
+        Resource r1 = TelemetryUtil.getTracerProviderResource("service-alpha");
+        Resource r2 = TelemetryUtil.getTracerProviderResource("service-beta");
+
+        Assert.assertEquals("First resource must carry service-alpha",
+                "service-alpha", r1.getAttribute(ServiceAttributes.SERVICE_NAME));
+        Assert.assertEquals("Second resource must carry service-beta",
+                "service-beta", r2.getAttribute(ServiceAttributes.SERVICE_NAME));
+    }
+}


### PR DESCRIPTION
## Summary

- Read `opentelemetry.service.name` from `SynapsePropertiesLoader` at `OTLPTelemetryManager.init()` time instead of using the hardcoded static constant `TelemetryConstants.SERVICE_NAME`
- Add `OPENTELEMETRY_SERVICE_NAME` constant for the property key and rename `SERVICE_NAME` to `DEFAULT_SERVICE_NAME`; keep deprecated `SERVICE_NAME` alias for backward compatibility
- Add unit tests for `TelemetryConstants` and `TelemetryUtil`

## Root Cause

`TelemetryConstants.SERVICE_NAME` is a `static final` set once at class load from the `SERVICE_NAME` environment variable. It never reads from synapse properties, so any `service_name` configured in `deployment.toml` (and written to `synapse.properties` via config-tool) was silently ignored — traces were always tagged with the default `WSO2-SYNAPSE`.

## Issue Analysis

<!-- issue-analysis -->
### Issue Analysis — [Issue #4200]: Incorrect Jaeger service name in Grafana dashboards

**Root Cause (wso2-synapse side):**

`OTLPTelemetryManager.init()` passes `TelemetryConstants.SERVICE_NAME` (a static final) directly to the tracer provider:
```java
.setResource(Resource.getDefault().merge(
    TelemetryUtil.getTracerProviderResource(TelemetryConstants.SERVICE_NAME)))
```

`SERVICE_NAME` is resolved once at class-load from the `SERVICE_NAME` environment variable; it never consults `synapse.properties`.

**Fix applied:**
```java
String serviceName = SynapsePropertiesLoader.getPropertyValue(
        TelemetryConstants.OPENTELEMETRY_SERVICE_NAME, TelemetryConstants.DEFAULT_SERVICE_NAME);
// ...
.setResource(Resource.getDefault().merge(TelemetryUtil.getTracerProviderResource(serviceName)))
```

Fixes wso2/product-micro-integrator#4200

## Test plan
- [ ] Unit tests added for `TelemetryConstants` service name resolution (env var present / absent)
- [ ] Unit tests added for `TelemetryUtil.getTracerProviderResource()` attribute verification
- [ ] Verify server starts with `service_name = "custom-test-service"` in `deployment.toml` and traces are tagged with `custom-test-service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)