### PR TITLE
Skip setting startInPauseMode property in tasks based on a property

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/quartz/StartUpController.java
@@ -353,7 +353,15 @@ public class StartUpController extends AbstractStartup implements AspectConfigur
         if (taskDescription == null) {
             handleException("Error while initializing the startup. TaskDescription is null.");
         }
-        configureStartupStateFromRegistry(taskDescription);
+        boolean skipConfiguringStartupState = false;
+        Object skipConfiguringStartupStateProp = taskDescription.getProperty(TaskConstants.SKIP_START_IN_PAUSED_MODE_ASSIGNMENT);
+        if (skipConfiguringStartupStateProp != null) {
+            skipConfiguringStartupState = Boolean.parseBoolean((String) skipConfiguringStartupStateProp);
+        }
+
+        if (!skipConfiguringStartupState) {
+            configureStartupStateFromRegistry(taskDescription);
+        }
         initSynapseTaskManager(synapseEnvironment);
         TaskDescriptionRepository repository = synapseTaskManager.getTaskDescriptionRepository();
         if (repository == null) {

--- a/modules/tasks/src/main/java/org/apache/synapse/task/TaskConstants.java
+++ b/modules/tasks/src/main/java/org/apache/synapse/task/TaskConstants.java
@@ -28,4 +28,6 @@ public final class TaskConstants {
     public static final String TASK_DESCRIPTION_REPOSITORY = "task_description_repository";
 
     public static final String SYNAPSE_ENV = "SynapseEnvironment";
+
+    public static final String SKIP_START_IN_PAUSED_MODE_ASSIGNMENT = "skipStartInPauseModeAssignment";
 }


### PR DESCRIPTION
$subject

Setting the `startInPauseMode` property based on the value of `skipStartInPauseModeAssignment` property in taskdescription.