### PR TITLE
Suppress Redis connection error log flooding in throttle replicator

### DIFF
--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterException.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterException.java
@@ -1,0 +1,73 @@
+/*
+*  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 LLC. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.synapse.commons.throttle.core;
+
+/**
+ * Unchecked exception thrown by {@link DistributedCounterManager} operations.
+ * Carries a {@link Kind} that classifies the failure so callers can make
+ * fine-grained decisions (retry strategy, log level, alert routing) without
+ * coupling the Synapse layer to any specific backing store or client library.
+ *
+ * <p>The convenience method {@link #isTransient()} derives the transient/permanent
+ * split from {@link Kind}, keeping existing callers compatible.
+ */
+public class DistributedCounterException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Classifies the nature of the distributed-counter failure in
+     * infrastructure-neutral terms.
+     */
+    public enum Kind {
+        /** The remote host is unreachable, the connection was refused or timed out, or the socket was closed. */
+        CONNECTION_FAILURE,
+
+        /** The connection pool is exhausted; no resource became available within the configured wait limit. */
+        POOL_EXHAUSTED,
+
+        /** An atomic transaction returned an unexpected result (null or insufficient responses). */
+        TRANSACTION_ABORT,
+
+        /** The remote store rejected the command or returned a structurally unexpected response. */
+        SERVER_ERROR
+    }
+
+    private final Kind kind;
+
+    public DistributedCounterException(String message, Throwable cause, Kind kind) {
+        super(message, cause);
+        this.kind = kind;
+    }
+
+    /**
+     * Returns the structured failure kind for fine-grained handling.
+     */
+    public Kind getKind() {
+        return kind;
+    }
+
+    /**
+     * Returns {@code true} if this exception represents a transient infrastructure
+     * failure ({@link Kind#CONNECTION_FAILURE} or {@link Kind#POOL_EXHAUSTED}) that
+     * may succeed on retry. Returns {@code false} for permanent errors.
+     */
+    public boolean isTransient() {
+        return kind == Kind.CONNECTION_FAILURE || kind == Kind.POOL_EXHAUSTED;
+    }
+}

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/DistributedCounterManager.java
@@ -141,7 +141,7 @@ public interface DistributedCounterManager {
 
     public long setLock(String key, String value);
 
-    public boolean setLockWithExpiry(String key, String value, long expiryTimeStamp);
+    public boolean setLockWithExpiry(String key, String value, long expiryTimeStamp) throws DistributedCounterException;
 
     public long getKeyLockRetrievalTimeout();
 
@@ -153,7 +153,7 @@ public interface DistributedCounterManager {
      * @param key distributed store key
      * @return long[2]: {timestamp, counter}
      */
-    default long[] getWindowState(String key) {
+    default long[] getWindowState(String key) throws DistributedCounterException {
         throw new UnsupportedOperationException("Not implemented");
     }
 
@@ -167,7 +167,7 @@ public interface DistributedCounterManager {
      * @param ts         window first-access time in milliseconds
      * @param expiryTime absolute expiry timestamp in milliseconds (ts + unitTime)
      */
-    default void setWindow(String key, long count, long ts, long expiryTime) {
+    default void setWindow(String key, long count, long ts, long expiryTime) throws DistributedCounterException {
         throw new UnsupportedOperationException("Not implemented");
     }
 
@@ -182,7 +182,7 @@ public interface DistributedCounterManager {
      * @param expiryTime absolute window-end timestamp in ms (sharedTimestamp + unitTime)
      * @return new global counter value after the increment
      */
-    default long incrWindowCounter(String key, long delta, long expiryTime) {
+    default long incrWindowCounter(String key, long delta, long expiryTime) throws DistributedCounterException {
         throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/UnifiedThrottleReplicator.java
+++ b/modules/commons/src/main/java/org/apache/synapse/commons/throttle/core/UnifiedThrottleReplicator.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Unified throttle window and counter replicator that serializes both window and counter
@@ -59,6 +60,11 @@ public class UnifiedThrottleReplicator {
     // in-flight push (its delta is in Redis but not yet subtracted from localCount) and can
     // briefly reject a caller that is actually under its limit.
     private final ConcurrentHashMap<String, Boolean> processing = new ConcurrentHashMap<>();
+
+    // Log at most one connection-error ERROR per this interval; extras go to DEBUG.
+    private static final long CONNECTION_ERROR_LOG_INTERVAL_MS = 30_000L;
+    private final AtomicLong lastConnectionErrorLogTime = new AtomicLong(0L);
+    private final AtomicLong consecutiveConnectionErrors = new AtomicLong(0L);
 
     public UnifiedThrottleReplicator() {
         throttleProperties = ThrottleServiceDataHolder.getInstance().getThrottleProperties();
@@ -179,7 +185,15 @@ public class UnifiedThrottleReplicator {
                     // Single-shot Redis lock attempt — no spin. If the lock is held by another
                     // cluster node, re-queue this key so another replicator thread can retry it
                     // within the same tick rather than blocking this thread or discarding the key.
-                    boolean lockAcquired = SharedParamManager.tryWindowLock(id, localFAT + unitTime);
+                    boolean lockAcquired = false;
+                    try {
+                        lockAcquired = SharedParamManager.tryWindowLock(id, localFAT + unitTime);
+                        onReplicationSuccess();
+                    } catch (DistributedCounterException e) {
+                        logReplicationError("Failed to acquire window lock for key=" + key
+                                + ". Redis may be unavailable. Will retry on next tick.", e);
+                        continue;  // No lock acquired, no lock to release.
+                    }
                     if (!lockAcquired) {
                         if (log.isDebugEnabled()) {
                             log.debug("Could not acquire window lock for callerId=" + id
@@ -208,8 +222,9 @@ public class UnifiedThrottleReplicator {
                         long[] windowState;
                         try {
                             windowState = SharedParamManager.getWindowState(id);
-                        } catch (Exception e) {
-                            log.error("Failed to read window state from Redis for key=" + key
+                            onReplicationSuccess();
+                        } catch (DistributedCounterException e) {
+                            logReplicationError("Failed to read window state from Redis for key=" + key
                                     + ". Will retry on next tick.", e);
                             continue;
                         }
@@ -227,8 +242,9 @@ public class UnifiedThrottleReplicator {
                         // Branch A: No active Redis window. Create it with this node's snapshot.
                         try {
                             SharedParamManager.setWindow(id, snapshotCounter, localFAT, localFAT + unitTime);
-                        } catch (Exception e) {
-                            log.error("Failed to set Redis window for key=" + key
+                            onReplicationSuccess();
+                        } catch (DistributedCounterException e) {
+                            logReplicationError("Failed to set Redis window for key=" + key
                                     + ". Will retry on next tick.", e);
                             continue;
                         }
@@ -319,6 +335,7 @@ public class UnifiedThrottleReplicator {
 
                         try {
                             long newTotal = SharedParamManager.incrWindowCounter(id, alignedSnapshot, sharedNextWindow);
+                            onReplicationSuccess();
                             synchronized (id.intern()) {
                                 if (callerContext.getFirstAccessTime() == sharedTimestamp
                                         && sharedNextWindow > System.currentTimeMillis()) {
@@ -336,8 +353,8 @@ public class UnifiedThrottleReplicator {
                                 log.debug("Replicated callerId=" + id
                                         + " pushed=" + alignedSnapshot + " total=" + newTotal);
                             }
-                        } catch (Exception e) {
-                            log.error("Failed to push counter for key=" + key
+                        } catch (DistributedCounterException e) {
+                            logReplicationError("Failed to push counter for key=" + key
                                     + ". Local count preserved (" + alignedSnapshot + ").", e);
                             continue;
                         }
@@ -363,6 +380,7 @@ public class UnifiedThrottleReplicator {
 
                         try {
                             long newTotal = SharedParamManager.incrWindowCounter(id, snapshotCounter, localFAT + unitTime);
+                            onReplicationSuccess();
                             synchronized (id.intern()) {
                                 if (callerContext.getFirstAccessTime() == localFAT
                                         && localFAT + unitTime > System.currentTimeMillis()) {
@@ -380,8 +398,8 @@ public class UnifiedThrottleReplicator {
                                 log.debug("Replicated callerId=" + id
                                         + " pushed=" + snapshotCounter + " total=" + newTotal);
                             }
-                        } catch (Exception e) {
-                            log.error("Failed to push counter for key=" + key
+                        } catch (DistributedCounterException e) {
+                            logReplicationError("Failed to push counter for key=" + key
                                     + ". Local count preserved (" + snapshotCounter + ").", e);
                             continue;
                         }
@@ -427,6 +445,7 @@ public class UnifiedThrottleReplicator {
                                                   long localFAT, long unitTime) {
             try {
                 long[] windowState = SharedParamManager.getWindowState(id);
+                onReplicationSuccess();
                 if (windowState[0] != localFAT) {
                     // Different or absent Redis window — leave realignment to the push path.
                     return;
@@ -443,12 +462,44 @@ public class UnifiedThrottleReplicator {
                         }
                     }
                 }
-            } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Lock-free global counter refresh failed for callerId=" + id
-                            + "; relying on push-path refresh next tick.", e);
-                }
+            } catch (DistributedCounterException e) {
+                logReplicationError("Lock-free global counter refresh failed for callerId=" + id
+                        + "; relying on push-path refresh next tick.", e);
             }
+        }
+    }
+    /**
+     * Logs a Redis operation error. Transient connection errors (Redis unreachable, timeout, etc.)
+     * are suppressed after the first ERROR within CONNECTION_ERROR_LOG_INTERVAL_MS to prevent log
+     * flooding during an outage — subsequent connection errors within the interval are dropped
+     * (in DEBUG mode all errors are logged individually without suppression). Non-transient errors
+     * (data faults, programming errors) are always logged at ERROR regardless.
+     */
+    private void logReplicationError(String message, DistributedCounterException e) {
+        if (e.isTransient()) {
+            long count = consecutiveConnectionErrors.incrementAndGet();
+            long now = System.currentTimeMillis();
+            long lastLog = lastConnectionErrorLogTime.get();
+            boolean shouldLog = now - lastLog > CONNECTION_ERROR_LOG_INTERVAL_MS
+                    && lastConnectionErrorLogTime.compareAndSet(lastLog, now);
+            if (log.isDebugEnabled()) {
+                // Debug mode: log every connection error individually without rate-limiting.
+                log.debug(message, e);
+            } else if (shouldLog) {
+                log.error(message + " [Transient connection error; suppressing for "
+                        + CONNECTION_ERROR_LOG_INTERVAL_MS / 1000 + "s, "
+                        + count + " transient errors since last success]", e);
+            }
+        } else {
+            log.error(message, e);
+        }
+    }
+
+    private void onReplicationSuccess() {
+        lastConnectionErrorLogTime.set(0L);
+        long prev = consecutiveConnectionErrors.getAndSet(0L);
+        if (prev > 0) {
+            log.warn("Distributed counter connection restored after " + prev + " consecutive connection errors.");
         }
     }
 }


### PR DESCRIPTION
### Description
This pull request enhances the resilience and clarity of Redis error handling in the distributed throttling logic. The main improvements are the introduction of transient connection error detection, smarter (rate-limited) logging to prevent log flooding during outages, and better separation of connection-level vs. programming/data errors. This should make it easier to monitor Redis connectivity issues without overwhelming logs, while still surfacing important failures.

**Redis connection error handling improvements:**

* Added a new method `isTransientConnectionException(Throwable t)` to the `DistributedCounterManager` interface, allowing implementations to distinguish between transient infrastructure failures (like Redis outages) and other errors.
* Exposed a static `SharedParamManager.isTransientConnectionException(Throwable t)` method that delegates to the active `DistributedCounterManager`, keeping the Synapse layer decoupled from Redis/Jedis specifics.

**Throttling replicator logging enhancements:**

* Updated `UnifiedThrottleReplicator` to track and rate-limit error logs for Redis connection failures, logging at most one ERROR per 30 seconds and demoting subsequent errors to DEBUG to avoid log flooding. Non-connection errors are always logged at ERROR. [[1]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R64-R68) [[2]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R465-R501)
* Refactored Redis operation error handling in `UnifiedThrottleReplicator` to use the new error classification and logging logic across all Redis interactions, ensuring consistent and clear error reporting. [[1]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046L182-R195) [[2]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R224-R227) [[3]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R244-R247) [[4]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R337) [[5]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046L340-R357) [[6]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R382) [[7]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046L384-R402) [[8]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R447) [[9]](diffhunk://#diff-296347ee811e961b9abdba104f76ce98ab506e2d60c443739555b5ba266b5046R465-R501)
* Added logic to track consecutive connection errors and log a warning when Redis connectivity is restored, providing better operational insight.

**Other technical improvements:**

* Imported `AtomicLong` for efficient timestamp tracking in rate-limited logging.

### Related Issue
- https://github.com/wso2/api-manager/issues/5113