### PR TITLE
Fix JMS consumer leak + stuck dequeue on coord-DB latency

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/ScheduledMessageProcessor.java
@@ -38,6 +38,7 @@ import org.apache.synapse.task.TaskDescription;
 import org.apache.synapse.task.TaskManager;
 import org.apache.synapse.task.TaskManagerObserver;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -79,9 +80,11 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 
 	private TaskManager taskManager = null;
 	/**
-	 * Task associated with Message Processor
+	 * All ForwardingService/SamplingService/FailoverForwardingService instances created in start(),
+	 * one per memberCount slot. Used by terminate() to stop ALL workers (not just the last one),
+	 * and by resumeRemotely() to reset each instance's isTerminated flag.
 	 */
-	private Task task;
+	private final List<Task> tasks = new ArrayList<Task>();
 
 	private int memberCount = 1;
 
@@ -167,13 +170,16 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 
     @Override
     public boolean start() {
+		// Reset the per-slot Task list before populating (idempotent under update() start()).
+		tasks.clear();
 		for (int i = 0; i < memberCount; i++) {
 			/*
 			 * Make sure to fetch the task after initializing the message sender
 			 * and consumer properly. Otherwise you may get NullPointer
 			 * exceptions.
 			 */
-			task = this.getTask();
+			Task task = this.getTask();
+			tasks.add(task);
 			TaskDescription taskDescription = new TaskDescription();
 			taskDescription.setName(TASK_PREFIX + name + SYMBOL_UNDERSCORE + i);
 			taskDescription.setTaskGroup(MessageProcessorConstants.SCHEDULED_MESSAGE_PROCESSOR_GROUP);
@@ -442,6 +448,14 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 
     @Override
     public void resumeService() {
+		// Mirror pauseService()->terminate(): clear isTerminated so workers reconnect on resume.
+		for (Task task : tasks) {
+			if (task instanceof ForwardingService) {
+				((ForwardingService) task).resetTerminated();
+			} else if (task instanceof FailoverForwardingService) {
+				((FailoverForwardingService) task).resetTerminated();
+			}
+		}
 		for (int i = 0; i < memberCount; i++) {
 			taskManager.resume(TASK_PREFIX + name + SYMBOL_UNDERSCORE + i);
 		}
@@ -547,6 +561,12 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
     public void cleanupLocalResources() {
         if (messageConsumers != null) {
             for (MessageConsumer messageConsumer : messageConsumers) {
+                // This cleanup is processor teardown. Mark the consumer dead before
+                // closing its resources so a task racing with pause/destroy cannot reconnect from
+                // receive() and leave a new JMS connection outside the processor lifecycle. Broker
+                // failure cleanup inside JmsConsumer.receive() does not set this flag, so that path
+                // can still use its reconnect retry logic. No-op for RabbitMQ.
+                messageConsumer.setAlive(false);
                 messageConsumer.cleanup();
             }
         }
@@ -619,12 +639,17 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
     }
 
 	private void terminate() {
-		if (task instanceof ForwardingService) {
-			((ForwardingService) task).terminate();
-		} else if (task instanceof SamplingService) {
-			((SamplingService) task).terminate();
-		} else if (task instanceof FailoverForwardingService) {
-			((FailoverForwardingService) task).terminate();
+		// Iterate ALL memberCount slots  previously only this.task (the last one
+		// created in start()) was terminated, leaving the other N-1 workers free to reconnect
+		// after cleanupLocalResources() and create orphan consumers.
+		for (Task task : tasks) {
+			if (task instanceof ForwardingService) {
+				((ForwardingService) task).terminate();
+			} else if (task instanceof SamplingService) {
+				((SamplingService) task).terminate();
+			} else if (task instanceof FailoverForwardingService) {
+				((FailoverForwardingService) task).terminate();
+			}
 		}
 	}
 
@@ -650,5 +675,17 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 	@Override
 	public void resumeRemotely() {
 		setMessageProcessorState(ProcessorState.RUNNING);
+		// Reset the per-slot isTerminated flag so the re-init guard (Syn-C, gated on
+		// !isTerminated) allows the next Quartz fire to rebuild a consumer. Same FwdSvc instances
+		// are reused across pause/resume  without this, terminate-all on pause would permanently
+		// brick every slot on resume (line 261's self-reset can't fire without a working consumer).
+		// SamplingService is intentionally skipped  it has no isTerminated state (different design).
+		for (Task task : tasks) {
+			if (task instanceof ForwardingService) {
+				((ForwardingService) task).resetTerminated();
+			} else if (task instanceof FailoverForwardingService) {
+				((FailoverForwardingService) task).resetTerminated();
+			}
+		}
 	}
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/failover/FailoverForwardingService.java
@@ -171,6 +171,34 @@ public class FailoverForwardingService implements Task, ManagedLifecycle {
         boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
         AspectConfiguration aspectConfiguration = messageProcessor.getAspectConfiguration();
 
+        /*
+         * If a previous pauseMessageProcessorTemporarily cycle marked the consumer as not alive,
+         * rebuild it via setMessageConsumerAndProducer() so this fire has a usable fresh JmsConsumer
+         * instance. Without this, the receive() guard in JmsConsumer would short-circuit every fetch
+         * and the task would never dequeue another message until the processor is restarted.
+         */
+        // Refuse to reconnect while this slot is terminated. Pairs with
+        // ScheduledMessageProcessor.terminate() (now terminate-all) on pause and
+        // resumeRemotely() resetTerminated on resume. Same rationale as ForwardingService:237.
+        if (!isTerminated && (messageConsumer == null || !messageConsumer.isAlive())) {
+            try {
+                setMessageConsumerAndProducer();
+            } catch (StoreForwardException | SynapseException e) {
+                // Rebuilding the consumer can fail while the store is unavailable.
+                // With no existing consumer there is nothing useful to do in this fire. If an old
+                // consumer still exists, continue to fetch(): broker-failure cleanup leaves the raw
+                // JMS isAlive flag true, so receive() can reconnect through the normal retry path.
+                // A teardown-marked consumer has the flag set to false and receive() returns null.
+                if (messageConsumer == null) {
+                    log.error("[" + messageProcessor.getName()
+                            + "] Failed to initialise message consumer; message store unavailable.", e);
+                    return;
+                }
+                log.warn("[" + messageProcessor.getName()
+                        + "] Message store unavailable while re-initialising consumer; "
+                        + "will attempt reconnect via the fetch loop.");
+            }
+        }
         do {
             resetService();
             MessageContext messageContext = null;
@@ -495,6 +523,16 @@ public class FailoverForwardingService implements Task, ManagedLifecycle {
                       messageProcessor.getName() + "]");
             return false;
         }
+    }
+
+    /**
+     * Reset isTerminated so the re-init guard at the top of execute() can rebuild a
+     * consumer on the next Quartz fire. Called by {@code ScheduledMessageProcessor.resumeRemotely()}
+     * on every resume  pairs with the terminate-all set by
+     * {@code ScheduledMessageProcessor.terminate()} on pause.
+     */
+    public void resetTerminated() {
+        isTerminated = false;
     }
 
     /*

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/forwarder/ForwardingService.java
@@ -253,6 +253,32 @@ public class ForwardingService implements Task, ManagedLifecycle {
 		boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
 		AspectConfiguration aspectConfiguration = messageProcessor.getAspectConfiguration();
 
+
+		// Refuse to reconnect while this slot is terminated. During the
+		// pauseAllLocallyRunningTasks cascade, terminate() (now terminate-all per Syn-A) sets
+		// isTerminated=true on every FwdSvc; without this guard, an un-paused worker would re-enter
+		// execute() between cleanupLocalResources() and its own Quartz pauseJob, see the dead
+		// consumer, and call setMessageConsumer() which appends a fresh consumer after cleanup 
+		// the orphan. resumeRemotely() resets isTerminated on resume so this guard re-opens cleanly.
+		if (!isTerminated && (messageConsumer == null || !messageConsumer.isAlive())) {
+			try {
+				setMessageConsumer();
+			} catch (StoreForwardException | SynapseException e) {
+				// Rebuilding the consumer can fail while the store is unavailable.
+				// With no existing consumer there is nothing useful to do in this fire. If an old
+				// consumer still exists, continue to fetch(): broker-failure cleanup leaves the raw
+				// JMS isAlive flag true, so receive() can reconnect through the normal retry path.
+				// A teardown-marked consumer has the flag set to false and receive() returns null.
+				if (messageConsumer == null) {
+					log.error("[" + messageProcessor.getName()
+							+ "] Failed to initialise message consumer; message store unavailable.", e);
+					return;
+				}
+				log.warn("[" + messageProcessor.getName()
+						+ "] Message store unavailable while re-initialising consumer; "
+						+ "will attempt reconnect via the fetch loop.");
+			}
+		}
 		do {
 			resetService();
 			MessageContext messageContext = null;
@@ -975,6 +1001,16 @@ public class ForwardingService implements Task, ManagedLifecycle {
 					+ messageProcessor.getName() + "]");
 			return false;
 		}
+	}
+
+	/**
+	 * Reset isTerminated so the re-init guard at {@link #execute()} can rebuild a
+	 * consumer on the next Quartz fire. Called by {@code ScheduledMessageProcessor.resumeRemotely()}
+	 * via {@code ScheduledTaskManager.scheduleCoordinatedTask} on every resume  pairs with the
+	 * terminate-all set by {@code ScheduledMessageProcessor.terminate()} on pause.
+	 */
+	public void resetTerminated() {
+		isTerminated = false;
 	}
 
 	/*

--- a/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processor/impl/sampler/SamplingService.java
@@ -145,6 +145,32 @@ public class SamplingService implements Task, ManagedLifecycle {
 			boolean isStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
 			AspectConfiguration aspectConfiguration = messageProcessor.getAspectConfiguration();
 
+			/*
+			 * If a previous pauseMessageProcessorTemporarily cycle marked the consumer as not alive,
+			 * rebuild it via setMessageConsumer() so this fire has a usable fresh JmsConsumer instance.
+			 * Without this, the receive() guard in JmsConsumer would short-circuit every fetch and the
+			 * task would never dequeue another message until the processor is restarted.
+			 */
+			if (messageConsumer == null || !messageConsumer.isAlive()) {
+				try {
+					setMessageConsumer();
+				} catch (SynapseException e) {
+					// Rebuilding the consumer can fail while the store is unavailable.
+					// With no existing consumer there is nothing useful to do in this tick. If an old
+					// consumer still exists, continue to fetch(): broker-failure cleanup leaves the raw
+					// JMS isAlive flag true, so receive() can reconnect through the normal retry path.
+					// A teardown-marked consumer has the flag set to false and receive() returns null.
+					if (messageConsumer == null) {
+						log.error("[" + messageProcessor.getName()
+								+ "] Failed to initialise message consumer; message store unavailable.", e);
+						return;
+					}
+					log.warn("[" + messageProcessor.getName()
+							+ "] Message store unavailable while re-initialising consumer; "
+							+ "will attempt reconnect via the fetch loop.");
+				}
+			}
+
 			if (!this.messageProcessor.isDeactivated()) {
 				for (int i = 0; i < concurrency; i++) {
 
@@ -324,6 +350,10 @@ public class SamplingService implements Task, ManagedLifecycle {
 	 */
 	public boolean terminate() {
         if (messageConsumer != null) {
+            // This terminate path is teardown. Mark the current consumer dead before
+            // closing it so a racing sampling execute() cannot reconnect from receive() using this
+            // consumer. A later active execution can create a fresh consumer through setMessageConsumer().
+            messageConsumer.setAlive(false);
             messageConsumer.cleanup();
         }
 		return true;

--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/jms/JmsConsumer.java
@@ -60,7 +60,7 @@ public class JmsConsumer implements MessageConsumer {
     /**
      * Boolean to store if the message processor is alive
      */
-    private boolean isAlive;
+    private volatile boolean isAlive;
 
     /**
      * Constructor for JMS consumer
@@ -149,6 +149,10 @@ public class JmsConsumer implements MessageConsumer {
     }
 
     public boolean cleanup() throws SynapseException {
+        // cleanup() only releases JMS resources and clears the local handles. It must not change
+        // the raw isAlive flag because receive() calls cleanup() after a JMSException and then calls
+        // receive() again; keeping the flag true lets that broker-failure path reconnect. Teardown
+        // callers that must block reconnects call setAlive(false) before cleanup().
         if (logger.isDebugEnabled()) {
             logger.debug(getId() + " cleaning up...");
         }
@@ -169,6 +173,11 @@ public class JmsConsumer implements MessageConsumer {
     public boolean isAlive() {
 
         if (isAlive) {
+            // cleanup() clears the session. The public health check should report that state as not
+            // alive so the processor can rebuild the consumer when needed.
+            if (session == null) {
+                return false;
+            }
             try {
                 session.getAcknowledgeMode(); /** No straight forward way to check session availability */
             } catch (JMSException e) {


### PR DESCRIPTION


## Purpose
When a ScheduledMessageForwardingProcessor task is paused via becameUnresponsive -> pauseMessageProcessorTemporarily -> cleanupLocalResources, the cleanup nulls each JmsConsumer's connection/session/consumer fields but does not flip isAlive. Quartz pauseJob stops future triggers but does not interrupt the in-flight execute() of an already-running instance. That thread proceeds into JmsConsumer.receive(), passes the isAlive guard, and calls checkAndTryConnect() which sees the just-nulled fields and runs reconnect() -> JmsStore.getConsumer() -> a brand-new Connection/Session/MessageConsumer is opened on the broker. The Quartz job is paused immediately after, so this fresh JMS connection becomes orphaned: it is owned by a paused-task's JmsConsumer and nothing closes it. After the next ownership reshuffle, the new owner opens its own consumer too, and the orphaned one remains - producing the ConsumerCount climb above member.count on the broker side. On the resume path the same reused JmsConsumer instance also exhibits a stuck dequeue: the broker biases against the just-reconnected subscriber and receive() returns null indefinitely.

Fix:
- JmsConsumer.cleanup(): set isAlive=false as the first line, atomic with field nulling. Any concurrent receive() arriving after cleanup starts bails at the isAlive guard instead of reconnecting.
- ForwardingService.tryToDispatchToEndpoint(): when messageConsumer is null or no longer alive, rebuild it via setMessageConsumer() before dispatch. This appends a brand-new JmsConsumer instance to the processor's list with a fresh consumerId on the broker side, which the broker treats as a new subscriber without the prior consumer's churn history.

fixes: https://github.com/wso2/product-integrator-mi/issues/4616

Fix ScheduledMessageProcessor fan-out orphan consumers on pause/resume

ScheduledMessageProcessor.start() creates memberCount ForwardingService instances in a loop but overwrites a single `task` field each iteration, so terminate() reaches only the last one. The other N-1 keep isTerminated=false. During pauseAllLocallyRunningTasks, cleanupLocalResources() closes every consumer at once while those un-terminated workers are still live; they re-enter execute(), hit the re-init guard, and reconnect - appending a fresh consumer after the cleanup pass that nothing ever closes. That orphan is the broker ConsumerCount climb above member.count

Fix:
- ScheduledMessageProcessor: track every memberCount ForwardingService in a List; terminate() iterates and stops ALL of them, not just the last.
- ForwardingService / FailoverForwardingService: gate the re-init reconnect guard on !isTerminated, so a terminated worker fired during the pause cascade does not rebuild a consumer.
- ScheduledMessageProcessor.resumeRemotely(): reset isTerminated on every tracked instance, so the next fire after resume reconnects normally (the same instances are reused across pause/resume via the ntask static task map; without this the !isTerminated guard would brick every slot on resume).

Fix JMS consumer cleanup during processor pause recovery

Preserve broker reconnect retries while marking teardown consumers dead to avoid orphan JMS connections.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4616