### PR TITLE
Fix Call mediator key-expression to support new ${...} syntax

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointFactory.java
@@ -21,9 +21,9 @@ package org.apache.synapse.config.xml.endpoints;
 
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.config.xml.FactoryUtils;
+import org.apache.synapse.config.xml.SynapsePathFactory;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.ResolvingEndpoint;
-import org.apache.synapse.config.xml.SynapseXPathFactory;
 import org.apache.axiom.om.OMElement;
 import org.jaxen.JaxenException;
 
@@ -55,7 +55,7 @@ public class ResolvingEndpointFactory extends EndpointFactory {
         }
         try {
             resolvingEndpoint.setKeyExpression(
-                    SynapseXPathFactory.getSynapseXPath(epConfig, ATTR_KEY_EXPRESSION));
+                    SynapsePathFactory.getSynapsePath(epConfig, ATTR_KEY_EXPRESSION));
         } catch (JaxenException e) {
             handleException("Couldn't build the ResolvingEndpoint, unable to set " +
                     "the key-expression XPath", e);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializer.java
@@ -24,7 +24,7 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.ResolvingEndpoint;
 import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.config.xml.SynapseXPathSerializer;
+import org.apache.synapse.config.xml.SynapsePathSerializer;
 
 /**
  * 
@@ -41,8 +41,8 @@ public class ResolvingEndpointSerializer extends EndpointSerializer {
         OMElement endpointElement = fac.createOMElement("endpoint", SynapseConstants.SYNAPSE_OMNAMESPACE);
 
         ResolvingEndpoint resolvingEndpoint = (ResolvingEndpoint) endpoint;
-        SynapseXPathSerializer.serializeXPath(resolvingEndpoint.getKeyExpression(),
-                endpointElement, "key-expression");
+        SynapsePathSerializer.serializePath(resolvingEndpoint.getKeyExpression(),
+                resolvingEndpoint.getKeyExpression().getExpression(), endpointElement, "key-expression");
         if (resolvingEndpoint.getName() != null && !resolvingEndpoint.isAnonymous()) {
             endpointElement.addAttribute("name", resolvingEndpoint.getName(), null);
         }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java
@@ -27,7 +27,7 @@ import org.apache.synapse.aspects.flow.statistics.collectors.CloseEventCollector
 import org.apache.synapse.aspects.flow.statistics.collectors.OpenEventCollector;
 import org.apache.synapse.aspects.flow.statistics.collectors.RuntimeStatisticCollector;
 import org.apache.synapse.config.xml.FactoryUtils;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.config.xml.SynapsePath;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -40,7 +40,7 @@ import org.json.JSONObject;
  */
 public class ResolvingEndpoint extends AbstractEndpoint {
 
-    private SynapseXPath keyExpression = null;
+    private SynapsePath keyExpression = null;
     private String artifactIdentifier = null;
 
     public void send(MessageContext synCtx) {
@@ -123,11 +123,11 @@ public class ResolvingEndpoint extends AbstractEndpoint {
         return null;
     }
 
-    public SynapseXPath getKeyExpression() {
+    public SynapsePath getKeyExpression() {
         return keyExpression;
     }
 
-    public void setKeyExpression(SynapseXPath keyExpression) {
+    public void setKeyExpression(SynapsePath keyExpression) {
         this.keyExpression = keyExpression;
     }
 

--- a/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java
@@ -54,7 +54,7 @@ import org.apache.synapse.endpoints.auth.oauth.MessageCache;
 import org.apache.synapse.endpoints.auth.oauth.OAuthUtils;
 import org.apache.synapse.util.MediatorPropertyUtils;
 import org.apache.synapse.util.MessageHelper;
-import org.apache.synapse.util.xpath.SynapseXPath;
+import org.apache.synapse.config.xml.SynapsePath;
 
 import javax.xml.namespace.QName;
 import java.io.PrintWriter;
@@ -124,7 +124,7 @@ public class BlockingMsgSender {
         //If the Endpoint is a resolving endpoint, real endpoint details are required to
         // get the correct endpoint definition
         if (endpoint instanceof ResolvingEndpoint) {
-            SynapseXPath keyExpression = ((ResolvingEndpoint) endpoint).getKeyExpression();
+            SynapsePath keyExpression = ((ResolvingEndpoint) endpoint).getKeyExpression();
             String key = keyExpression.stringValueOf(synapseInMsgCtx);
             endpoint = ((ResolvingEndpoint) endpoint).loadAndInitEndpoint(((Axis2MessageContext) synapseInMsgCtx).
                     getAxis2MessageContext().getConfigurationContext(), key);

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializationTest.java
@@ -1,0 +1,209 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.config.xml.endpoints;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.xml.AbstractTestCase;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.endpoints.Endpoint;
+import org.apache.synapse.endpoints.ResolvingEndpoint;
+import org.apache.synapse.util.xpath.SynapseExpression;
+import org.apache.synapse.util.xpath.SynapseXPath;
+
+import java.util.Properties;
+
+/**
+ * Tests for ResolvingEndpointFactory and ResolvingEndpointSerializer.
+ *
+ * Covers the bug fix for GitHub issue #4574: key-expression with the new
+ * ${...} Synapse Expression syntax was rejected with an XPathSyntaxException
+ * because the factory was unconditionally using SynapseXPathFactory instead
+ * of the polymorphic SynapsePathFactory.
+ */
+public class ResolvingEndpointSerializationTest extends AbstractTestCase {
+
+    private static final String SYNAPSE_NS = "xmlns=\"http://ws.apache.org/ns/synapse\"";
+
+    // -------------------------------------------------------------------------
+    // Factory parse tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Issue #4574 — the primary bug scenario.
+     * A key-expression using ${...} syntax must be parsed without error and
+     * must produce a SynapseExpression (not a SynapseXPath).
+     */
+    public void testParseNewExpressionSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS + " key-expression=\"${params.functionParams.Endpoint}\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+
+        assertNotNull("Endpoint must not be null", endpoint);
+        assertTrue("Must be a ResolvingEndpoint", endpoint instanceof ResolvingEndpoint);
+
+        SynapsePath expr = ((ResolvingEndpoint) endpoint).getKeyExpression();
+        assertNotNull("keyExpression must not be null", expr);
+        assertTrue("keyExpression must be a SynapseExpression for ${...} syntax",
+                expr instanceof SynapseExpression);
+        assertEquals("Inner expression must equal the payload path",
+                "params.functionParams.Endpoint", expr.getExpression());
+    }
+
+    /**
+     * Legacy XPath syntax ($url:myKey style) must still be accepted without regression.
+     */
+    public void testParseLegacyXPathSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS + " key-expression=\"get-property('myEndpointKey')\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof ResolvingEndpoint);
+
+        SynapsePath expr = ((ResolvingEndpoint) endpoint).getKeyExpression();
+        assertNotNull(expr);
+        assertTrue("Legacy XPath expression must produce a SynapseXPath", expr instanceof SynapseXPath);
+    }
+
+    /**
+     * A named (non-anonymous) ResolvingEndpoint with new expression syntax.
+     */
+    public void testParseNamedEndpointWithNewExpressionSyntax() throws Exception {
+        String inputXML = "<endpoint name=\"myResolvingEP\" " + SYNAPSE_NS
+                + " key-expression=\"${vars.targetEndpoint}\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, false, new Properties());
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint instanceof ResolvingEndpoint);
+        assertEquals("myResolvingEP", endpoint.getName());
+
+        SynapsePath expr = ((ResolvingEndpoint) endpoint).getKeyExpression();
+        assertTrue(expr instanceof SynapseExpression);
+        assertEquals("vars.targetEndpoint", expr.getExpression());
+    }
+
+    // -------------------------------------------------------------------------
+    // Serializer round-trip tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Round-trip: parse ${...} expression, serialize, and verify the attribute
+     * value is preserved as ${...}.
+     */
+    public void testRoundTripNewExpressionSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS
+                + " key-expression=\"${params.functionParams.Endpoint}\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+        OMElement serialized = EndpointSerializer.getElementFromEndpoint(endpoint);
+
+        assertNotNull(serialized);
+        String keyExprAttr = serialized.getAttributeValue(
+                new javax.xml.namespace.QName("key-expression"));
+        assertNotNull("key-expression attribute must be present after serialization", keyExprAttr);
+        assertEquals("${params.functionParams.Endpoint}", keyExprAttr);
+    }
+
+    /**
+     * Round-trip: parse legacy XPath expression, serialize, and verify value is preserved.
+     */
+    public void testRoundTripLegacyXPathSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS
+                + " key-expression=\"get-property('myEndpointKey')\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+        OMElement serialized = EndpointSerializer.getElementFromEndpoint(endpoint);
+
+        assertNotNull(serialized);
+        String keyExprAttr = serialized.getAttributeValue(
+                new javax.xml.namespace.QName("key-expression"));
+        assertNotNull(keyExprAttr);
+        assertEquals("get-property('myEndpointKey')", keyExprAttr);
+    }
+
+    /**
+     * Round-trip: parse a multi-level ${...} expression (e.g. nested property access).
+     */
+    public void testRoundTripNestedNewExpressionSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS
+                + " key-expression=\"${vars.ep}\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+        OMElement serialized = EndpointSerializer.getElementFromEndpoint(endpoint);
+
+        String keyExprAttr = serialized.getAttributeValue(
+                new javax.xml.namespace.QName("key-expression"));
+        assertEquals("${vars.ep}", keyExprAttr);
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative / edge-case tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * An invalid XPath expression (not ${...}) must still throw SynapseException
+     * so that deployment errors surface clearly.
+     */
+    public void testInvalidXPathThrowsSynapseException() {
+        String inputXML = "<endpoint " + SYNAPSE_NS + " key-expression=\"$$invalid!!\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+        try {
+            EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+            fail("Expected SynapseException for invalid expression");
+        } catch (SynapseException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Path type of the parsed SynapseExpression must be SYNAPSE_EXPRESSIONS_PATH.
+     */
+    public void testPathTypeForNewExpressionSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS + " key-expression=\"${vars.myKey}\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+        SynapsePath expr = ((ResolvingEndpoint) endpoint).getKeyExpression();
+
+        assertEquals(SynapsePath.SYNAPSE_EXPRESSIONS_PATH, expr.getPathType());
+        assertEquals("vars.myKey", expr.getExpression());
+    }
+
+    /**
+     * Path type of the parsed legacy XPath must be X_PATH.
+     */
+    public void testPathTypeForLegacyXPathSyntax() throws Exception {
+        String inputXML = "<endpoint " + SYNAPSE_NS + " key-expression=\"get-property('ep')\"/>";
+        OMElement inputElement = createOMElement(inputXML);
+
+        Endpoint endpoint = EndpointFactory.getEndpointFromElement(inputElement, true, new Properties());
+        SynapsePath expr = ((ResolvingEndpoint) endpoint).getKeyExpression();
+
+        assertEquals(SynapsePath.X_PATH, expr.getPathType());
+    }
+}


### PR DESCRIPTION
## Summary

- `ResolvingEndpointFactory` was using `SynapseXPathFactory.getSynapseXPath()` to parse the `key-expression` attribute, which rejected `${...}` Synapse Expression syntax with an `XPathSyntaxException`
- Replace with `SynapsePathFactory.getSynapsePath()` which correctly dispatches to `SynapseExpression` for `${...}`, `SynapseJsonPath` for `json-eval(...)`, and `SynapseXPath` for legacy expressions
- Update `ResolvingEndpoint.keyExpression` field and accessor types from `SynapseXPath` → `SynapsePath`; update `ResolvingEndpointSerializer` and `BlockingMsgSender` accordingly

Fixes: wso2/product-micro-integrator#4574

## Test plan

- [ ] New unit tests in `ResolvingEndpointSerializationTest` covering parse + round-trip for `${...}` syntax, legacy XPath syntax, path-type assertions, and a negative/invalid-expression case
- [ ] Verify existing resolving endpoint tests still pass (no regression in legacy `$url:myKey` / XPath syntax)
- [ ] Manual: deploy a synapse template containing `<endpoint key-expression="${params.functionParams.Endpoint}"/>` and confirm it deploys successfully

## Issue Analysis

<details>
<summary>Issue Analysis — #4574: Call mediator endpoint key-expression does not work with new syntax</summary>

### Classification
- **Type:** Bug
- **Severity:** High — prevents use of `${...}` expression syntax in dynamic endpoint resolution via Call mediator
- **Affected Component(s):** `wso2/wso2-synapse` — `ResolvingEndpointFactory`, `SynapseXPathFactory`

### Root Cause

`ResolvingEndpointFactory.createEndpoint()` calls `SynapseXPathFactory.getSynapseXPath()` to parse the `key-expression` attribute. When the value is `${params.functionParams.Endpoint}`, the `{` character is invalid in XPath 1.0, causing an `XPathSyntaxException`.

The fix replaces this call with `SynapsePathFactory.getSynapsePath()`, which handles three cases:
1. `json-eval(...)` → `SynapseJsonPath`
2. `${...}` → `SynapseExpression`
3. everything else → `SynapseXPath`

**Files changed:**
- `modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointFactory.java`
- `modules/core/src/main/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializer.java`
- `modules/core/src/main/java/org/apache/synapse/endpoints/ResolvingEndpoint.java`
- `modules/core/src/main/java/org/apache/synapse/message/senders/blocking/BlockingMsgSender.java`
- `modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/ResolvingEndpointSerializationTest.java` (new)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ResolvingEndpoint key expressions now support Synapse Expression syntax (${...}) in addition to XPath expressions.
  * Backward compatibility with existing XPath-based configurations is maintained.

* **Tests**
  * Added test coverage for key-expression parsing, serialization, and edge-case validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->