### PR TITLE
Fix redundant ThreadingView schedulers (Fixes #4952)

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/jmx/ThreadingView.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/jmx/ThreadingView.java
@@ -87,6 +87,25 @@ public class ThreadingView implements ThreadingViewMBean {
 
     private Queue<Double> runnableShortTermQueue = new LinkedList<Double>();
 
+    private static final Map<String, ThreadingView> viewCache = new java.util.concurrent.ConcurrentHashMap<String, ThreadingView>();
+    private static final Map<String, java.util.concurrent.atomic.AtomicInteger> viewRefCount = new java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicInteger>();
+
+    public static synchronized ThreadingView getInstance(final String threadNamePrefix, boolean periodicLogs, double alertMargin) {
+        ThreadingView view = viewCache.get(threadNamePrefix);
+        if (view == null) {
+            view = new ThreadingView(threadNamePrefix, periodicLogs, alertMargin);
+            viewCache.put(threadNamePrefix, view);
+            viewRefCount.put(threadNamePrefix, new java.util.concurrent.atomic.AtomicInteger(1));
+        } else {
+            viewRefCount.get(threadNamePrefix).incrementAndGet();
+        }
+        return view;
+    }
+
+    public static synchronized ThreadingView getInstance(final String threadNamePrefix) {
+        return getInstance(threadNamePrefix, false, -1);
+    }
+
     public ThreadingView(final String threadNamePrefix) {
         this.threadNamePrefix = threadNamePrefix;
         this.scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
@@ -136,9 +155,16 @@ public class ThreadingView implements ThreadingViewMBean {
             log.debug("Un-registering the Synapse threading view for the thread group: " +
                     threadNamePrefix);
         }
-        MBeanRegistrar.getInstance().unRegisterMBean(SYNAPSE_THREADING_VIEW, threadNamePrefix);
-        if (!scheduler.isShutdown()) {
-            scheduler.shutdownNow();
+        java.util.concurrent.atomic.AtomicInteger count = viewRefCount.get(threadNamePrefix);
+        if (count == null || count.decrementAndGet() <= 0) {
+            MBeanRegistrar.getInstance().unRegisterMBean(SYNAPSE_THREADING_VIEW, threadNamePrefix);
+            if (!scheduler.isShutdown()) {
+                scheduler.shutdownNow();
+            }
+            viewCache.remove(threadNamePrefix);
+            if (count != null) {
+                viewRefCount.remove(threadNamePrefix);
+            }
         }
     }
 

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ClientHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ClientHandler.java
@@ -198,7 +198,7 @@ public class ClientHandler implements NHttpClientEventHandler {
         this.connStrategy = new DefaultConnectionReuseStrategy();
         this.metrics = metrics;
         this.allocator = new HeapByteBufferAllocator();
-        this.threadingView = new ThreadingView("HttpClientWorker", true, 50);
+        this.threadingView = ThreadingView.getInstance("HttpClientWorker", true, 50);
 
         this.cfg = NHttpConfiguration.getInstance();
         workerPool = WorkerPoolFactory.getWorkerPool(

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ServerHandler.java
@@ -156,7 +156,7 @@ public class ServerHandler implements NHttpServerEventHandler {
         boolean enableAdvancedForS2SView = cfg.getBooleanValue("synapse.nhttp.s2slatency_view.enable_advanced_view", false);
         this.latencyView = new LatencyView("NHTTPLatencyView", scheme.isSSL(), strNamePostfix, enableAdvancedForLatencyView);
         this.s2sLatencyView = new LatencyView("NHTTPS2SLatencyView", scheme.isSSL(), strNamePostfix, enableAdvancedForS2SView);
-        this.threadingView = new ThreadingView("HttpServerWorker", true, 50);
+        this.threadingView = ThreadingView.getInstance("HttpServerWorker", true, 50);
 
         if (listenerContext.getExecutor() == null)  {
             this.workerPool = WorkerPoolFactory.getWorkerPool(

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/SourceHandler.java
@@ -132,7 +132,7 @@ public class SourceHandler implements NHttpServerEventHandler {
                                                scheme.isSSL(), strNamePostfix, enableAdvancedForLatencyView);
             this.s2sLatencyView = new LatencyView(PassThroughConstants.PASSTHROUGH_S2SLATENCY_VIEW, scheme.isSSL(),
                                                   strNamePostfix, enableAdvancedForS2SView);
-            this.threadingView = new ThreadingView(PassThroughConstants.PASSTHROUGH_MESSAGE_PROCESSOR, true, 50);
+            this.threadingView = ThreadingView.getInstance(PassThroughConstants.PASSTHROUGH_MESSAGE_PROCESSOR, true, 50);
         }
 
         Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);


### PR DESCRIPTION
## Description
Fixes wso2/micro-integrator#4952.

WSO2 MI starts four PassThrough transport listeners at server startup, each instantiating its own \ThreadingView\ for the \PassThroughMessageProcessor\ thread pool. Since each instance initiates its own background scheduler that executes a full JVM thread dump via \ThreadMXBean.getThreadInfo()\ every 2 seconds, this introduces unnecessary 4x overhead and redundant system alerts.

This PR implements a \ThreadingView.getInstance\ factory method alongside a static caching map and reference counting. It guarantees that only a single scheduler operates per thread group prefix, significantly reducing CPU overhead under load and completely eliminating duplicate logs.

## Approach
- Cached \ThreadingView\ instances internally by \	hreadNamePrefix\.
- Implemented reference counting via \AtomicInteger\ to safely tear down the scheduler when the last listener shuts down.
- Modified \ServerHandler\, \SourceHandler\, and \ClientHandler\ to consume the factory method rather than constructing explicit instances.