### PR TITLE
Fix GraalJS resource lifecycle in ScriptMediator to prevent heap growth

### DIFF
--- a/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
+++ b/modules/extensions/src/main/java/org/apache/synapse/mediators/bsf/ScriptMediator.java
@@ -335,9 +335,13 @@ public class ScriptMediator extends AbstractMediator {
             if (language.equals(RHINO_JAVA_SCRIPT)) {
                 org.mozilla.javascript.Context.exit();
             }
-            if (language.equals("js") || language.equals(GRAAL_JAVA_SCRIPT)) {
+            if (language.equals(JAVA_SCRIPT) || language.equals(GRAAL_JAVA_SCRIPT)) {
                 if (context != null) {
-                    context.leave();
+                    try {
+                        context.leave();
+                    } finally {
+                        closeQuietly(context);
+                    }
                 }
             }
         }
@@ -386,10 +390,10 @@ public class ScriptMediator extends AbstractMediator {
             }
             obj = invocableScript.invokeFunction(function, scriptArgs.toArray());
         } finally {
-          if(sew != null){
-              // return engine to front of queue or drop if queue is full (i.e. if getNewScriptEngine() spawns a new engine)
-              pool.offer(sew);
-          }
+            if(sew != null){
+                // return engine to front of queue or drop if queue is full (i.e. if getNewScriptEngine() spawns a new engine)
+                pool.offer(sew);
+            }
         }
 
 
@@ -468,15 +472,29 @@ public class ScriptMediator extends AbstractMediator {
         scriptMC = getScriptMessageContext(synCtx, xmlHelper, context);
         processJSONPayload(synCtx, scriptMC);
         Bindings bindings = scriptEngine.createBindings();
-        bindings.put(MC_VAR_NAME, scriptMC);
+        try {
+            bindings.put(MC_VAR_NAME, scriptMC);
 
-        Object response;
-        if (compiledScript != null) {
-            response = compiledScript.eval(bindings);
-        } else {
-            response = scriptEngine.eval(scriptSourceCode, bindings);
+            Object response;
+            if (compiledScript != null) {
+                response = compiledScript.eval(bindings);
+            } else {
+                response = scriptEngine.eval(scriptSourceCode, bindings);
+            }
+            return response;
+        } finally {
+            closeQuietly(bindings);
         }
-        return response;
+    }
+
+    private void closeQuietly(Object closeable) {
+        if (closeable instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) closeable).close();
+            } catch (Exception e) {
+                log.warn("Error while closing script engine resource", e);
+            }
+        }
     }
 
     private void processJSONPayload(MessageContext synCtx, ScriptMessageContext scriptMC) throws ScriptException {

--- a/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/GraalVMJavaScriptMediatorTest.java
+++ b/modules/extensions/src/test/java/org/apache/synapse/mediators/bsf/javascript/GraalVMJavaScriptMediatorTest.java
@@ -23,6 +23,7 @@ import org.apache.axiom.attachments.ByteArrayDataSource;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMText;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -155,5 +156,50 @@ public class GraalVMJavaScriptMediatorTest extends TestCase {
         ScriptMediator mediator = new ScriptMediator("js", INLINE_SCRIPT,null);
         boolean responese = mediator.mediate(mc);
         assertTrue(responese);
+    }
+
+    /**
+     * Verify that persisting a raw GraalJS object across mediators is unsafe once contexts are
+     * properly released after each mediation.
+     */
+    public void testInlineMediatorWithRawJsObjectAcrossMediators() throws Exception {
+        MessageContext mc = TestUtils.getTestContext("<foo/>", null);
+        ScriptMediator producer = new ScriptMediator("js",
+                "mc.setProperty('rawJsObject', { foo: 'bar' }); true;", null);
+        assertTrue(producer.mediate(mc));
+
+        ScriptMediator consumer = new ScriptMediator("js",
+                "var o = mc.getProperty('rawJsObject'); o.foo === 'bar';", null);
+
+        boolean synapseExceptionThrown = false;
+        try {
+            consumer.mediate(mc);
+        } catch (SynapseException e) {
+            synapseExceptionThrown = true;
+        }
+
+        assertTrue("Reading raw JS objects across mediators should fail once contexts are closed",
+                synapseExceptionThrown);
+    }
+
+    /**
+     * Primitives and strings stored via mc.setProperty remain readable in a later script
+     * mediator after Graal contexts are closed.
+     */
+    public void testInlineMediatorWithPrimitivesAcrossMediators() throws Exception {
+        MessageContext mc = TestUtils.getTestContext("<foo/>", null);
+        ScriptMediator producer = new ScriptMediator("js",
+                "mc.setProperty('s', 'hello');\n"
+                        + "mc.setProperty('n', 42);\n"
+                        + "mc.setProperty('b', true);\n"
+                        + "true;", null);
+        assertTrue(producer.mediate(mc));
+
+        ScriptMediator consumer = new ScriptMediator("js",
+                "var s = mc.getProperty('s');\n"
+                        + "var n = mc.getProperty('n');\n"
+                        + "var b = mc.getProperty('b');\n"
+                        + "s === 'hello' && n === 42 && b === true;", null);
+        assertTrue(consumer.mediate(mc));
     }
 }


### PR DESCRIPTION
## Purpose
This PR aims to resolve wso2/product-integrator-mi#4949

A custom `synapse-extensions` build with this change applied no longer reproduces the problem in my validation.

## Goals
Ensure GraalJS resources are released after each mediation so repeated invocations do not lead to heap growth and eventual OOM.

## Approach
The observed leak pattern points to a per-invocation resource lifecycle issue in `ScriptMediator`. The underlying problem is likely deeper in the Graal engine layer and became visible after the Graal version upgrade on the Micro Integrator side (22.3.4 -> 25.0.2). It is also possible that the leak was introduced elsewhere in the `wso2-synapse` stack but I was not able to identify the exact root cause.

The fixes applied:
- `Context.leave()` is still called for GraalJS, but the context is now also closed afterwards.
- Inline script bindings are closed.

## Further enhancements
This fix is intentionally minimal, potential follow-up improvements include sharing a Graal Engine, adding ManagedLifecycle cleanup on undeploy/redeploy, and closing overflow engines when the pool drops them.