### PR TITLE
[FIX] Support Unified Expressions in ForEach (V2) Aggregate phase

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/v2/ForEachMediatorV2.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/v2/ForEachMediatorV2.java
@@ -703,22 +703,31 @@ public class ForEachMediatorV2 extends AbstractMediator implements ManagedLifecy
 
     private String getVariableName(SynapsePath expression) {
 
-        return expression.getExpression().split("\\.")[1];
+        String expr = expression.getExpression();
+        if (expr.startsWith(ExpressionConstants.SYNAPSE_EXPRESSION_IDENTIFIER_START)) {
+            expr = expr.substring(2, expr.length() - 1);
+        }
+        return expr.split("\\.")[1];
     }
 
     private boolean isCollectionReferencedByVariable(SynapsePath expression) {
 
-        return expression.getExpression().startsWith(VARIABLE_DOT);
+        String expr = expression.getExpression();
+        return expr.startsWith(VARIABLE_DOT) ||
+                expr.startsWith(ExpressionConstants.SYNAPSE_EXPRESSION_IDENTIFIER_START + VARIABLE_DOT);
     }
 
     private JsonPath getJsonPathFromExpression(String expression) {
 
         String jsonPath = expression;
+        if (jsonPath.startsWith(ExpressionConstants.SYNAPSE_EXPRESSION_IDENTIFIER_START)) {
+            jsonPath = jsonPath.substring(2, jsonPath.length() - 1);
+        }
         if (jsonPath.startsWith(ExpressionConstants.PAYLOAD)) {
             jsonPath = jsonPath.replace(ExpressionConstants.PAYLOAD, ExpressionConstants.PAYLOAD_$);
         } else if (jsonPath.startsWith(VARIABLE_DOT)) {
             // Remove the "vars." prefix and variable name and replace it with "$" for JSON path
-            jsonPath = expression.replaceAll(ExpressionConstants.VARIABLES + "\\.\\w+\\.(\\w+)", "\\$.$1")
+            jsonPath = jsonPath.replaceAll(ExpressionConstants.VARIABLES + "\\.\\w+\\.(\\w+)", "\\$.$1")
                     .replaceAll(ExpressionConstants.VARIABLES + "\\.\\w+", "\\$");
         }
         return JsonPath.compile(jsonPath);


### PR DESCRIPTION
### Problem
The `ForEachMediatorV2` fails during the aggregation phase when a Synapse variable (using the unified expression syntax `${vars.name}`) is used as the collection. This happens because the aggregation logic does not recognize the `${` and `}` delimiters, leading it to treat the expression as a JSON path relative to the message body. This results in a `PathNotFoundException` and subsequent `NullPointerException`.

### Solution
Updated the following methods in `ForEachMediatorV2.java` to be aware of the unified expression delimiters:
- `isCollectionReferencedByVariable`: Now checks for both `vars.` and `${vars.`.
- `getVariableName`: Now strips delimiters before extracting the variable name.
- `getJsonPathFromExpression`: Now strips delimiters and correctly performs replacements for both `payload` and `vars` prefixes.

### Impact
This fix enables users to use the newer `foreach` (V2) mediator with arrays stored in variables while keeping `update-original=true`. It ensures correct aggregation of results back into the original variable or message body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression parsing in the ForEach mediator to correctly support Synapse expression wrappers and variable notation. Collections referenced through variables are now properly identified during expression evaluation. Expression transformations for JSON paths and variable expressions are processed with enhanced accuracy, improving overall reliability of expression handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->