### PR TITLE
CallMediator: stop blocking JMS transport sender on destroy

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/CallMediator.java
@@ -23,6 +23,7 @@ import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.context.ConfigurationContextFactory;
+import org.apache.axis2.description.TransportOutDescription;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.ContinuationState;
 import org.apache.synapse.ManagedLifecycle;
@@ -465,7 +466,22 @@ public class CallMediator extends AbstractMediator implements ManagedLifecycle {
         if (endpoint != null) {
             endpoint.destroy();
         }
-        if (!blocking) {
+        if (blocking) {
+            // Stop the per mediator JMS transport sender so its JMSConnectionFactoryManager
+            // closes the cached SMF connections. Without this hook, every CAR redeploy
+            // orphans up to maxSharedConnectionCount JMS Connections on the broker.
+            if (configCtx != null) {
+                try {
+                    TransportOutDescription jmsOut =
+                            configCtx.getAxisConfiguration().getTransportOut("jms");
+                    if (jmsOut != null && jmsOut.getSender() != null) {
+                        jmsOut.getSender().stop();
+                    }
+                } catch (Exception e) {
+                    log.warn("Error stopping JMS transport sender on CallMediator destroy", e);
+                }
+            }
+        } else {
             synapseEnv.updateCallMediatorCount(false);
         }
     }


### PR DESCRIPTION


## Purpose
The blocking branch of CallMediator builds its own ConfigurationContext via ConfigurationContextFactory.createConfigurationContextFromFileSystem, which constructs a fresh JMSSender and JMSConnectionFactory per mediator instance. On CAR redeploy the old mediator is destroyed and a new one is created, but destroy() did not release the JMS resources, leaving the previous chain's cached JMS Connections open until broker-side idle timeout.

destroy() now looks up the "jms" TransportOutDescription on the per-mediator ConfigurationContext and calls TransportSender.stop() on its sender. This triggers the existing JMSConnectionFactoryManager / JMSConnectionFactory teardown chain. Non-blocking calls are unaffected since they reuse the runtime's global ConfigurationContext.


Fixes: https://github.com/wso2/product-integrator-mi/issues/4878