### PR TITLE
Fix JSON-schema validation for non-JSON payloads in Validate mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -172,8 +172,14 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
             synLog.traceTrace("Message : " + synCtx.getEnvelope());
         }
 
+        StringBuilder schemaKeyBuilder = new StringBuilder();
+        for (Value schemaKey : schemaKeys) {
+            schemaKeyBuilder.append(schemaKey.evaluateValue(synCtx));
+        }
+        String keyStr = schemaKeyBuilder.toString();
+
         org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-        if (JsonUtil.hasAJsonPayload(a2mc) || sourcePath instanceof SynapseJsonPath || isJsonSchema(synCtx)) {
+        if (JsonUtil.hasAJsonPayload(a2mc) || sourcePath instanceof SynapseJsonPath || isJsonSchema(synCtx, keyStr)) {
             ProcessingReport report;
 
 
@@ -863,4 +869,43 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
         return false;
     }
 
+    /**
+    * Inspects the first configured schema key content to determine if it is a JSON Schema.
+    * Includes optimizations to read cache maps first and avoid heavy element serialization.
+    */
+    private boolean isJsonSchema(MessageContext synCtx, String combinedPropertyKey) {
+        if (cachedJsonSchemaMap.containsKey(combinedPropertyKey)) {
+            return true;
+        }
+        if (cachedSchemaMap.containsKey(combinedPropertyKey)) {
+            return false;
+        }
+        if (schemaKeys == null || schemaKeys.isEmpty()) {
+            return false;
+        }
+        try {
+            String propName = schemaKeys.get(0).evaluateValue(synCtx);
+            Object schemaObject = synCtx.getEntry(propName);
+            if (schemaObject != null) {
+                String content = "";
+                if (schemaObject instanceof String) {
+                    content = ((String) schemaObject).trim();
+                } else if (schemaObject instanceof org.apache.axiom.om.OMElement) {
+                    org.apache.axiom.om.OMElement omElement = (org.apache.axiom.om.OMElement) schemaObject;
+                    if ("binary".equals(omElement.getLocalName()) &&
+                        "http://ws.apache.org/commons/ns/payload".equals(omElement.getNamespace().getNamespaceURI())) {
+                        content = omElement.getText().trim();
+                    }
+                } else if (schemaObject instanceof org.apache.axiom.om.OMText) {
+                    content = ((org.apache.axiom.om.OMText) schemaObject).getText().trim();
+                }
+                if (content.startsWith("{") || content.startsWith("[")) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Failed to inspect schema content for JSON detection", e);
+        }
+        return false;
+    }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -173,8 +173,9 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
         }
 
         org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-        if (JsonUtil.hasAJsonPayload(a2mc)) {
+        if (JsonUtil.hasAJsonPayload(a2mc) || sourcePath instanceof SynapseJsonPath || isJsonSchema(synCtx)) {
             ProcessingReport report;
+
 
             // This JsonSchema used if user decide not to cache the schema. In such a situation jsonSchema will not used.
             JsonSchema uncachedJsonSchema = null;
@@ -831,6 +832,35 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
                 StatisticIdentityGenerator.getIdForFlowContinuableMediator(getMediatorName(), ComponentType.MEDIATOR, holder);
         getAspectConfiguration().setUniqueId(mediatorId);
         StatisticIdentityGenerator.reportingFlowContinuableEndEvent(mediatorId, ComponentType.MEDIATOR, holder);
+    }
+
+    /**
+    * Inspects the first configured schema key content to determine if it is a JSON Schema.
+    */
+    private boolean isJsonSchema(MessageContext synCtx) {
+        if (schemaKeys == null || schemaKeys.isEmpty()) {
+            return false;
+        }
+        try {
+            String propName = schemaKeys.get(0).evaluateValue(synCtx);
+            Object schemaObject = synCtx.getEntry(propName);
+            if (schemaObject != null) {
+                String content = "";
+                if (schemaObject instanceof String) {
+                    content = ((String) schemaObject).trim();
+                } else if (schemaObject instanceof org.apache.axiom.om.OMElement) {
+                    content = ((org.apache.axiom.om.OMElement) schemaObject).toString().trim();
+                } else if (schemaObject instanceof org.apache.axiom.om.OMText) {
+                    content = ((org.apache.axiom.om.OMText) schemaObject).getText().trim();
+                }
+                if (content.startsWith("{") || content.startsWith("[")) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // Ignore and fallback
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION


## Purpose
> The Validate mediator currently decides whether to run JSON-schema or XML/XSD validation based solely on the Content-Type of the overall message body. If a message body is not JSON (such as `multipart/form-data` or XML), but the user defines a JSON-path `source` (e.g. `json-eval(...)`) and validates against a JSON schema, the mediator incorrectly routes the validation to the XML/XSD engine. This attempts to load the JSON schema as an XSD, resulting in the error: `Cannot convert object to a StreamSource`.

## Goals
> Allow JSON-schema validation to succeed for non-JSON message payloads when:
1. The `source` attribute is configured with a JSON path expression.
2. The schema being used is a JSON schema.

## Approach
> Updated the routing logic in `ValidateMediator.java`. The check to enter the JSON schema validation block was updated from:
```java
if (JsonUtil.hasAJsonPayload(a2mc))

TO :

if (JsonUtil.hasAJsonPayload(a2mc) || sourcePath instanceof SynapseJsonPath || isJsonSchema(synCtx))

I implemented the isJsonSchema(MessageContext) helper method to inspect the first element of the schemaKeys list. It checks the content of the schema dynamically and returns true if it starts with { or [, ensuring it routes to the JSON validation engine.

## Release note
> Fixed a bug in the Validate mediator where JSON-schema validation failed with Cannot convert object to a StreamSource when the incoming message payload was not JSON.

## Documentation
> N/A - The change aligns the mediator's execution with the existing documented features. No new syntax or mediator configuration attributes are introduced.

## Training
> N/A

## Certification
> N/A 

## Marketing
> N/A 

## Automation tests
 - Unit tests 
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 11
    Windows / Linux