### PR TITLE
Make Pipe serialization-completion flags volatile to fix cross-lock visibility race

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/Pipe.java
@@ -96,9 +96,9 @@ public class Pipe {
 
     private BaseConfiguration baseConfig;
 
-    private boolean serializationComplete = false;
+    private volatile boolean serializationComplete = false;
 
-    private boolean rawSerializationComplete = false;
+    private volatile boolean rawSerializationComplete = false;
 
     private boolean hasHttpProducer = true;
 


### PR DESCRIPTION
## Purpose

`serializationComplete` and `rawSerializationComplete` in `Pipe` are written under `synchronized(this)` (or with no lock, in `setRawSerializationComplete`) but read in `consume()` / `consumePostActions()` while the calling thread holds the `ReentrantLock lock`. Because the fields are not `volatile` and the write/read paths use different monitors, the JMM provides no happens-before edge between them. On the content-altering out path (`outputBuffer != null`) the consumer can observe a stale completion flag at the empty-buffer boundary and either complete the response early (truncation) or fail to suspend the encoder (short/spliced body), corrupting responses at ~8 KB IO-buffer multiples under load. The pure-relay path (`outputBuffer == null`) is unaffected because it gates on `producerCompleted`, which is published under the same `lock`.

Resolves wso2/api-manager#5099

## Goals

Close the cross-lock memory-visibility gap on the two serialization-completion flags so the consumer always observes the latest value regardless of which lock the writer held.

## Approach

Mark both `serializationComplete` and `rawSerializationComplete` as `volatile`. This establishes a happens-before edge for every read and write independent of the monitor held, with no change to locking strategy or control flow. Minimal, behavior-preserving fix.

## Release note

Fixed a rare data race on the PassThrough `Pipe` serialization-completion flags that could produce truncated or spliced HTTP responses at IO-buffer boundaries under load.

## Documentation

N/A — internal concurrency fix, no user-facing or API change.

## Training

N/A

## Certification

N/A — no behavioral or API change.

## Automation tests

- Unit tests: N/A — the defect is a timing-dependent memory-visibility race that is not deterministically reproducible in a unit test. The change is a single-keyword, behavior-preserving fix.
- Integration tests: Existing PassThrough transport integration tests continue to apply.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

Field-validated against WSO2 API Manager 2.6.0 (synapse-core 2.1.7-wso2v80) on JDK 8 / Linux. The corruption (~5–10 per million responses, at ~8 KB multiples) disappears when a no-op `<enrich>` mediator forces an in-memory copy, consistent with the diagnosed race on the content-altering path.

## Learning

Diagnosed from production field evidence by correlating truncated/spliced response sizes with IO-buffer multiples, then tracing the lock asymmetry between the flag writers (`synchronized(this)`) and readers (`ReentrantLock`). See wso2/api-manager#5099 for the full analysis.