### PR TITLE
Fix INCOMPATIBLE_PARAMETERS_ERROR on GET data service with Content-Type header

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ServerWorker.java
@@ -253,11 +253,16 @@ private WorkerState state;
                 contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
             }
         }
+        String httpMethod = (String) msgContext.getProperty(HTTP_METHOD);
+        boolean isGetOrDelete = HTTPConstants.HTTP_METHOD_GET.equals(httpMethod) || "DELETE".equals(httpMethod);
+        if (isGetOrDelete) {
+            contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
+        }
         if (HTTPConstants.MEDIA_TYPE_X_WWW_FORM.equals(contentType) ||
                 (PassThroughConstants.APPLICATION_OCTET_STREAM.equals(contentType) && contentTypeHdr == null)) {
             msgContext.setTo(new EndpointReference(request.getRequest().getRequestLine().getUri()));
             String charSetEncoding;
-            if (contentTypeHdr != null) {
+            if (contentTypeHdr != null && !isGetOrDelete) {
                 msgContext.setProperty(Constants.Configuration.CONTENT_TYPE, contentTypeHdr);
                 charSetEncoding = BuilderUtil.getCharSetEncoding(contentTypeHdr);
             } else {


### PR DESCRIPTION
## Summary
- When a GET request to a data service endpoint with path parameters includes a `Content-Type` header (e.g., `application/json`), the server incorrectly uses the header value instead of `application/x-www-form-urlencoded` for the message context `CONTENT_TYPE` property. This causes URL path parameter extraction to fail with `INCOMPATIBLE_PARAMETERS_ERROR`.
- Fix: In `ServerWorker.handleRESTUrlPost()`, added `&& !isGetOrDelete` condition so GET/DELETE requests always use `x-www-form-urlencoded` as the message context content type, ensuring path parameters are correctly extracted from the URL.

## Related Issue
Fixes https://github.com/wso2/product-integrator-mi/issues/4111

## Test plan
- [x] Deploy a data service with a GET resource using URL path parameters (e.g., `biller/email/{billerId}`)
- [x] Verify `GET /services/BillerDataService/biller/email/1` without Content-Type header returns correct data
- [x] Verify `GET /services/BillerDataService/biller/email/1` with `Content-Type: application/json` returns correct data (was INCOMPATIBLE_PARAMETERS_ERROR before fix)
- [x] Verify `GET /services/BillerDataService/biller/email/1` with `Content-Type: application/xml` returns correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP GET and DELETE request handling with enhanced content type header processing. These requests now consistently apply standardized defaults and properly derive charset encoding information, resolving edge cases with missing or malformed content type headers and improving API reliability and request consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->