### PR TITLE
[APIM] Fixing POST/PUT/PATCH requests failing with empty body

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/xpath/SynapseJsonPath.java
@@ -174,6 +174,7 @@ public class SynapseJsonPath extends SynapsePath {
                         stream = JsonUtil.getJsonPayload(amc);
                     } else {
                         JsonUtil.getNewJsonPayload(amc, stream, true, true);
+                        stream = JsonUtil.toReadOnlyStream(stream);
                     }
                 } else {
                     // Message Already built.
@@ -278,6 +279,7 @@ public class SynapseJsonPath extends SynapsePath {
                         stream = JsonUtil.getJsonPayload(amc);
                     } else {
                         JsonUtil.getNewJsonPayload(amc, stream, true, true);
+                        stream = JsonUtil.toReadOnlyStream(stream);
                     }
                 } else {
                     // Message Already built.


### PR DESCRIPTION
## Purpose

- This PR fixes a runtime failure in APIs that use content-aware mediators with json-eval(...) when requests are sent with Content-Type: application/json and empty body
- In the streaming branch of SynapseJsonPath, JSONPath evaluation could run on the raw transport stream returned by `getMessageDataStream(...)`. If that stream was consumed/closed during evaluation, later outbound serialization (`JsonUtil.writeAsJson -> writeJsonStream`) failed with `Could not write JSON stream / java.io.IOException: Stream closed`.

- The fix now retrieves the JSON stream from the message context using `JsonUtil.toReadOnlyStream(stream) `after JsonUtil.getNewJsonPayload(...) in both JSONPath evaluation paths (stringValueOf and listValueOf). 
- Note that even without that for empty body scenarios, we are returning partially consumed stream with` return stringValueOf(stream);`
- Also this conditional branch is ideally reached in empty-body scenarios

## Related issues

- Fixes https://github.com/wso2/api-manager/issues/4826

## Tests

- https://github.com/wso2/api-manager/issues/4826#issuecomment-4293283046 