### PR TITLE
[master] Improve fix for duplicate VFS provider registration when multiple CARs include the same connector dependency

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
+++ b/modules/core/src/main/java/org/apache/synapse/libraries/util/LibDeployerUtils.java
@@ -91,14 +91,7 @@ public class LibDeployerUtils {
         } else {
             if (deployedLibClassLoader instanceof LibClassLoader) {
                 try {
-                    if (!isDependencyAlreadyLoaded((LibClassLoader) deployedLibClassLoader, extractPath)) {
-                        ((LibClassLoader) deployedLibClassLoader).addToClassPath(extractPath);
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Synapse Library '" + libArtifactName +
-                                    "' is already loaded in the class loader. Skipping duplicate addition of: " + extractPath);
-                        }
-                    }
+                    ((LibClassLoader) deployedLibClassLoader).addToClassPath(extractPath);
                 } catch (MalformedURLException e) {
                     throw new SynapseArtifactDeploymentException("Error setting up lib classpath for Synapse" +
                             " Library  : " + libFile.getAbsolutePath(), e);


### PR DESCRIPTION
## Purpose
Revert duplicate checks when adding connector ZIPs to the class loader, since the generated ZIP names include unique prefixes and cannot be reliably identified by name comparison

Fixes: https://github.com/wso2/product-integrator-mi/issues/4901