### PR TITLE
Add nonProxyHosts/targetProxyHosts support to OAuth token endpoint proxy configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/endpoints/ProxyConfigs.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/ProxyConfigs.java
@@ -29,6 +29,8 @@ public class ProxyConfigs {
     private String proxyPassword;
     private String proxyProtocol;
     private boolean proxyEnabled;
+    private String nonProxyHosts;
+    private String targetProxyHosts;
     private SecretResolver proxyPasswordSecretResolver;
 
     public void setProxyEnabled(boolean proxyEnabled) {
@@ -77,6 +79,22 @@ public class ProxyConfigs {
 
     public String getProxyProtocol() {
         return proxyProtocol;
+    }
+
+    public void setNonProxyHosts(String nonProxyHosts) {
+        this.nonProxyHosts = nonProxyHosts;
+    }
+
+    public String getNonProxyHosts() {
+        return nonProxyHosts;
+    }
+
+    public void setTargetProxyHosts(String targetProxyHosts) {
+        this.targetProxyHosts = targetProxyHosts;
+    }
+
+    public String getTargetProxyHosts() {
+        return targetProxyHosts;
     }
 
     public void setProxyPasswordSecretResolver(SecretResolver proxyPasswordSecretResolver) {

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/AuthConstants.java
@@ -97,12 +97,16 @@ public class AuthConstants {
     public static final String PROXY_USERNAME = "proxyUsername";
     public static final String PROXY_PASSWORD = "proxyPassword";
     public static final String OAUTH_PROXY_PROTOCOL = "proxyProtocol";
+    public static final String PROXY_NON_PROXY_HOSTS = "nonProxyHosts";
+    public static final String PROXY_TARGET_PROXY_HOSTS = "targetProxyHosts";
     public static final String OAUTH_GLOBAL_PROXY_ENABLED = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.enabled";
     public static final String OAUTH_GLOBAL_PROXY_HOST = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.host";
     public static final String OAUTH_GLOBAL_PROXY_PORT = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.port";
     public static final String OAUTH_GLOBAL_PROXY_USERNAME = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.username";
     public static final String OAUTH_GLOBAL_PROXY_PASSWORD = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.password";
     public static final String OAUTH_GLOBAL_PROXY_PROTOCOL = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.protocol";
+    public static final String OAUTH_GLOBAL_PROXY_NON_PROXY_HOSTS = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.nonProxyHosts";
+    public static final String OAUTH_GLOBAL_PROXY_TARGET_PROXY_HOSTS = "synapse.endpoint.http.oauth.token.endpoint.global.proxy.targetProxyHosts";
 
     // OAuth token endpoint truststore property names for synapse.properties
     public static final String OAUTH_TOKEN_ENDPOINT_TRUST_STORE_LOCATION = "synapse.endpoint.http.oauth.token.endpoint.trust.store.location";

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -78,6 +78,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Properties;
@@ -1044,8 +1045,10 @@ public class OAuthUtils {
         }
 
         private boolean matchesPattern(String hostname, String pattern) {
-            String regex = pattern.replace(".", "\\.").replace("*", ".*");
-            return hostname.matches(regex);
+            String normalizedHost = hostname.toLowerCase(Locale.ROOT);
+            String normalizedPattern = pattern.toLowerCase(Locale.ROOT);
+            String regex = normalizedPattern.replace(".", "\\.").replace("*", ".*");
+            return normalizedHost.matches(regex);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -973,6 +973,10 @@ public class OAuthUtils {
 
     private static class NonProxyAwareProxyRoutePlanner extends DefaultProxyRoutePlanner {
 
+        // Small arbitrary buffer added to the initial StringBuilder capacity as a hint to reduce resizes
+        // for typical short hostname patterns. StringBuilder grows automatically if this is exceeded.
+        private static final int REGEX_BUILDER_EXTRA_CAPACITY = 8;
+
         private final String[] nonProxyPatterns;
         private final String[] targetProxyPatterns;
 
@@ -1048,7 +1052,7 @@ public class OAuthUtils {
         private boolean matchesPattern(String hostname, String pattern) {
             String normalizedHost = hostname.toLowerCase(Locale.ROOT);
             String normalizedPattern = pattern.toLowerCase(Locale.ROOT);
-            StringBuilder regex = new StringBuilder(normalizedPattern.length() + 8);
+            StringBuilder regex = new StringBuilder(normalizedPattern.length() + REGEX_BUILDER_EXTRA_CAPACITY);
             StringBuilder literal = new StringBuilder();
             for (int i = 0; i < normalizedPattern.length(); i++) {
                 char c = normalizedPattern.charAt(i);

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -28,7 +28,9 @@ import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -46,6 +48,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
@@ -343,6 +346,8 @@ public class OAuthUtils {
             proxyConfigs.setProxyProtocol(getChildValue(proxyConfigsOM, AuthConstants.OAUTH_PROXY_PROTOCOL));
             proxyConfigs.setProxyUsername(getChildValue(proxyConfigsOM, AuthConstants.PROXY_USERNAME));
             proxyConfigs.setProxyPassword(getChildValue(proxyConfigsOM, AuthConstants.PROXY_PASSWORD));
+            proxyConfigs.setNonProxyHosts(getChildValue(proxyConfigsOM, AuthConstants.PROXY_NON_PROXY_HOSTS));
+            proxyConfigs.setTargetProxyHosts(getChildValue(proxyConfigsOM, AuthConstants.PROXY_TARGET_PROXY_HOSTS));
         } else {
             Properties synapseProperties = SynapsePropertiesLoader.loadSynapseProperties();
             if (Boolean.parseBoolean(getChildValue(grantTypeOMElement, AuthConstants.USE_GLOBAL_PROXY_CONFIGS))
@@ -352,6 +357,8 @@ public class OAuthUtils {
                 proxyConfigs.setProxyHost(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_HOST));
                 proxyConfigs.setProxyPort(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PORT));
                 proxyConfigs.setProxyProtocol(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PROTOCOL));
+                proxyConfigs.setNonProxyHosts(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_NON_PROXY_HOSTS));
+                proxyConfigs.setTargetProxyHosts(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_TARGET_PROXY_HOSTS));
                 if (StringUtils.isNotBlank(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME)) &&
                         StringUtils.isNotBlank(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_PASSWORD))) {
                     proxyConfigs.setProxyUsername(synapseProperties.getProperty(AuthConstants.OAUTH_GLOBAL_PROXY_USERNAME));
@@ -812,6 +819,18 @@ public class OAuthUtils {
                 proxyConfigs.getProxyProtocol());
         proxyConfigsOM.addChild(proxyProtocolOM);
 
+        if (StringUtils.isNotBlank(proxyConfigs.getNonProxyHosts())) {
+            OMElement nonProxyHostsOM = OAuthUtils.createOMElementWithValue(omFactory,
+                    AuthConstants.PROXY_NON_PROXY_HOSTS, proxyConfigs.getNonProxyHosts());
+            proxyConfigsOM.addChild(nonProxyHostsOM);
+        }
+
+        if (StringUtils.isNotBlank(proxyConfigs.getTargetProxyHosts())) {
+            OMElement targetProxyHostsOM = OAuthUtils.createOMElementWithValue(omFactory,
+                    AuthConstants.PROXY_TARGET_PROXY_HOSTS, proxyConfigs.getTargetProxyHosts());
+            proxyConfigsOM.addChild(targetProxyHostsOM);
+        }
+
         return proxyConfigsOM;
     }
 
@@ -888,7 +907,8 @@ public class OAuthUtils {
             HttpHost host = new HttpHost(proxyConfigs.getProxyHost(), Integer.parseInt(proxyConfigs.getProxyPort()),
                     proxyConfigs.getProxyProtocol());
 
-            DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(host);
+            NonProxyAwareProxyRoutePlanner routePlanner = new NonProxyAwareProxyRoutePlanner(host,
+                    proxyConfigs.getNonProxyHosts(), proxyConfigs.getTargetProxyHosts());
 
             clientBuilder = HttpClients.custom().setConnectionManager(pool).setRoutePlanner(routePlanner)
                     .setDefaultRequestConfig(config).setSSLSocketFactory(sslConnectionFactory);
@@ -946,6 +966,86 @@ public class OAuthUtils {
         } else {
             // Resolves the password when endpoint specific proxy configurations are used
             return OAuthUtils.resolveExpression(proxyConfigs.getProxyPassword(), messageContext);
+        }
+    }
+
+    private static class NonProxyAwareProxyRoutePlanner extends DefaultProxyRoutePlanner {
+
+        private final String[] nonProxyPatterns;
+        private final String[] targetProxyPatterns;
+
+        NonProxyAwareProxyRoutePlanner(HttpHost proxy, String nonProxyHosts, String targetProxyHosts) {
+            super(proxy);
+            if (org.apache.commons.lang3.StringUtils.isNotBlank(nonProxyHosts)) {
+                this.nonProxyPatterns = nonProxyHosts.split("\\|");
+            } else {
+                this.nonProxyPatterns = new String[0];
+            }
+            if (org.apache.commons.lang3.StringUtils.isNotBlank(targetProxyHosts)) {
+                this.targetProxyPatterns = targetProxyHosts.split("\\|");
+            } else {
+                this.targetProxyPatterns = new String[0];
+            }
+        }
+
+        @Override
+        protected HttpHost determineProxy(HttpHost target, HttpRequest request, HttpContext context)
+                throws HttpException {
+
+            String targetHost = target.getHostName();
+
+            for (String pattern : nonProxyPatterns) {
+                String trimmedPattern = pattern.trim();
+                if (!trimmedPattern.isEmpty()) {
+                    if ("*".equals(trimmedPattern)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Host [" + targetHost + "] matches wildcard non-proxy pattern [*]. "
+                                    + "Bypassing proxy.");
+                        }
+                        return null;
+                    }
+                    if (matchesPattern(targetHost, trimmedPattern)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Host [" + targetHost + "] matches non-proxy pattern [" + trimmedPattern
+                                    + "]. Bypassing proxy.");
+                        }
+                        return null;
+                    }
+                }
+            }
+
+            if (targetProxyPatterns.length > 0) {
+                for (String pattern : targetProxyPatterns) {
+                    String trimmedPattern = pattern.trim();
+                    if (!trimmedPattern.isEmpty()) {
+                        if ("*".equals(trimmedPattern)) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Host [" + targetHost + "] matches wildcard target-proxy pattern [*]. "
+                                        + "Using proxy.");
+                            }
+                            return super.determineProxy(target, request, context);
+                        }
+                        if (matchesPattern(targetHost, trimmedPattern)) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Host [" + targetHost + "] matches target-proxy pattern [" + trimmedPattern
+                                        + "]. Using proxy.");
+                            }
+                            return super.determineProxy(target, request, context);
+                        }
+                    }
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Host [" + targetHost + "] does not match any target-proxy pattern. Bypassing proxy.");
+                }
+                return null;
+            }
+
+            return super.determineProxy(target, request, context);
+        }
+
+        private boolean matchesPattern(String hostname, String pattern) {
+            String regex = pattern.replace(".", "\\.").replace("*", ".*");
+            return hostname.matches(regex);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/endpoints/auth/oauth/OAuthUtils.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -1047,8 +1048,31 @@ public class OAuthUtils {
         private boolean matchesPattern(String hostname, String pattern) {
             String normalizedHost = hostname.toLowerCase(Locale.ROOT);
             String normalizedPattern = pattern.toLowerCase(Locale.ROOT);
-            String regex = normalizedPattern.replace(".", "\\.").replace("*", ".*");
-            return normalizedHost.matches(regex);
+            StringBuilder regex = new StringBuilder(normalizedPattern.length() + 8);
+            StringBuilder literal = new StringBuilder();
+            for (int i = 0; i < normalizedPattern.length(); i++) {
+                char c = normalizedPattern.charAt(i);
+                if (c == '*') {
+                    if (literal.length() > 0) {
+                        regex.append(Pattern.quote(literal.toString()));
+                        literal.setLength(0);
+                    }
+                    regex.append(".*");
+                } else {
+                    literal.append(c);
+                }
+            }
+            if (literal.length() > 0) {
+                regex.append(Pattern.quote(literal.toString()));
+            }
+            try {
+                return normalizedHost.matches(regex.toString());
+            } catch (PatternSyntaxException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Invalid proxy host pattern [" + pattern + "], treating as no match.", e);
+                }
+                return false;
+            }
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/ProxyConfigsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/ProxyConfigsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com/).
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/ProxyConfigsTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/ProxyConfigsTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com/).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.endpoints;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ProxyConfigsTest {
+
+    @Test
+    public void testNonProxyHostsGetterSetter() {
+        ProxyConfigs proxyConfigs = new ProxyConfigs();
+        assertNull(proxyConfigs.getNonProxyHosts());
+
+        proxyConfigs.setNonProxyHosts("localhost|*.internal.com");
+        assertEquals("localhost|*.internal.com", proxyConfigs.getNonProxyHosts());
+    }
+
+    @Test
+    public void testTargetProxyHostsGetterSetter() {
+        ProxyConfigs proxyConfigs = new ProxyConfigs();
+        assertNull(proxyConfigs.getTargetProxyHosts());
+
+        proxyConfigs.setTargetProxyHosts("*.external.com|api.example.com");
+        assertEquals("*.external.com|api.example.com", proxyConfigs.getTargetProxyHosts());
+    }
+
+    @Test
+    public void testNonProxyHostsWithEmptyString() {
+        ProxyConfigs proxyConfigs = new ProxyConfigs();
+        proxyConfigs.setNonProxyHosts("");
+        assertEquals("", proxyConfigs.getNonProxyHosts());
+    }
+
+    @Test
+    public void testTargetProxyHostsWithNull() {
+        ProxyConfigs proxyConfigs = new ProxyConfigs();
+        proxyConfigs.setTargetProxyHosts(null);
+        assertNull(proxyConfigs.getTargetProxyHosts());
+    }
+
+    @Test
+    public void testExistingFieldsUnaffected() {
+        ProxyConfigs proxyConfigs = new ProxyConfigs();
+        proxyConfigs.setProxyHost("proxy.example.com");
+        proxyConfigs.setProxyPort("8080");
+        proxyConfigs.setProxyProtocol("HTTP");
+        proxyConfigs.setProxyEnabled(true);
+        proxyConfigs.setNonProxyHosts("localhost");
+        proxyConfigs.setTargetProxyHosts("*.external.com");
+
+        assertEquals("proxy.example.com", proxyConfigs.getProxyHost());
+        assertEquals("8080", proxyConfigs.getProxyPort());
+        assertEquals("HTTP", proxyConfigs.getProxyProtocol());
+        assertEquals(true, proxyConfigs.isProxyEnabled());
+        assertEquals("localhost", proxyConfigs.getNonProxyHosts());
+        assertEquals("*.external.com", proxyConfigs.getTargetProxyHosts());
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
@@ -91,6 +91,27 @@ public class NonProxyAwareProxyRoutePlannerTest {
     }
 
     @Test
+    public void testNonProxyHostsBracketPatternDoesNotThrow() throws Exception {
+        Object planner = createRoutePlanner("host[1].internal.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("anything.example.com", 443));
+        assertNotNull("Pattern with literal brackets should not crash; host should use proxy", result);
+    }
+
+    @Test
+    public void testNonProxyHostsBracketPatternMatchesLiteral() throws Exception {
+        Object planner = createRoutePlanner("host[1].internal.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("host[1].internal.com", 443));
+        assertNull("Literal bracketed host should match the same bracketed pattern", result);
+    }
+
+    @Test
+    public void testNonProxyHostsRegexMetacharsDoNotThrow() throws Exception {
+        Object planner = createRoutePlanner("foo?+.example.(com)", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("api.example.com", 443));
+        assertNotNull("Pattern with regex metacharacters should not crash; host should use proxy", result);
+    }
+
+    @Test
     public void testNonProxyHostsWildcardNoMatch() throws Exception {
         Object planner = createRoutePlanner("*.internal.com", null);
         HttpHost result = callDetermineProxy(planner, new HttpHost("api.external.com", 443));

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
@@ -84,6 +84,13 @@ public class NonProxyAwareProxyRoutePlannerTest {
     }
 
     @Test
+    public void testNonProxyHostsCaseInsensitiveMatch() throws Exception {
+        Object planner = createRoutePlanner("*.INTERNAL.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("API.internal.COM", 443));
+        assertNull("Host should match nonProxyHosts regardless of case", result);
+    }
+
+    @Test
     public void testNonProxyHostsWildcardNoMatch() throws Exception {
         Object planner = createRoutePlanner("*.internal.com", null);
         HttpHost result = callDetermineProxy(planner, new HttpHost("api.external.com", 443));
@@ -156,6 +163,13 @@ public class NonProxyAwareProxyRoutePlannerTest {
                 callDetermineProxy(planner, new HttpHost("api.partner.org", 443)));
         assertNull("localhost should not match any targetProxyHosts",
                 callDetermineProxy(planner, new HttpHost("localhost", 80)));
+    }
+
+    @Test
+    public void testTargetProxyHostsCaseInsensitiveMatch() throws Exception {
+        Object planner = createRoutePlanner(null, "*.EXTERNAL.com");
+        HttpHost result = callDetermineProxy(planner, new HttpHost("API.external.COM", 443));
+        assertNotNull("Host should match targetProxyHosts regardless of case", result);
     }
 
     @Test

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com/).
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/endpoints/auth/oauth/NonProxyAwareProxyRoutePlannerTest.java
@@ -1,0 +1,195 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com/).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.synapse.endpoints.auth.oauth;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class NonProxyAwareProxyRoutePlannerTest {
+
+    private static final HttpHost PROXY = new HttpHost("proxy.example.com", 3128, "http");
+    private static final HttpRequest REQUEST = new BasicHttpRequest("GET", "/");
+    private static final HttpContext CONTEXT = new BasicHttpContext();
+
+    private Object createRoutePlanner(String nonProxyHosts, String targetProxyHosts) throws Exception {
+        Class<?> outerClass = OAuthUtils.class;
+        Class<?>[] innerClasses = outerClass.getDeclaredClasses();
+        Class<?> plannerClass = null;
+        for (Class<?> c : innerClasses) {
+            if (c.getSimpleName().equals("NonProxyAwareProxyRoutePlanner")) {
+                plannerClass = c;
+                break;
+            }
+        }
+        assertNotNull("NonProxyAwareProxyRoutePlanner class not found", plannerClass);
+
+        Constructor<?> constructor = plannerClass.getDeclaredConstructor(HttpHost.class, String.class, String.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(PROXY, nonProxyHosts, targetProxyHosts);
+    }
+
+    private HttpHost callDetermineProxy(Object planner, HttpHost target) throws Exception {
+        Method method = DefaultProxyRoutePlanner.class.getDeclaredMethod(
+                "determineProxy", HttpHost.class, HttpRequest.class, HttpContext.class);
+        method.setAccessible(true);
+        return (HttpHost) method.invoke(planner, target, REQUEST, CONTEXT);
+    }
+
+    @Test
+    public void testNonProxyHostsExactMatch() throws Exception {
+        Object planner = createRoutePlanner("localhost", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("localhost", 9876));
+        assertNull("localhost should bypass proxy", result);
+    }
+
+    @Test
+    public void testNonProxyHostsNoMatch() throws Exception {
+        Object planner = createRoutePlanner("internal.example.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("external.example.com", 443));
+        assertNotNull("external.example.com should use proxy", result);
+    }
+
+    @Test
+    public void testNonProxyHostsWildcardMatch() throws Exception {
+        Object planner = createRoutePlanner("*.internal.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("api.internal.com", 443));
+        assertNull("api.internal.com should match *.internal.com and bypass proxy", result);
+    }
+
+    @Test
+    public void testNonProxyHostsWildcardNoMatch() throws Exception {
+        Object planner = createRoutePlanner("*.internal.com", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("api.external.com", 443));
+        assertNotNull("api.external.com should not match *.internal.com", result);
+    }
+
+    @Test
+    public void testNonProxyHostsWildcardAll() throws Exception {
+        Object planner = createRoutePlanner("*", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("anything.example.com", 443));
+        assertNull("* should bypass proxy for all hosts", result);
+    }
+
+    @Test
+    public void testNonProxyHostsPipeSeparated() throws Exception {
+        Object planner = createRoutePlanner("localhost|*.internal.com|10.0.*", null);
+
+        assertNull("localhost should match",
+                callDetermineProxy(planner, new HttpHost("localhost", 80)));
+        assertNull("api.internal.com should match *.internal.com",
+                callDetermineProxy(planner, new HttpHost("api.internal.com", 443)));
+        assertNull("10.0.1.5 should match 10.0.*",
+                callDetermineProxy(planner, new HttpHost("10.0.1.5", 80)));
+        assertNotNull("external.com should not match any",
+                callDetermineProxy(planner, new HttpHost("external.com", 443)));
+    }
+
+    @Test
+    public void testNonProxyHostsEmpty() throws Exception {
+        Object planner = createRoutePlanner("", null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("localhost", 80));
+        assertNotNull("Empty nonProxyHosts should use proxy (default)", result);
+    }
+
+    @Test
+    public void testNonProxyHostsNull() throws Exception {
+        Object planner = createRoutePlanner(null, null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("localhost", 80));
+        assertNotNull("Null nonProxyHosts should use proxy (default)", result);
+    }
+
+    @Test
+    public void testTargetProxyHostsExactMatch() throws Exception {
+        Object planner = createRoutePlanner(null, "api.external.com");
+        HttpHost result = callDetermineProxy(planner, new HttpHost("api.external.com", 443));
+        assertNotNull("api.external.com matches targetProxyHosts — should use proxy", result);
+    }
+
+    @Test
+    public void testTargetProxyHostsNoMatch() throws Exception {
+        Object planner = createRoutePlanner(null, "*.external.com");
+        HttpHost result = callDetermineProxy(planner, new HttpHost("localhost", 80));
+        assertNull("localhost doesn't match *.external.com — should bypass proxy", result);
+    }
+
+    @Test
+    public void testTargetProxyHostsWildcardAll() throws Exception {
+        Object planner = createRoutePlanner(null, "*");
+        HttpHost result = callDetermineProxy(planner, new HttpHost("anything.example.com", 443));
+        assertNotNull("* targetProxyHosts should proxy all hosts", result);
+    }
+
+    @Test
+    public void testTargetProxyHostsPipeSeparated() throws Exception {
+        Object planner = createRoutePlanner(null, "*.external.com|api.partner.org");
+
+        assertNotNull("api.external.com should match *.external.com",
+                callDetermineProxy(planner, new HttpHost("api.external.com", 443)));
+        assertNotNull("api.partner.org should match exactly",
+                callDetermineProxy(planner, new HttpHost("api.partner.org", 443)));
+        assertNull("localhost should not match any targetProxyHosts",
+                callDetermineProxy(planner, new HttpHost("localhost", 80)));
+    }
+
+    @Test
+    public void testNonProxyHostsTakesPrecedenceOverTargetProxyHosts() throws Exception {
+        Object planner = createRoutePlanner("localhost", "localhost");
+        HttpHost result = callDetermineProxy(planner, new HttpHost("localhost", 80));
+        assertNull("nonProxyHosts should take precedence — bypass proxy", result);
+    }
+
+    @Test
+    public void testBothConfiguredDifferentHosts() throws Exception {
+        Object planner = createRoutePlanner("localhost", "*.external.com");
+
+        assertNull("localhost matches nonProxyHosts — bypass",
+                callDetermineProxy(planner, new HttpHost("localhost", 80)));
+        assertNotNull("api.external.com matches targetProxyHosts — use proxy",
+                callDetermineProxy(planner, new HttpHost("api.external.com", 443)));
+        assertNull("unknown.com doesn't match targetProxyHosts — bypass",
+                callDetermineProxy(planner, new HttpHost("unknown.com", 443)));
+    }
+
+    @Test
+    public void testNonProxyHostsWithSpaces() throws Exception {
+        Object planner = createRoutePlanner(" localhost | *.internal.com ", null);
+        assertNull("localhost should match despite spaces",
+                callDetermineProxy(planner, new HttpHost("localhost", 80)));
+        assertNull("api.internal.com should match despite spaces",
+                callDetermineProxy(planner, new HttpHost("api.internal.com", 443)));
+    }
+
+    @Test
+    public void testNoConfigDefaultBehavior() throws Exception {
+        Object planner = createRoutePlanner(null, null);
+        HttpHost result = callDetermineProxy(planner, new HttpHost("any.host.com", 443));
+        assertNotNull("No config should default to using proxy", result);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `nonProxyHosts` and `targetProxyHosts` support to the Synapse-level OAuth token endpoint proxy configuration. This was lost when APIM migrated from class-mediator-based OAuth to the Synapse endpoint implementation.

**Issue:** https://github.com/wso2/api-manager/issues/5003

## Root Cause
The `ProxyConfigs` class and `OAuthUtils.getSecureClient()` did not support `nonProxyHosts` or `targetProxyHosts` fields. The HTTP client always used `DefaultProxyRoutePlanner` which routes ALL traffic through the proxy unconditionally.

## Changes

### ProxyConfigs.java
- Added `nonProxyHosts` and `targetProxyHosts` String fields with getters and setters

### AuthConstants.java
- Added 4 constants: `PROXY_NON_PROXY_HOSTS`, `PROXY_TARGET_PROXY_HOSTS`, `OAUTH_GLOBAL_PROXY_NON_PROXY_HOSTS`, `OAUTH_GLOBAL_PROXY_TARGET_PROXY_HOSTS`

### OAuthUtils.java
- `getProxyConfigs()`: Reads new fields from endpoint XML and global synapse.properties
- `createOMProxyConfigs()`: Serializes new fields
- `getSecureClient()`: Replaced `DefaultProxyRoutePlanner` with `NonProxyAwareProxyRoutePlanner`
- Added `NonProxyAwareProxyRoutePlanner` inner class that evaluates glob patterns for proxy bypass/restrict

### New Test Files
- `ProxyConfigsTest.java` — 5 tests for getter/setter
- `NonProxyAwareProxyRoutePlannerTest.java` — 16 tests covering: exact match, wildcard, pipe-separated, null/empty, targetProxyHosts restrict, precedence, edge cases

## Verification
- All 21 unit tests pass
- End-to-end test with real HTTP proxy and echo backend confirmed:
  - Requests matching `targetProxyHosts` route through proxy
  - Requests NOT matching bypass proxy
  - `nonProxyHosts` takes precedence over `targetProxyHosts`