### PR TITLE
Add json-source attribute to ValidateMediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ValidateMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ValidateMediatorFactory.java
@@ -35,7 +35,7 @@ import java.util.*;
  * <p>
  * Configuration syntax:
  * <pre>
- * &lt;validate [source="xpath"] [cache-schema = "true|false"]>
+ * &lt;validate [source="xpath"] [cache-schema = "true|false"] [json-source="true|false"]>
  *   &lt;schema key="string">+
  *   &lt;resource location="&lt;external-schema>" key="string">+
  *   &lt;feature name="&lt;validation-feature-name>" value="true|false"/>
@@ -51,6 +51,7 @@ public class ValidateMediatorFactory extends AbstractListMediatorFactory {
     private static final QName ON_FAIL_Q  = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "on-fail");
     private static final QName SCHEMA_Q   = new QName(XMLConfigConstants.SYNAPSE_NAMESPACE, "schema");
     private static final QName ATT_CACHE_SCHEMA = new QName("cache-schema");
+    private static final QName ATT_JSON_SOURCE = new QName("json-source");
 
     public Mediator createSpecificMediator(OMElement elem, Properties properties) {
 
@@ -109,6 +110,15 @@ public class ValidateMediatorFactory extends AbstractListMediatorFactory {
                 log.debug("Schema cached: " + cacheSchema);
             }
             validateMediator.setCacheSchema(cacheSchema);
+        }
+
+        OMAttribute attIsJSONSource = elem.getAttribute(ATT_JSON_SOURCE);
+        if (attIsJSONSource != null) {
+            final boolean isJsonSource = Boolean.parseBoolean(attIsJSONSource.getAttributeValue());
+            if (log.isDebugEnabled()) {
+                log.debug("isJsonSource: " + isJsonSource);
+            }
+            validateMediator.setIsJSONSource(isJsonSource);
         }
 
         //process external schema resources

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ValidateMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ValidateMediatorSerializer.java
@@ -81,6 +81,10 @@ public class ValidateMediatorSerializer extends AbstractListMediatorSerializer {
                 String.valueOf(mediator.isCacheSchema()));
         validate.addAttribute(cacheSchemaAtt);
 
+        if (mediator.isJSONSource()) {
+            validate.addAttribute(fac.createOMAttribute("json-source", nullNS, "true"));
+        }
+
         serializeComments(validate, mediator.getCommentsList());
 
         return validate;

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/ValidateMediator.java
@@ -152,6 +152,8 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
      */
     private boolean cacheSchema = true;
 
+    private boolean isJSONSource = false;
+
     @SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})
     public boolean mediate(MessageContext synCtx) {
 
@@ -173,7 +175,7 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
         }
 
         org.apache.axis2.context.MessageContext a2mc = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
-        if (JsonUtil.hasAJsonPayload(a2mc)) {
+        if (isJSONSource || JsonUtil.hasAJsonPayload(a2mc)) {
             ProcessingReport report;
 
             // This JsonSchema used if user decide not to cache the schema. In such a situation jsonSchema will not used.
@@ -815,6 +817,16 @@ public class ValidateMediator extends AbstractListMediator implements FlowContin
      */
     public boolean isCacheSchema() {
         return cacheSchema;
+    }
+
+    public void setIsJSONSource(boolean isJSONSourcePath) {
+
+        this.isJSONSource = isJSONSourcePath;
+    }
+
+    public boolean isJSONSource() {
+
+        return isJSONSource;
     }
 
     @Override


### PR DESCRIPTION
## Purpose

Add json-source attribute to ValidateMediator

```xml
<validate source="json-eval($ctx:metadata)" cache-schema="true" json-source="true">
```

ValidateMediator currently validates JSON message bodies, but when the source expression points to a JSON value outside the message body, the mediator falls through to XML validation. The new json-source attribute allows users to explicitly set the source as JSON, enabling schema validation against the given JSON source expression.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4963