### PR TITLE
Improve distributed throttle counter synchronization

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/AccessRateController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/AccessRateController.java
@@ -114,27 +114,27 @@ public class AccessRateController {
                     long currentTime = System.currentTimeMillis();
 
                     if (!caller.canAccess(throttleContext, configuration, currentTime)) {
-                        //if current caller cannot access , then perform cleaning
                         log.info(ACCESS_DENIED_TEMPORALLY);
-                        throttleContext.processCleanList(currentTime);
                         accessInformation.setAccessAllowed(false);
                         accessInformation.setFaultReason(ACCESS_DENIED_TEMPORALLY);
-                        return accessInformation;
                     } else {
                         if (debugOn) {
                             log.debug("Access  from " + type + " " + callerID + " is successful.");
                         }
                         accessInformation.setAccessAllowed(true);
-                        return accessInformation;
                     }
                 } else {
                     if (debugOn) {
                         log.debug("Caller " + type + " not found! " + callerID);
                     }
                     accessInformation.setAccessAllowed(true);
-                    return accessInformation;
                 }
             }
+            //if current caller cannot access , then perform cleaning
+            if (!accessInformation.isAccessAllowed()) {
+                throttleContext.processCleanList(System.currentTimeMillis());
+            }
+            return accessInformation;
         }
         accessInformation.setAccessAllowed(true);
         return accessInformation;

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
@@ -40,9 +40,9 @@ public abstract class CallerContext implements Serializable, Cloneable {
     /* next access time - the end of prohibition */
     private long nextAccessTime = 0;
     /* first access time - when caller came across the on first time */
-    private long firstAccessTime = 0;
+    private volatile long firstAccessTime = 0;
     /* The nextTimeWindow - beginning of next unit time period- end of current unit time period  */
-    private long nextTimeWindow = 0;
+    private volatile long nextTimeWindow = 0;
     /* The globalCount to keep track number of request */
     private AtomicLong globalCount = new AtomicLong(0);
     private long localQuota;
@@ -485,6 +485,14 @@ public abstract class CallerContext implements Serializable, Cloneable {
             }
             newValue = currentValue - 1;
         } while (!localCount.compareAndSet(currentValue, newValue));
