### PR TITLE
[APIM] Fixing POST/PUT/PATCH requests failing with empty body

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughConstants.java
@@ -241,6 +241,7 @@ public class PassThroughConstants {
     public static final String HTTP_POST = "POST";
     public static final String HTTP_DELETE = "DELETE";
     public static final String HTTP_PUT = "PUT";
+    public static final String HTTP_PATCH = "PATCH";
     public static final String HTTP_OPTIONS = "OPTIONS";
     public static final String HTTP_CONNECT = "CONNECT";
     public static final String HTTP_METHOD = "HTTP_METHOD";

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -370,14 +370,8 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
     private void sendRequestContent(final MessageContext msgContext, final EndpointReference epr) throws AxisFault {
 
         boolean hasNoMessageBody = HTTPConstants.HTTP_METHOD_GET.equals(msgContext.getProperty(Constants.Configuration.
-                HTTP_METHOD)) || RelayUtils.isDeleteRequestWithoutPayload(msgContext);
-        String requestMethod = (String) msgContext.getProperty(Constants.Configuration.HTTP_METHOD);
-        if (PassThroughConstants.HTTP_PUT.equals(requestMethod)
-                || PassThroughConstants.HTTP_POST.equals(requestMethod)
-                || PassThroughConstants.HTTP_PATCH.equals(requestMethod)) {
-            // Determine if request truly has no payload
-            hasNoMessageBody = RelayUtils.isRequestWithoutPayload(msgContext);
-        }
+                HTTP_METHOD)) || RelayUtils.isDeleteRequestWithoutPayload(msgContext) ||
+                RelayUtils.isRequestWithoutPayload(msgContext);
 
         // consume the buffer completely before sending a request without a payload
         if (hasNoMessageBody) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -371,7 +371,15 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
 
         boolean hasNoMessageBody = HTTPConstants.HTTP_METHOD_GET.equals(msgContext.getProperty(Constants.Configuration.
                 HTTP_METHOD)) || RelayUtils.isDeleteRequestWithoutPayload(msgContext);
-        // consume the buffer completely before sending a GET request or DELETE request without a payload
+        String requestMethod = (String) msgContext.getProperty(Constants.Configuration.HTTP_METHOD);
+        if (PassThroughConstants.HTTP_PUT.equals(requestMethod)
+                || PassThroughConstants.HTTP_POST.equals(requestMethod)
+                || PassThroughConstants.HTTP_PATCH.equals(requestMethod)) {
+            // Determine if request truly has no payload
+            hasNoMessageBody = RelayUtils.isRequestWithoutPayload(msgContext);
+        }
+
+        // consume the buffer completely before sending a request without a payload
         if (hasNoMessageBody) {
             RelayUtils.discardMessage(msgContext);
         }
@@ -398,7 +406,7 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                     }
                     out = (OutputStream) msgContext.getProperty(PassThroughConstants.BUILDER_OUTPUT_STREAM);
                     if (out != null) {
-                        // Check HTTP method is GET or DELETE with no body
+                        // Check whether HTTP method is with no body
                         if (ignoreMessageBody(pipe, hasNoMessageBody)) {
                             return;
                         }
@@ -420,7 +428,7 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                 }
                 out = (OutputStream) msgContext.getProperty(PassThroughConstants.BUILDER_OUTPUT_STREAM);
                 if (out != null) {
-                    // Check HTTP method is GET or DELETE with no body
+                    // Check whether HTTP method is with no body
                     if (ignoreMessageBody(pipe, hasNoMessageBody)) {
                         return;
                     }
@@ -438,7 +446,7 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
         }
     }
 
-    // If the HTTP method is GET or DELETE with no body, we need to write down the HEADER information to the wire
+    // If the HTTP method is with no body, we need to write down the HEADER information to the wire
     // and need to ignore any entity enclosed methods available.
     private boolean ignoreMessageBody(Pipe pipe, boolean hasNoMessageBody) {
         if (hasNoMessageBody) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/DeferredMessageBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/DeferredMessageBuilder.java
@@ -91,14 +91,17 @@ public class DeferredMessageBuilder {
             XMLStreamException, IOException {
 
 		/**
-		 * HTTP Delete requests may contain entity body or not. Hence if the request is a HTTP DELETE, we have to verify
-		 * that the payload stream is empty or not.
+		 * HTTP Delete, PUT, POST, PATCH requests may contain entity body or not. Hence if the request is a HTTP DELETE,
+         * PUT, POST or PATCH we have to verify that the payload stream is empty or not.
 		 */
-		if (HTTPConstants.HEADER_DELETE.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) &&
-				RelayUtils.isEmptyPayloadStream(in)) {
-			msgCtx.setProperty(PassThroughConstants.NO_ENTITY_BODY, Boolean.TRUE);
-			return TransportUtils.createSOAPEnvelope(null);
-		}
+        if ((HTTPConstants.HEADER_DELETE.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
+                PassThroughConstants.HTTP_PUT.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
+                PassThroughConstants.HTTP_POST.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
+                PassThroughConstants.HTTP_PATCH.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)))
+                && RelayUtils.isEmptyPayloadStream(in)) {
+            msgCtx.setProperty(PassThroughConstants.NO_ENTITY_BODY, Boolean.TRUE);
+            return TransportUtils.createSOAPEnvelope(null);
+        }
     	
 		String contentType = (String) msgCtx.getProperty(Constants.Configuration.CONTENT_TYPE);
 		String _contentType = getContentType(contentType, msgCtx);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/DeferredMessageBuilder.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/DeferredMessageBuilder.java
