### PR TITLE
Delay pipe attachment for builder-invoked responses to prevent race condition

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/PassThroughHttpSender.java
@@ -553,8 +553,13 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                 msgContext.setProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED, Boolean.TRUE);
             }
 
-            pipe.attachConsumer(conn);
-            sourceResponse.connect(pipe);
+            boolean delayPipeAttachment = msgContext.isPropertyTrue(PassThroughConstants.MESSAGE_BUILDER_INVOKED)
+                            && !Boolean.TRUE.equals(noEntityBody);
+
+            if (!delayPipeAttachment) {
+                pipe.attachConsumer(conn);
+                sourceResponse.connect(pipe);
+            }
         }
 
         Integer errorCode = (Integer) msgContext.getProperty(PassThroughConstants.ERROR_CODE);
@@ -602,6 +607,8 @@ public class PassThroughHttpSender extends AbstractHandler implements TransportS
                 MessageFormatter formatter = MessageFormatterDecoratorFactory.createMessageFormatterDecorator(msgContext);
                 OMOutputFormat format = PassThroughTransportUtils.getOMOutputFormat(msgContext);
                 setContentType(msgContext, sourceResponse, formatter, format, sourceConfiguration);
+                pipe.attachConsumer(conn);
+                sourceResponse.connect(pipe);
                 try {
                     formatter.writeTo(msgContext, format, out, false);
                 } catch (RemoteException fault) {


### PR DESCRIPTION
## Purpose

Delay pipe attachment for builder-invoked responses to prevent race condition

When multiple chunks are received by the TargetHandler, the target response may read from the pipe and mark consumer output as active. This can trigger the SourceResponse to start writing the response while the worker thread is still executing setContentType() and adding response headers.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4938