+    }
+
+    public void subtractFromLocalCounterSafe(long amount) {
+        long current, next;
+        do {
+            current = localCount.get();
+            next = Math.max(0L, current - amount);
+        } while (!localCount.compareAndSet(current, next));
     }
 
     public long getGlobalCounter() {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
@@ -146,16 +146,17 @@ public abstract class CallerContext implements Serializable, Cloneable {
         boolean canAccess = false;
         int maxRequest = configuration.getMaximumRequestPerUnitTime();
         if (maxRequest != 0) {
-            long currentGlobal = this.globalCount.get();
             long currentLocal;
             boolean incremented = false;
+            long requestedCount = eventCount == null ? 1L : eventCount;
             do {
+                long currentGlobal = this.globalCount.get();
                 currentLocal = this.localCount.get();
-                if (currentGlobal + currentLocal >= maxRequest) {
+                if (currentGlobal + currentLocal + requestedCount > maxRequest) {
                     break; // slot exhausted; do not increment
                 }
                 // Try to atomically increment only if localCount hasn't changed
-                incremented = this.localCount.compareAndSet(currentLocal, currentLocal + 1);
+                incremented = this.localCount.compareAndSet(currentLocal, currentLocal + requestedCount);
             } while (!incremented);
 
             if (incremented) {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/CallerContext.java
@@ -52,7 +52,7 @@ public abstract class CallerContext implements Serializable, Cloneable {
      This is specific for each API EP
      if this is true, then syncing of throttle parameter with global redis counters be synced will be done in sync mode
      */
-    private boolean isThrottleParamSyncingModeSync;
+    private volatile boolean isThrottleParamSyncingModeSync;
     private ThrottleProperties throttleProperties;
 
 
@@ -146,7 +146,19 @@ public abstract class CallerContext implements Serializable, Cloneable {
         boolean canAccess = false;
         int maxRequest = configuration.getMaximumRequestPerUnitTime();
         if (maxRequest != 0) {
-            if ((this.globalCount.get() + this.localCount.get()) < maxRequest) {    //If the globalCount is less than max request
+            long currentGlobal = this.globalCount.get();
+            long currentLocal;
+            boolean incremented = false;
+            do {
+                currentLocal = this.localCount.get();
+                if (currentGlobal + currentLocal >= maxRequest) {
+                    break; // slot exhausted; do not increment
+                }
+                // Try to atomically increment only if localCount hasn't changed
+                incremented = this.localCount.compareAndSet(currentLocal, currentLocal + 1);
+            } while (!incremented);
+
+            if (incremented) {
                 if (log.isDebugEnabled()) {
                     log.debug("CallerContext Checking access if unit time is not over and less than max count>> Access "
                             + "allowed=" + maxRequest + " available="+ (maxRequest - (this.globalCount.get() + this.localCount.get()))
@@ -155,7 +167,6 @@ public abstract class CallerContext implements Serializable, Cloneable {
                             + configuration.getID() + " nextAccessTime=" + this.nextAccessTime);
                 }
                 canAccess = true;     // can continue access
-                this.localCount.addAndGet(eventCount);
                 // Send the current state to others (clustered env)
                 throttleContext.flushCallerContext(this, id);
                 // can complete access
@@ -453,6 +464,14 @@ public abstract class CallerContext implements Serializable, Cloneable {
 
     public void incrementLocalCounter() {
         localCount.incrementAndGet();
+    }
+
+    public long getAndSetLocalCounter(long newValue) {
+        return localCount.getAndSet(newValue);
+    }
+
+    public void incrementLocalCounterBy(long delta) {
+        localCount.addAndGet(delta);
     }
 
     public void decrementLocalCounter() {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
@@ -146,4 +146,43 @@ public interface DistributedCounterManager {
     public long getKeyLockRetrievalTimeout();
 
     public void removeLock(String key);
+
+     /**
+     * Atomically reads the window timestamp and counter for the given key.
+     *
+     * @param key distributed store key
+     * @return long[2]: {timestamp, counter}
+     */
+    default long[] getWindowState(String key) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Unconditionally sets a throttle window by overwriting both timestamp and counter,
+     * then setting the TTL. Must be called while holding the per-caller window lock so no
+     * concurrent writer can race. Stale data from a previous window is overwritten atomically.
+     *
+     * @param key        distributed store key
+     * @param count      initial counter value
+     * @param ts         window first-access time in milliseconds
+     * @param expiryTime absolute expiry timestamp in milliseconds (ts + unitTime)
+     */
+    default void setWindow(String key, long count, long ts, long expiryTime) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Atomically increments the window counter by {@code delta}, refreshes the TTL to
+     * {@code expiryTime}, and returns the new value. Refreshing the TTL guards against the
+     * narrow race where the hash key expires between the caller's pre-check and this call —
+     * without a TTL the HINCRBY-created hash would persist indefinitely.
+     *
+     * @param key        distributed store key
+     * @param delta      value to add to the counter
+     * @param expiryTime absolute window-end timestamp in ms (sharedTimestamp + unitTime)
+     * @return new global counter value after the increment
+     */
+    default long incrWindowCounter(String key, long delta, long expiryTime) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/RoleBasedAccessRateController.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/RoleBasedAccessRateController.java
@@ -122,27 +122,27 @@ public class RoleBasedAccessRateController {
                     long currentTime = System.currentTimeMillis();
 
                     if (!caller.canAccess(throttleContext, configuration, currentTime, eventCount)) {
-                        //if current caller cannot access , then perform cleaning
                         log.info(ACCESS_DENIED_TEMPORALLY);
-                        throttleContext.processCleanList(currentTime);
                         accessInformation.setAccessAllowed(false);
                         accessInformation.setFaultReason(ACCESS_DENIED_TEMPORALLY);
-                        return accessInformation;
                     } else {
                         if (debugOn) {
                             log.debug("Access  from " + type + " " + roleID + " is successful.");
                         }
                         accessInformation.setAccessAllowed(true);
-                        return accessInformation;
                     }
                 } else {
                     if (debugOn) {
                         log.debug("Caller " + type + " not found! " + roleID);
                     }
                     accessInformation.setAccessAllowed(true);
-                    return accessInformation;
                 }
             }
+            //if current caller cannot access , then perform cleaning
+            if (!accessInformation.isAccessAllowed()) {
+                throttleContext.processCleanList(System.currentTimeMillis());
+            }
+            return accessInformation;
         }
         accessInformation.setAccessAllowed(true);
         return accessInformation;

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/SharedParamManager.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/SharedParamManager.java
@@ -374,4 +374,107 @@ public class SharedParamManager {
 			}
 		}
 	}
+	/**
+	 * Atomically reads the window timestamp and counter for the given caller id.
+	 *
+	 * @param id caller context id
+	 * @return long[2]: {timestamp, counter}
+	 */
+	public static long[] getWindowState(String id) {
+		String key = ThrottleConstants.THROTTLE_WINDOW_HASH_KEY + id;
+		DistributedCounterManager distributedCounterManager =
+				ThrottleServiceDataHolder.getInstance().getDistributedCounterManager();
+		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
+			return distributedCounterManager.getWindowState(key);
+		} else {
+			String tsKey      = ThrottleConstants.THROTTLE_TIMESTAMP_KEY + id;
+			String counterKey = ThrottleConstants.THROTTLE_SHARED_COUNTER_KEY + id;
+			Long ts      = timestamps.get(tsKey);
+			Long counter = counters.get(counterKey);
+			return new long[]{
+					ts      != null ? ts      : 0L,
+					counter != null ? counter : 0L
+			};
+		}
+	}
+
+	/**
+	 * Unconditionally sets a throttle window by overwriting both timestamp and counter, then
+	 * refreshing the TTL. Must be called while holding the per-caller window lock.
+	 *
+	 * @param id         caller context id
+	 * @param count      initial counter value
+	 * @param ts         window first-access time in milliseconds
+	 * @param expiryTime absolute expiry timestamp in milliseconds (ts + unitTime)
+	 */
+	public static void setWindow(String id, long count, long ts, long expiryTime) {
+		String key = ThrottleConstants.THROTTLE_WINDOW_HASH_KEY + id;
+		DistributedCounterManager distributedCounterManager =
+				ThrottleServiceDataHolder.getInstance().getDistributedCounterManager();
+		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
+			distributedCounterManager.setWindow(key, count, ts, expiryTime);
+		} else {
+			timestamps.put(ThrottleConstants.THROTTLE_TIMESTAMP_KEY + id, ts);
+			counters.put(ThrottleConstants.THROTTLE_SHARED_COUNTER_KEY + id, count);
+		}
+	}
+
+	/**
+	 * Atomically increments the window counter by {@code delta}.
+	 *
+	 * @param id    caller context id
+	 * @param delta value to add to the counter
+	 * @return new global counter value after the increment
+	 */
+	public static long incrWindowCounter(String id, long delta, long expiryTime) {
+		String key = ThrottleConstants.THROTTLE_WINDOW_HASH_KEY + id;
+		DistributedCounterManager distributedCounterManager =
+				ThrottleServiceDataHolder.getInstance().getDistributedCounterManager();
+		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
+			return distributedCounterManager.incrWindowCounter(key, delta, expiryTime);
+		} else {
+			String counterKey = ThrottleConstants.THROTTLE_SHARED_COUNTER_KEY + id;
+			long[] result = {0L};
+			counters.compute(counterKey, (k, v) -> {
+				result[0] = ((v != null) ? v : 0L) + delta;
+				return result[0];
+			});
+			return result[0];
+		}
+	}
+
+	/**
+	 * Tries to acquire the per-caller window lock without blocking.
+	 * Returns {@code true} if the lock was acquired, {@code false} if another node holds it.
+	 * The lock TTL is set to {@code expiryTime} (absolute window boundary) so it auto-expires
+	 * when the window ends, even if the holder crashes mid-tick.
+	 *
+	 * @param id         caller context id
+	 * @param expiryTime absolute window-end timestamp in ms (localFAT + unitTime)
+	 * @return true if this node acquired the lock
+	 */
+	public static boolean tryWindowLock(String id, long expiryTime) {
+		DistributedCounterManager distributedCounterManager =
+				ThrottleServiceDataHolder.getInstance().getDistributedCounterManager();
+		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
+			String lockKey = ThrottleConstants.THROTTLE_WINDOW_LOCK_KEY + id;
+			return distributedCounterManager.setLockWithExpiry(lockKey, "1", expiryTime);
+		}
+		return true;  // Single-JVM: no cluster contention, always proceed.
+	}
+
+	/**
+	 * Releases the per-caller window lock acquired by {@link #tryWindowLock}.
+	 * Should be called in a {@code finally} block after lock-protected Redis work completes.
+	 *
+	 * @param id caller context id
+	 */
+	public static void releaseWindowLock(String id) {
+		DistributedCounterManager distributedCounterManager =
+				ThrottleServiceDataHolder.getInstance().getDistributedCounterManager();
+		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
+			String lockKey = ThrottleConstants.THROTTLE_WINDOW_LOCK_KEY + id;
+			distributedCounterManager.removeLock(lockKey);
+		}
+	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/SharedParamManager.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/SharedParamManager.java
@@ -123,10 +123,8 @@ public class SharedParamManager {
 		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
 			return distributedCounterManager.addAndGetCounter(id, value);
 		} else {
-			long currentCount = counters.get(id);
-			long updatedCount = currentCount + value;
-			counters.put(id, updatedCount);
-			return updatedCount;
+			// Atomically increment counter and return new total.
+			return counters.compute(id, (k, v) -> (v == null ? 0L : v) + value);
 		}
 	}
 
@@ -147,13 +145,13 @@ public class SharedParamManager {
 		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
 			return distributedCounterManager.asyncGetAndAddCounter(id, value);
 		} else {
-			Long currentCount = counters.get(id);
-			if(currentCount == null) {
-				currentCount = 0L;
-			}
-			long updatedCount = currentCount + value;
-			counters.put(id, updatedCount);
-			return currentCount;
+			// Atomically increment counter and return old value (before the add).
+			long[] oldValue = {0L};
+			counters.compute(id, (k, v) -> {
+				oldValue[0] = (v == null ? 0L : v);
+				return oldValue[0] + value;
+			});
+			return oldValue[0];
 		}
 	}
 
@@ -171,13 +169,13 @@ public class SharedParamManager {
 		if (distributedCounterManager != null && distributedCounterManager.isEnable()) {
 			return distributedCounterManager.asyncGetAndAlterCounter(id,value);
 		} else {
-			Long currentCount = counters.get(id);
-			if(currentCount == null) {
-				currentCount = 0L;
-			}
-			long updatedCount = currentCount + value;
-			counters.put(id, updatedCount);
-			return currentCount;
+			// Atomically alter counter and return old value (before the alter).
+			long[] oldValue = {0L};
+			counters.compute(id, (k, v) -> {
+				oldValue[0] = (v == null ? 0L : v);
+				return oldValue[0] + value;
+			});
+			return oldValue[0];
 		}
 	}
 

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleConstants.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleConstants.java
@@ -185,6 +185,9 @@ public final class ThrottleConstants {
     public static final String THROTTLING_KEYS_TO_REPLICATE = "throttling.keys.to.replicate";
     public static final String WINDOW_REPLICATOR_POOL_SIZE = "throttlingWindowReplicator.pool.size";
     public static final String WINDOW_REPLICATOR_FREQUENCY = "throttlingWindowReplicator.replication.frequency";
+    public static final String UNIFIED_THROTTLE_REPLICATOR_ENABLED = "throttling.unified_replicator.enable";
+    public static final String THROTTLE_WINDOW_HASH_KEY = "throttle_window:";
+    public static final String THROTTLE_WINDOW_LOCK_KEY = "throttle_window_lock:";
     public static final String DISTRIBUTED_COUNTER_TYPE = "throttling.distributed.counter.type";
     public static final String DISTRIBUTED_COUNTER_CONFIGURATIONS  = "throttling.distributed.counter.configurations.";
     public static final String THROTTLE_SYNC_ASYNC_HYBRID_MODE_ENABLED = "throttling.sync-async_hybrid_mode.enable";

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContext.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContext.java
@@ -43,7 +43,7 @@ public abstract class ThrottleContext {
     /* For mapping id (ip | domainame) to TimeStamp */
     private Map keyToTimeStampMap;
     /* The Time which next cleaning for this throttle will have to take place */
-    private long nextCleanTime;
+    private volatile long nextCleanTime;
     /* The configuration of a throttle */
     private ThrottleConfiguration throttleConfiguration;
     /* The configuration that corresponding to this context – this holds all
@@ -63,6 +63,10 @@ public abstract class ThrottleContext {
 
     private ThrottleWindowReplicator throttleWindowReplicator;
 
+    private UnifiedThrottleReplicator unifiedThrottleReplicator;
+
+    private final boolean unifiedReplicatorEnabled;
+
     /**
      * default constructor – expects a throttle configuration.
      *
@@ -81,6 +85,9 @@ public abstract class ThrottleContext {
         this.throttleConfiguration = throttleConfiguration;
         this.debugOn = log.isDebugEnabled();
         this.throttleWindowReplicator = ThrottleContextFactory.getThrottleWindowReplicatorInstance();
+        this.unifiedThrottleReplicator = ThrottleContextFactory.getUnifiedThrottleReplicatorInstance();
+        this.unifiedReplicatorEnabled = ThrottleServiceDataHolder.getInstance()
+                .getThrottleProperties().isUnifiedThrottleReplicatorEnabled();
         ThrottleContextFactory.getThrottleContextCleanupTaskInstance().addThrottleContext(this);
     }
 
@@ -236,44 +243,56 @@ public abstract class ThrottleContext {
         if (debugOn) {
             log.debug("Cleaning up process is executing");
         }
+        // Double-checked lock: volatile outer check is a cheap fast-path that avoids
+        // monitor acquisition on most calls. The inner lock ensures only one thread
+        // runs the cleanup loop per DEFAULT_THROTTLE_CLEAN_PERIOD (5 minutes).
         if (time > nextCleanTime) {
-            SortedMap map = ((ConcurrentNavigableMap) callersMap).headMap(new Long(time));
-            if (map != null && map.size() > 0) {
-                for (Iterator it = map.values().iterator(); it.hasNext(); ) {
-                    Object o = it.next();
-                    if (o != null) {
-                        if (o instanceof CallerContext) { // In the case nextAccessTime is unique
-                            CallerContext c = ((CallerContext) o);
-                            String key = c.getId();
-                            String role = c.getRoleId();
-                            if (key != null) {
-                                if (dataHolder != null && keyPrefix != null) {
-                                    c = dataHolder.getCallerContext(key);
-                                }
-                                if (c != null) {
-                                    c.cleanUpCallers(
-                                            this.throttleConfiguration.getCallerConfiguration(role)
-                                            , this
-                                            , time);
+            synchronized (this) {
+                if (time <= nextCleanTime) {
+                    return;
+                }
+                nextCleanTime = time + ThrottleConstants.DEFAULT_THROTTLE_CLEAN_PERIOD;
+            }
+            boolean cleanupCompleted = false;
+            try {
+                SortedMap map = ((ConcurrentNavigableMap) callersMap).headMap(new Long(time));
+                if (map != null && map.size() > 0) {
+                    for (Iterator it = map.values().iterator(); it.hasNext(); ) {
+                        Object o = it.next();
+                        if (o != null) {
+                            if (o instanceof CallerContext) { // In the case nextAccessTime is unique
+                                CallerContext c = ((CallerContext) o);
+                                String key = c.getId();
+                                String role = c.getRoleId();
+                                if (key != null) {
+                                    if (dataHolder != null && keyPrefix != null) {
+                                        c = dataHolder.getCallerContext(key);
+                                    }
+                                    if (c != null) {
+                                        c.cleanUpCallers(
+                                                this.throttleConfiguration.getCallerConfiguration(role)
+                                                , this
+                                                , time);
+                                    }
                                 }
                             }
-                        }
-                        if (o instanceof LinkedList) { //In the case nextAccessTime of callers are same
-                            LinkedList callers = (LinkedList) o;
-                            synchronized (callers) {
-                                for (Iterator ite = callers.iterator(); ite.hasNext(); ) {
-                                    CallerContext c = (CallerContext) ite.next();
-                                    String key = c.getId();
-                                    String role = c.getRoleId();
-                                    if (key != null) {
-                                        if (dataHolder != null && keyPrefix != null) {
-                                            c = (CallerContext) dataHolder.getCallerContext(key);
-                                        }
-                                        if (c != null) {
-                                            c.cleanUpCallers(
-                                                    this.throttleConfiguration.getCallerConfiguration(role)
-                                                    , this
-                                                    , time);
+                            if (o instanceof LinkedList) { //In the case nextAccessTime of callers are same
+                                LinkedList callers = (LinkedList) o;
+                                synchronized (callers) {
+                                    for (Iterator ite = callers.iterator(); ite.hasNext(); ) {
+                                        CallerContext c = (CallerContext) ite.next();
+                                        String key = c.getId();
+                                        String role = c.getRoleId();
+                                        if (key != null) {
+                                            if (dataHolder != null && keyPrefix != null) {
+                                                c = (CallerContext) dataHolder.getCallerContext(key);
+                                            }
+                                            if (c != null) {
+                                                c.cleanUpCallers(
+                                                        this.throttleConfiguration.getCallerConfiguration(role)
+                                                        , this
+                                                        , time);
+                                            }
                                         }
                                     }
                                 }
@@ -281,8 +300,18 @@ public abstract class ThrottleContext {
                         }
                     }
                 }
+                cleanupCompleted = true;
+            } finally {
+                if (!cleanupCompleted) {
+                    // Cleanup aborted (exception/error) — roll the claim back so a subsequent
+                    // call retries rather than skipping cleanup for a full clean period.
+                    synchronized (this) {
+                        if (nextCleanTime == time + ThrottleConstants.DEFAULT_THROTTLE_CLEAN_PERIOD) {
+                            nextCleanTime = time;
+                        }
+                    }
+                }
             }
-            nextCleanTime = time + ThrottleConstants.DEFAULT_THROTTLE_CLEAN_PERIOD;
         }
     }
 
@@ -408,8 +437,13 @@ public abstract class ThrottleContext {
                     log.debug("Going to replicate the states of the caller : " + id);
                 }
 
-                throttleReplicator.setConfigContext(configctx);
-                throttleReplicator.add(id);
+                if (unifiedReplicatorEnabled) {
+                    unifiedThrottleReplicator.setConfigContext(configctx);
+                    unifiedThrottleReplicator.add(id);
+                } else {
+                    throttleReplicator.setConfigContext(configctx);
+                    throttleReplicator.add(id);
+                }
 
             } catch (Exception clusteringFault) {
                 log.error("Error during the replicating states ", clusteringFault);
@@ -428,8 +462,13 @@ public abstract class ThrottleContext {
                     log.debug("Going to replicate the time window states of the caller : " + id);
                 }
 
-                throttleWindowReplicator.setConfigContext(configctx);
-                throttleWindowReplicator.add(id);
+                if (unifiedReplicatorEnabled) {
+                    unifiedThrottleReplicator.setConfigContext(configctx);
+                    unifiedThrottleReplicator.add(id);
+                } else {
+                    throttleWindowReplicator.setConfigContext(configctx);
+                    throttleWindowReplicator.add(id);
+                }
 
             } catch (Exception e) {
                 log.error("Error during the replicating window change ", e);

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContextCleanupTask.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleContextCleanupTask.java
@@ -21,8 +21,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.throttle.core.internal.ThrottleServiceDataHolder;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -36,7 +36,7 @@ public class ThrottleContextCleanupTask {
 
 	private static final Log log = LogFactory.getLog(ThrottleContextCleanupTask.class);
 
-	private List<ThrottleContext> throttleContexts = new ArrayList<ThrottleContext>();
+	private List<ThrottleContext> throttleContexts = new CopyOnWriteArrayList<ThrottleContext>();
 
 	public ThrottleContextCleanupTask() {
 

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleProperties.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleProperties.java
@@ -39,6 +39,7 @@ public class ThrottleProperties implements Serializable {
 	private String distributedThrottleProcessorType = "hybrid";
 	private String hybridThrottleProcessorWindowType = "start_time_based";
 	private String localQuotaBufferPercentage = "20";
+	private boolean unifiedThrottleReplicatorEnabled = false;
 
 	public String getWindowReplicatorPoolSize() {
 		return windowReplicatorPoolSize;
@@ -192,5 +193,13 @@ public class ThrottleProperties implements Serializable {
 
 	public String getLocalQuotaBufferPercentage() {
 		return localQuotaBufferPercentage;
+	}
+	
+	public boolean isUnifiedThrottleReplicatorEnabled() {
+		return unifiedThrottleReplicatorEnabled;
+	}
+
+	public void setUnifiedThrottleReplicatorEnabled(boolean unifiedThrottleReplicatorEnabled) {
+		this.unifiedThrottleReplicatorEnabled = unifiedThrottleReplicatorEnabled;
 	}
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleReplicator.java
@@ -50,10 +50,12 @@ public class ThrottleReplicator {
         if (log.isDebugEnabled()) {
             log.debug("Replicator pool size set to " + replicatorPoolSize);
         }
-        if (ThrottleServiceDataHolder.getInstance().getThrottleProperties().isThrottleSyncAsyncHybridModeEnabled()) {
+        if (throttleProperties.isThrottleSyncAsyncHybridModeEnabled()
+                || throttleProperties.isUnifiedThrottleReplicatorEnabled()) {
             if (log.isDebugEnabled()) {
                 log.debug(
-                        "Throttle Sync Async Hybrid Mode is enabled. So throttle replicator task will not be scheduled.");
+                        "Throttle Sync Async Hybrid Mode or Unified Replicator is enabled. So throttle replicator "
+                                + "task will not be scheduled.");
             }
             return;
         }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleUtil.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleUtil.java
@@ -166,6 +166,13 @@ public class ThrottleUtil {
 									Boolean.parseBoolean(throttleSyncAsyncHybridModeEnabled));
 						}
 					}
+					if (key.contains(ThrottleConstants.UNIFIED_THROTTLE_REPLICATOR_ENABLED)) {
+						String unifiedThrottleReplicatorEnabled = properties.getProperty(key);
+						if (StringUtils.isNotEmpty(unifiedThrottleReplicatorEnabled)) {
+							throttleProperties.setUnifiedThrottleReplicatorEnabled(
+									Boolean.parseBoolean(unifiedThrottleReplicatorEnabled));
+						}
+					}
 					if (key.contains(ThrottleConstants.HYBRID_THROTTLE_PROCESSOR_WINDOW_TYPE)) {
 						String hybridThrottleProcessorWindowType = properties.getProperty(key);
 						if (StringUtils.isNotEmpty(hybridThrottleProcessorWindowType)) {

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleWindowReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/ThrottleWindowReplicator.java
@@ -54,10 +54,11 @@ private ThrottleProperties throttleProperties;
 			log.debug("Throttle window replicator pool size set to " + replicatorPoolSize);
 		}
 
-		if (ThrottleServiceDataHolder.getInstance().getThrottleProperties().isThrottleSyncAsyncHybridModeEnabled()) {
+		if (throttleProperties.isThrottleSyncAsyncHybridModeEnabled()
+				|| throttleProperties.isUnifiedThrottleReplicatorEnabled()) {
 			if (log.isDebugEnabled()) {
-				log.debug("Throttle Sync Async Hybrid Mode is enabled. So throttle window replicator task will not be "
-						+ "scheduled.");
+				log.debug("Throttle Sync Async Hybrid Mode or Unified Replicator is enabled. So throttle window "
+						+ "replicator task will not be scheduled.");
 			}
 			return;
 		}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/UnifiedThrottleReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/UnifiedThrottleReplicator.java
@@ -1,0 +1,454 @@
+/*
+*  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 LLC. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.synapse.commons.throttle.core;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.commons.throttle.core.internal.ThrottleServiceDataHolder;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unified throttle window and counter replicator that serializes both window and counter
+ * operations per caller to eliminate race conditions. Coordinates state synchronization across
+ * cluster nodes via Redis while detecting concurrent window resets. No Redis operations are
+ * performed inside synchronization locks. Enable via {@code throttling.unified_replicator.enable=true}.
+ */
+public class UnifiedThrottleReplicator {
+
+    private static final Log log = LogFactory.getLog(UnifiedThrottleReplicator.class);
+
+    private volatile ConfigurationContext configContext;
+    private final ThrottleProperties throttleProperties;
+    private final AtomicInteger replicatorCount = new AtomicInteger(0);
+    private int replicatorPoolSize;
+
+    // workQueue: keys to replicate this tick; inQueue: dedup guard so the same key is
+    // not offered twice by concurrent request threads.
+    private final ConcurrentLinkedQueue<String> workQueue = new ConcurrentLinkedQueue<>();
+    private final Set<String> inQueue = ConcurrentHashMap.newKeySet();
+
+    // processing: per-caller mutex guaranteeing at most one replicator thread works a given
+    // caller at a time. Distinct from inQueue (which only dedups queue entries). Without this,
+    // when throttling.pool.size > 1 two threads can process the same caller concurrently — one
+    // pushing while another runs the lock-free global-counter refresh — which double-counts the
+    // in-flight push (its delta is in Redis but not yet subtracted from localCount) and can
+    // briefly reject a caller that is actually under its limit.
+    private final ConcurrentHashMap<String, Boolean> processing = new ConcurrentHashMap<>();
+
+    public UnifiedThrottleReplicator() {
+        throttleProperties = ThrottleServiceDataHolder.getInstance().getThrottleProperties();
+        replicatorPoolSize = Integer.parseInt(throttleProperties.getThrottlingPoolSize());
+
+        if (!throttleProperties.isUnifiedThrottleReplicatorEnabled()
+                || throttleProperties.isThrottleSyncAsyncHybridModeEnabled()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Unified throttle replicator is not enabled or hybrid mode is active."
+                        + " Scheduler will not be started.");
+            }
+            return;
+        }
+
+        String frequency = throttleProperties.getThrottlingReplicationFrequency();
+        int freq = Integer.parseInt(frequency);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Starting unified throttle replicator: pool=" + replicatorPoolSize
+                    + " frequency=" + freq + "ms");
+        }
+
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(replicatorPoolSize,
+                new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r);
+                        t.setName("Unified Throttle Replicator - " + replicatorCount.getAndIncrement());
+                        return t;
+                    }
+                });
+
+        for (int i = 0; i < replicatorPoolSize; i++) {
+            executor.scheduleAtFixedRate(new ReplicatorTask(), freq, freq, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public void setConfigContext(ConfigurationContext configContext) {
+        if (configContext == null) {
+            throw new IllegalArgumentException("ConfigurationContext must not be null");
+        }
+        if (this.configContext == null) {
+            this.configContext = configContext;
+        }
+    }
+
+    public void add(String key) {
+        if (configContext == null) {
+            throw new IllegalStateException("ConfigurationContext has not been set");
+        }
+        if (inQueue.add(key)) {
+            workQueue.offer(key);
+            if (log.isTraceEnabled()) {
+                log.trace("Enqueued key for replication: " + key);
+            }
+        }
+    }
+
+    private class ReplicatorTask implements Runnable {
+
+        public void run() {
+            if (workQueue.isEmpty()) {
+                return;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Unified throttle replicator tick started. Queue size=" + workQueue.size());
+            }
+
+            String key;
+            while ((key = workQueue.poll()) != null) {
+                // Key is now owned by this thread for this attempt; remove from inQueue so
+                // concurrent add() calls for the same key can re-enqueue it if needed.
+                inQueue.remove(key);
+
+                // Claim exclusive processing of this caller. If another replicator thread already
+                // owns it, drop this (redundant) copy: the owner is already handling the caller's
+                // current state, and any later change will re-enqueue via add(). This serialization
+                // is what prevents a concurrent push and lock-free refresh from double-counting.
+                if (processing.putIfAbsent(key, Boolean.TRUE) != null) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("Caller already being processed by another thread, skipping: " + key);
+                    }
+                    continue;
+                }
+
+                try {
+                    ThrottleDataHolder dataHolder = (ThrottleDataHolder)
+                            configContext.getProperty(ThrottleConstants.THROTTLE_INFO_KEY);
+                    if (dataHolder == null) {
+                        log.warn("ThrottleDataHolder not available for key=" + key
+                                + ". Will retry on next tick.");
+                        continue;
+                    }
+
+                    CallerContext callerContext = dataHolder.getCallerContext(key);
+                    if (callerContext == null) {
+                        continue;
+                    }
+
+                    String id     = callerContext.getId();
+                    long localFAT = callerContext.getFirstAccessTime();
+                    long unitTime = callerContext.getUnitTime();
+                    long currentTime = System.currentTimeMillis();
+
+                    // Skip expired windows — no point syncing stale state.
+                    if (localFAT + unitTime <= currentTime) {
+                        continue;
+                    }
+
+                    // Quick-exit if local counter is zero — avoid Redis lock round-trip.
+                    // Still refresh the cached global counter (lock-free) so a node with
+                    // nothing to push does not freeze on a stale cluster total.
+                    if (callerContext.getLocalCounter() == 0) {
+                        refreshGlobalCounterLockFree(callerContext, id, localFAT, unitTime);
+                        continue;
+                    }
+
+                    // Single-shot Redis lock attempt — no spin. If the lock is held by another
+                    // cluster node, re-queue this key so another replicator thread can retry it
+                    // within the same tick rather than blocking this thread or discarding the key.
+                    boolean lockAcquired = SharedParamManager.tryWindowLock(id, localFAT + unitTime);
+                    if (!lockAcquired) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Could not acquire window lock for callerId=" + id
+                                    + ". Re-queuing for peer thread retry this tick.");
+                        }
+                        // Couldn't push this tick — refresh the cached global counter (lock-free)
+                        // so a node that keeps losing the lock still tracks the cluster total.
+                        refreshGlobalCounterLockFree(callerContext, id, localFAT, unitTime);
+                        requeueThisTick(key);
+                        continue;
+                    }
+
+                    try {
+                        // Verify window is still active and hasn't changed since lock acquisition.
+                        if (callerContext.getFirstAccessTime() != localFAT) { continue; }
+                        if (localFAT + unitTime <= System.currentTimeMillis()) { continue; }
+
+                        // Snapshot local counter under lock. Ensures all code paths use consistent value
+                        // and prevents divergence from concurrent request threads.
+                        long snapshotCounter = callerContext.getLocalCounter();
+                        if (snapshotCounter == 0) {
+                            continue;
+                        }
+
+                        // Read Redis window state (no race while lock is held).
+                        long[] windowState;
+                        try {
+                            windowState = SharedParamManager.getWindowState(id);
+                        } catch (Exception e) {
+                            log.error("Failed to read window state from Redis for key=" + key
+                                    + ". Will retry on next tick.", e);
+                            continue;
+                        }
+                        long sharedTimestamp    = windowState[0];
+                        long distributedCounter = windowState[1];
+                        long sharedNextWindow   = sharedTimestamp + unitTime;
+
+                    // State routing based on Redis window and local window alignment:
+                    // A (no/expired Redis window): sharedTimestamp==0 or expired or local ahead
+                    // B (window desync): sharedTimestamp != localFAT (cluster rolled or FAT drift)
+                    // C (fully synced): sharedTimestamp == localFAT (counters only)
+                    // States A & B handle window creation/alignment; State C pushes counters only.
+
+                    if (sharedTimestamp == 0 || sharedNextWindow <= currentTime || localFAT >= sharedNextWindow) {
+                        // Branch A: No active Redis window. Create it with this node's snapshot.
+                        try {
+                            SharedParamManager.setWindow(id, snapshotCounter, localFAT, localFAT + unitTime);
+                        } catch (Exception e) {
+                            log.error("Failed to set Redis window for key=" + key
+                                    + ". Will retry on next tick.", e);
+                            continue;
+                        }
+
+                        // Commit local state. The synchronized block is the authoritative gate:
+                        // if the window rolled or expired during the setWindow call the check
+                        // fails and counts are left for the next tick. setGlobalCounter atomically
+                        // replaces any stale previous-window value — no pre-call reset needed.
+                        synchronized (id.intern()) {
+                            if (callerContext.getFirstAccessTime() == localFAT
+                                    && localFAT + unitTime > System.currentTimeMillis()) {
+                                callerContext.subtractFromLocalCounterSafe(snapshotCounter);
+                                callerContext.setGlobalCounter(snapshotCounter);
+                            } else {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Window changed or expired while pushing counter"
+                                            + " for key=" + key + ". Local count retained.");
+                                }
+                                continue;
+                            }
+                        }
+                        if (log.isDebugEnabled()) {
+                            log.debug("Replicated callerId=" + id
+                                    + " pushed=" + snapshotCounter + " total=" + snapshotCounter);
+                        }
+
+                    } else if (sharedTimestamp != localFAT) {
+                        // Branch B: Window mismatch — either cluster rolled (State 4) or FAT drift (State 5).
+                        // Both require window realignment; State 4 also resets local counters.
+
+                        synchronized (id.intern()) {
+                            long currentFAT = callerContext.getFirstAccessTime();
+
+                            // Guard: if a concurrent window change occurred between the localFAT
+                            // capture (top of run()) and here, currentFAT != localFAT.  Overwriting
+                            // the newer window's FAT with sharedTimestamp (from an older epoch) would
+                            // set it backwards.  Skip all alignment and let the newer window's own
+                            // replication tick handle it.
+                            if (localFAT != currentFAT) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Concurrent window change detected for callerId=" + id
+                                            + " localFAT=" + localFAT + " currentFAT=" + currentFAT
+                                            + ". Skipping Branch B alignment.");
+                                }
+                                continue;
+                            }
+
+                            // State 4: cluster is in a newer epoch — clear local counts so this
+                            // node does not carry forward stale numbers that would throttle valid requests.
+                            // State 5: FAT drift within the same epoch. This can occur in either direction:
+                            //   sharedTimestamp < localFAT — another node started slightly earlier.
+                            //   sharedTimestamp > localFAT (by a small delta < unitTime) — another node
+                            //     started slightly later. In this sub-case sharedTimestamp > currentFAT
+                            //     is TRUE so the reset fires, discarding counts from the small drift
+                            //     interval. This conservative behaviour is shared with ThrottleWindowReplicator.
+                            if (sharedTimestamp > currentFAT) {
+                                callerContext.resetLocalCounter();
+                                callerContext.resetGlobalCounter();
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Cluster window is newer — resetting local counters for callerId=" + id
+                                            + " currentFAT=" + currentFAT + " sharedTimestamp=" + sharedTimestamp);
+                                }
+                            } else {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("FAT drift within same epoch for callerId=" + id
+                                            + " currentFAT=" + currentFAT + " sharedTimestamp=" + sharedTimestamp);
+                                }
+                            }
+
+                            // localFAT == currentFAT is guaranteed here, so FAT/counter updates are safe.
+                            callerContext.setFirstAccessTime(sharedTimestamp);
+                            callerContext.setNextTimeWindow(sharedNextWindow);
+                            callerContext.setGlobalCounter(distributedCounter);
+                        }
+
+                        // Push remaining local counts. State 4 reset localCounter (~0 after reset); State 5 has counts.
+                        long alignedSnapshot = callerContext.getLocalCounter();
+                        if (alignedSnapshot == 0) {
+                            continue;
+                        }
+
+                        // Verify alignment persists and window is active. Prevents double-increment
+                        // if window changes after alignment but before Redis push.
+                        if (callerContext.getFirstAccessTime() != sharedTimestamp
+                                || sharedNextWindow <= System.currentTimeMillis()) {
+                            continue;
+                        }
+
+                        try {
+                            long newTotal = SharedParamManager.incrWindowCounter(id, alignedSnapshot, sharedNextWindow);
+                            synchronized (id.intern()) {
+                                if (callerContext.getFirstAccessTime() == sharedTimestamp
+                                        && sharedNextWindow > System.currentTimeMillis()) {
+                                    callerContext.subtractFromLocalCounterSafe(alignedSnapshot);
+                                    callerContext.setGlobalCounter(newTotal);
+                                } else {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Window changed or expired while pushing counter"
+                                                + " for key=" + key + ". Local count retained.");
+                                    }
+                                    continue;
+                                }
+                            }
+                            if (log.isDebugEnabled()) {
+                                log.debug("Replicated callerId=" + id
+                                        + " pushed=" + alignedSnapshot + " total=" + newTotal);
+                            }
+                        } catch (Exception e) {
+                            log.error("Failed to push counter for key=" + key
+                                    + ". Local count preserved (" + alignedSnapshot + ").", e);
+                            continue;
+                        }
+
+                    } else {
+                        // Branch C: Windows fully synced — push counter only.
+                        if (log.isDebugEnabled()) {
+                            log.debug("Windows are in sync for callerId=" + id);
+                        }
+
+                        // Verify window hasn't changed since cluster state was read.
+                        if (callerContext.getFirstAccessTime() != localFAT) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Window changed during replication for key=" + key
+                                        + ". Discarding " + snapshotCounter
+                                        + " pending counts. New window will be replicated on next tick.");
+                            }
+                            continue;
+                        }
+                        if (localFAT + unitTime <= System.currentTimeMillis()) {
+                            continue;
+                        }
+
+                        try {
+                            long newTotal = SharedParamManager.incrWindowCounter(id, snapshotCounter, localFAT + unitTime);
+                            synchronized (id.intern()) {
+                                if (callerContext.getFirstAccessTime() == localFAT
+                                        && localFAT + unitTime > System.currentTimeMillis()) {
+                                    callerContext.subtractFromLocalCounterSafe(snapshotCounter);
+                                    callerContext.setGlobalCounter(newTotal);
+                                } else {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Window changed or expired while pushing counter"
+                                                + " for key=" + key + ". Local count retained.");
+                                    }
+                                    continue;
+                                }
+                            }
+                            if (log.isDebugEnabled()) {
+                                log.debug("Replicated callerId=" + id
+                                        + " pushed=" + snapshotCounter + " total=" + newTotal);
+                            }
+                        } catch (Exception e) {
+                            log.error("Failed to push counter for key=" + key
+                                    + ". Local count preserved (" + snapshotCounter + ").", e);
+                            continue;
+                        }
+                    }
+
+                } finally {
+                    // Always release per-caller Redis lock. Failure blocks all cluster nodes for window TTL.
+                    SharedParamManager.releaseWindowLock(id);
+                }
+
+                } catch (Throwable t) {
+                    log.error("Unexpected error during throttle replication for key=" + key
+                            + ". Will retry on next tick.", t);
+                } finally {
+                    // Release the per-caller processing claim on EVERY exit path. A leaked claim
+                    // would permanently block this caller from ever being replicated again.
+                    processing.remove(key);
+                }
+            }
+        }
+        private void requeueThisTick(String key) {
+            if (inQueue.add(key)) {
+                workQueue.offer(key);
+                if (log.isDebugEnabled()) {
+                    log.debug("Re-queued key=" + key + " for lock retry");
+                }
+            }
+        }
+
+        /**
+         * Lock-free refresh of this node's cached global counter from Redis. Decouples the
+         * global-counter read from the lock-gated push so that a node which never wins the
+         * window lock — or has nothing to push — still keeps a fresh view of the cluster
+         * total instead of freezing on the value from its last successful push.
+         *
+         * <p>The Redis value is adopted only if the Redis window timestamp matches this
+         * node's current window — checked both at read time and again under the per-caller
+         * monitor — so a window roll cannot contaminate a freshly started window with the
+         * previous epoch's counter. Best-effort: any Redis hiccup is swallowed and retried
+         * on the next tick.</p>
+         */
+        private void refreshGlobalCounterLockFree(CallerContext callerContext, String id,
+                                                  long localFAT, long unitTime) {
+            try {
+                long[] windowState = SharedParamManager.getWindowState(id);
+                if (windowState[0] != localFAT) {
+                    // Different or absent Redis window — leave realignment to the push path.
+                    return;
+                }
+                synchronized (id.intern()) {
+                    // Re-check the live window under the per-caller monitor: a request thread
+                    // may have rolled the window between the Redis read above and here.
+                    if (callerContext.getFirstAccessTime() == localFAT
+                            && localFAT + unitTime > System.currentTimeMillis()) {
+                        callerContext.setGlobalCounter(windowState[1]);
+                        if (log.isTraceEnabled()) {
+                            log.trace("Lock-free refresh of global counter for callerId=" + id
+                                    + " to " + windowState[1]);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Lock-free global counter refresh failed for callerId=" + id
+                            + "; relying on push-path refresh next tick.", e);
+                }
+            }
+        }
+    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/factory/ThrottleContextFactory.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/factory/ThrottleContextFactory.java
@@ -30,6 +30,7 @@ public class ThrottleContextFactory {
     // Task for replicating CallerContexts.
     private static final ThrottleReplicator throttleReplicator = new ThrottleReplicator();
     private static final ThrottleWindowReplicator throttleWindowReplicator = new ThrottleWindowReplicator();
+    private static final UnifiedThrottleReplicator unifiedThrottleReplicator = new UnifiedThrottleReplicator();
     private static final ThrottleContextCleanupTask throttleContextCleanupTask = new ThrottleContextCleanupTask();
     /**
      * To create a ThrottleContext for the given throttle type
@@ -61,6 +62,16 @@ public class ThrottleContextFactory {
      */
     public static ThrottleWindowReplicator getThrottleWindowReplicatorInstance() {
         return throttleWindowReplicator;
+    }
+
+    /**
+     * Get the unified throttle replicator instance to make sure there is one unified replicator in the
+     * implementation
+     *
+     * @return UnifiedThrottleReplicator instance
+     */
+    public static UnifiedThrottleReplicator getUnifiedThrottleReplicatorInstance() {
+        return unifiedThrottleReplicator;
     }
 
     /**


### PR DESCRIPTION
## Overview

This PR delivers two improvements to the WSO2 Synapse throttle engine:

1. **`UnifiedThrottleReplicator`** — a new opt-in replication mode that serializes both window-reset and counter-push operations per caller.
2. **Concurrency hardening** across the existing throttle path — CAS-based local counter mutations, volatile field promotion, and a double-checked cleanup lock.

---

## 1. Unified Throttle Replicator

### Problem

The existing implementation uses two independent replicators:
- `ThrottleWindowReplicator` — propagates window resets.
- `ThrottleReplicator` — propagates local counter increments.

Because these run on separate threads with no per-caller ordering guarantee, a cluster node can push a stale window reset *after* another node has already advanced the window, silently wiping accumulated counts and briefly allowing traffic beyond the configured limit.

### Solution

`UnifiedThrottleReplicator` is a single scheduled executor that processes **both** window and counter state for a caller in one serialized pass:

| Aspect | Detail |
|---|---|
| **Queue** | `ConcurrentLinkedQueue<String>` work-queue + `ConcurrentHashMap` dedup guard (`inQueue`) so the same caller key is enqueued at most once per tick regardless of how many concurrent request threads hit it. |
| **Per-caller mutex** | A `processing` map ensures at most one replicator thread works a given caller at a time. Without this, with `throttling.pool.size > 1`, two threads could process the same caller concurrently — one pushing the counter delta to Redis while another runs the global-counter refresh — causing a transient double-count that can reject a caller still under its limit. |
| **Window coordination** | Before pushing a counter delta, the replicator reads the current Redis window state (`DistributedCounterManager.getWindowState`). If the Redis timestamp has advanced past the local `firstAccessTime`, the local window is already stale; the replicator resets local state rather than propagating an obsolete delta. |
| **No Redis I/O inside locks** | All distributed store operations happen outside Java `synchronized` blocks to prevent lock contention from inflating replication latency. |
| **Feature flag** | Disabled by default. Enable with `throttling.unified_replicator.enable=true` in `throttle.properties`. Automatically inactive when `throttling.sync_async_hybrid_mode.enable=true`. |

### New / Changed Files

| File | Change |
|---|---|
| `UnifiedThrottleReplicator.java` | **New**|
| `DistributedCounterManager.java` | Added three new default interface methods: `getWindowState`, `setWindow`, `incrWindowCounter` |
| `SharedParamManager.java` | Wired the above methods for the non-Redis (local) fallback path; added `getWindowState` / `setWindow` atomic helpers |
| `ThrottleContext.java` | Injects `UnifiedThrottleReplicator`; routes `replicateState` calls through it when the feature flag is on |
| `ThrottleContextFactory.java` | Added `getUnifiedThrottleReplicatorInstance()` singleton factory method |
| `ThrottleProperties.java` | Added `isUnifiedThrottleReplicatorEnabled` / `setUnifiedThrottleReplicatorEnabled` |
| `ThrottleConstants.java` | Added `UNIFIED_THROTTLE_REPLICATOR_ENABLED`, `THROTTLE_WINDOW_HASH_KEY`, `THROTTLE_WINDOW_LOCK_KEY` |
| `ThrottleUtil.java` | Reads `UNIFIED_THROTTLE_REPLICATOR_ENABLED` property during startup |
| `ThrottleReplicator.java` | Checks `isUnifiedThrottleReplicatorEnabled()` at startup and skips scheduling when the unified replicator is active |
| `ThrottleWindowReplicator.java` | Same — skips scheduling when the unified replicator is active, ensuring both legacy replicators are dormant when the new path is enabled |

### `CallerContext` changes required by `UnifiedThrottleReplicator`

**`volatile` field promotions** — The replicator thread writes these fields outside any lock; request threads read them in `canAccess()`. Without `volatile` the JVM may never flush the replicator's write to main memory, making it invisible to request threads.

| Field | Why |
|---|---|
| `firstAccessTime` | Replicator resets this when it detects a stale window; request threads read it to decide whether a new window has started. A stale read causes a request to count against an already-expired window. |
| `nextTimeWindow` | Replicator writes the next window boundary; request threads read it to check window expiry. |
| `isThrottleParamSyncingModeSync` | Written by the replicator during mode transitions; read by request threads to choose the sync path. A stale read takes the wrong code path. |

**Atomic counter helper** — `subtractFromLocalCounterSafe(long)` added to `CallerContext` and called by `UnifiedThrottleReplicator` to subtract the pushed delta from `localCount` after a successful Redis push, flooring at zero via a CAS loop to avoid a negative local counter.

---

## 2. Concurrency Hardening

These fixes apply regardless of whether the unified replicator is enabled.

### 2a. CAS-guarded local counter increment in `CallerContext.canAccess()`

**Problem:** `localCount` was incremented with a plain `addAndGet` after a `get`-based capacity check, creating a TOCTOU window where multiple threads could simultaneously pass the check and push the count past `maxRequest`.

**Fix:** Replaced with a CAS retry loop that re-reads `globalCount` and `localCount` on each iteration and commits only if `localCount` has not changed since the read — making the check-and-increment atomic:

```java
long requestedCount = eventCount == null ? 1L : eventCount;
do {
    long currentGlobal = this.globalCount.get();
    currentLocal = this.localCount.get();
    if (currentGlobal + currentLocal + requestedCount > maxRequest) {
        break; // capacity exhausted — do not increment
    }
    incremented = this.localCount.compareAndSet(currentLocal, currentLocal + requestedCount);
} while (!incremented);
```

Also added two atomic helpers on `CallerContext` for future use:
- `getAndSetLocalCounter(long)` — atomic swap of `localCount`
- `incrementLocalCounterBy(long)` — unconditional add to `localCount`

### 2b. Cleanup lock reduction (`AccessRateController`, `RoleBasedAccessRateController`, `ThrottleContext`)

These three changes form a single coordinated improvement: move the O(n) cleanup scan out of the controller lock, then replace the safety that lock previously provided with a lighter internal guard inside `ThrottleContext` itself.

**Step 1 — move `processCleanList` outside the controller's `synchronized (lock)`**

Previously `processCleanList` was called inside the `synchronized (lock)` block in both controllers. Every throttled request held the monitor for the full duration of the O(n) caller-map scan, blocking all concurrent threads on the same lock.

```java
// Before
synchronized (lock) {
    if (!caller.canAccess(...)) {
        throttleContext.processCleanList(currentTime);  // O(n) scan inside the lock
        accessInformation.setAccessAllowed(false);
        return accessInformation;
    } else { ... }
}

// After
synchronized (lock) {
    if (!caller.canAccess(...)) {
        accessInformation.setAccessAllowed(false);
    } else { ... }
}  // lock released here — cleanup runs outside
if (!accessInformation.isAccessAllowed()) {
    throttleContext.processCleanList(System.currentTimeMillis());
}
return accessInformation;
```

The monitor is now held only for the lightweight `canAccess` decision, and cleanup runs only on denied requests.

**Step 2 — double-checked lock inside `ThrottleContext.processCleanList`**

With the outer controller lock removed, multiple threads can now call `processCleanList` concurrently. Previously `nextCleanTime` was set at the *end* of the cleanup loop, so two racing threads would both run a full O(n) pass for the same period. The fix claims `nextCleanTime` upfront inside its own `synchronized` block with a double-checked guard:

```java
if (time > nextCleanTime) {           // volatile fast-path (no lock)
    synchronized (this) {
        if (time <= nextCleanTime) return;   // lost the race — bail early
        nextCleanTime = time + DEFAULT_THROTTLE_CLEAN_PERIOD;
    }
    // cleanup loop runs here, lock already released
}
```

A `finally` block rolls `nextCleanTime` back if the cleanup loop throws, so the period is retried rather than silently skipped.

**Step 3 — `volatile nextCleanTime`**

The outer `if (time > nextCleanTime)` fast-path check runs without any lock. Promoting `nextCleanTime` to `volatile` ensures that when one thread commits the new value inside the inner `synchronized` block, it is immediately visible to all other threads on their next fast-path check — making the double-checked lock pattern correct.

### 2c. `ThrottleContextCleanupTask` — thread-safe context list

Replaced `ArrayList<ThrottleContext>` with `CopyOnWriteArrayList<ThrottleContext>`. The cleanup task iterates the list on a background thread while request threads may call `addThrottleContext` concurrently, which is unsafe on `ArrayList`.

### 2d. `SharedParamManager` — atomic counter operations

Replaced `get` + `put` counter patterns with `ConcurrentHashMap.compute`, making increment-and-return and get-old-and-increment both atomic under concurrent access.


### Related issue: 
- https://github.com/wso2/api-manager/issues/5032
- https://github.com/wso2/api-manager/issues/5048