@@ -94,11 +94,8 @@ public class DeferredMessageBuilder {
 		 * HTTP Delete, PUT, POST, PATCH requests may contain entity body or not. Hence if the request is a HTTP DELETE,
          * PUT, POST or PATCH we have to verify that the payload stream is empty or not.
 		 */
-        if ((HTTPConstants.HEADER_DELETE.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
-                PassThroughConstants.HTTP_PUT.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
-                PassThroughConstants.HTTP_POST.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)) ||
-                PassThroughConstants.HTTP_PATCH.equals(msgCtx.getProperty(Constants.Configuration.HTTP_METHOD)))
-                && RelayUtils.isEmptyPayloadStream(in)) {
+        if (isEmptyBodySupportedMethod(msgCtx) && RelayUtils.isEmptyPayloadStream(in)
+                && isEnvelopeBodyMissingFirstElement(msgCtx)) {
             msgCtx.setProperty(PassThroughConstants.NO_ENTITY_BODY, Boolean.TRUE);
             return TransportUtils.createSOAPEnvelope(null);
         }
@@ -308,5 +305,27 @@ public class DeferredMessageBuilder {
                     type = HTTPConstants.MEDIA_TYPE_APPLICATION_XML;
         }
         return type;
+    }
+
+    /**
+     * Methods that may arrive with an empty payload. For these methods we evaluate empty-stream handling.
+     */
+    private boolean isEmptyBodySupportedMethod(MessageContext msgCtx) {
+        String method = (String) msgCtx.getProperty(Constants.Configuration.HTTP_METHOD);
+        return HTTPConstants.HEADER_DELETE.equals(method)
+                || PassThroughConstants.HTTP_PUT.equals(method)
+                || PassThroughConstants.HTTP_POST.equals(method)
+                || PassThroughConstants.HTTP_PATCH.equals(method);
+    }
+
+    /**
+     * Returns true when there is no usable first payload element in the current envelope.
+     * This avoids replacing an already-populated body (e.g., xformValues created
+     * earlier in the request flow) with an empty envelope on a subsequent build pass.
+     */
+    private boolean isEnvelopeBodyMissingFirstElement(MessageContext msgCtx) {
+        return msgCtx.getEnvelope() == null
+                || msgCtx.getEnvelope().getBody() == null
+                || msgCtx.getEnvelope().getBody().getFirstElement() == null;
     }
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -277,6 +277,19 @@ public class RelayUtils {
     }
 
     /**
+     * Function to check whether the processing request (enclosed within MessageContext) is a request without
+     * entity body since we allow to have payload for PUT,POST or PATCH requests
+     *
+     * @param msgContext MessageContext
+     * @return whether the request is a PUT, POST or PATCH without payload
+     */
+    public static boolean isRequestWithoutPayload(MessageContext msgContext) {
+        // True if message builder ran and NO_ENTITY_BODY was set
+        return Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED))
+                && Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.NO_ENTITY_BODY));
+    }
+
+    /**
      * Check whether the we should overwrite the content type for the outgoing request.
      * @param msgContext MessageContext
      * @return whether to overwrite the content type for the outgoing request

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/util/RelayUtils.java
@@ -281,9 +281,16 @@ public class RelayUtils {
      * entity body since we allow to have payload for PUT,POST or PATCH requests
      *
      * @param msgContext MessageContext
-     * @return whether the request is a PUT, POST or PATCH without payload
+     * @return whether the request is a POST, PUT,  or PATCH without payload
      */
     public static boolean isRequestWithoutPayload(MessageContext msgContext) {
+        String method = (String) msgContext.getProperty(Constants.Configuration.HTTP_METHOD);
+        if (!PassThroughConstants.HTTP_POST.equals(method)
+                && !PassThroughConstants.HTTP_PUT.equals(method)
+                && !PassThroughConstants.HTTP_PATCH.equals(method)) {
+            //Not a HTTP POST, PUT or PATCH request
+            return false;
+        }
         // True if message builder ran and NO_ENTITY_BODY was set
         return Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED))
                 && Boolean.TRUE.equals(msgContext.getProperty(PassThroughConstants.NO_ENTITY_BODY));


### PR DESCRIPTION
## Purpose

This PR  fixes runtime failures for empty-body requests(POST/PUT/PATCH) when a content-aware mediation flow is used with `Content-Type: application/json` header.

Previously, empty-body handling was effectively aligned to DELETE behavior, while POST/PUT (and now PATCH) could still proceed to formatter serialization and hit JSON stream write failures.

## Approach

This PR extends the existing available empty-payload logic used for DELETE to other entity-enclosing methods, instead of introducing a new separate mechanism.

- Extended empty-payload detection in DeferredMessageBuilder from `DELETE` only to `DELETE, POST, PUT, and PATCH.`

- Reused the NO_ENTITY_BODY + MESSAGE_BUILDER_INVOKED model by introducing `RelayUtils.isRequestWithoutPayload()`

- Updated `PassThroughHttpSender.sendRequestContent() `to apply the same no-body decision to POST/PUT/PATCH, so serialization is skipped when the request is confirmed as payload-less.

- Kept existing discard flow intact for no-body requests, preserving current transport behavior patterns.

- Additionally, Added an envelope-aware guard to DeferredMessageBuilder empty-payload shortcut for DELETE/POST/PUT/PATCH. This addresses the WebSub/Webhook failure path where a second build pass could override an already materialized xformValues body and lead to downstream NPEs.


## Tested Flows

- https://github.com/wso2/api-manager/issues/4826#issuecomment-4293283046 