### PR TITLE
Correlate HTTP access log request/response entries with a correlation id

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
@@ -273,6 +273,10 @@ public class Access {
         return getParam(message, "http.remote.addr");
     }
 
+    public static String getCorrelationIdElement(HttpMessage message) {
+        return getParam(message, AccessConstants.PARAM_CORRELATION_ID);
+    }
+
     /**
      * AccessLogElement writes the partial message into the buffer.
      */
@@ -325,6 +329,28 @@ public class Access {
             buf.append(remoteHost);
         }
 
+    }
+
+    /**
+     * write the correlation id shared between a request's access log entry and its
+     * corresponding response's entry, since they are otherwise logged independently with
+     * no way to tell which response belongs to which request - %I
+     */
+    protected static class CorrelationIdElement implements AccessLogElement {
+        public void addElement(StringBuilder buf, Date date, HttpRequest request,
+                               HttpResponse response) {
+            String correlationId = "-";
+            try {
+                if (request != null) {
+                    correlationId = getCorrelationIdElement(request);
+                } else if (response != null) {
+                    correlationId = getCorrelationIdElement(response);
+                }
+            } catch (Exception e) {
+                // empty correlation id
+            }
+            buf.append(correlationId);
+        }
     }
 
     /**
@@ -814,6 +840,8 @@ public class Access {
                 return new RefererElement();
             case 'h':
                 return new HostElement();         //%h
+            case 'I':
+                return new CorrelationIdElement();   //%I
             case 'k':
                 return new KeepAliveElement();
             case 'l':

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
@@ -77,6 +77,15 @@ public class AccessConstants {
 
     public static final String CONFIG_ENABLE_LOGGING = "access_log_enable";
 
+    /**
+     * HttpParams key used to carry the transport's correlation id (see
+     * {@code org.apache.synapse.commons.CorrelationConstants#CORRELATION_ID}) into the access
+     * log renderer, so that a request's log line and its corresponding response's log line -
+     * logged independently of one another - can be correlated. HttpParams are local, in-memory
+     * message metadata only and are never written to the wire, matching the existing
+     * "http.remote.addr" parameter used for the same purpose.
+     */
+    public static final String PARAM_CORRELATION_ID = "synapse.access.log.correlation.id";
 
     public static String getLogPattern() {
         return AccessConfiguration.getInstance().getStringProperty(CONFIG_PATTERN, LOG_PATTERN);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectionKey;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
@@ -46,7 +47,10 @@ import org.apache.http.nio.reactor.SessionInputBuffer;
 import org.apache.http.nio.reactor.SessionOutputBuffer;
 import org.apache.http.nio.util.ByteBufferAllocator;
 import org.apache.http.params.HttpParams;
+import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.transport.http.access.AccessConstants;
 import org.apache.synapse.transport.http.access.AccessHandler;
+import org.apache.synapse.transport.passthru.config.PassThroughConfiguration;
 
 public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
         implements UpgradableNHttpConnection {
@@ -78,6 +82,32 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
         if (this.iolog.isDebugEnabled() || this.wirelog.isDebugEnabled() || SynapseDebugInfoHolder.getInstance().isDebuggerEnabled()) {
             super.bind(new LoggingIOSession(session, this.id, this.iolog, this.wirelog));
         }
+    }
+
+    /**
+     * Resolves the correlation id for the given request so the access log's request-line
+     * entry can carry it, generating (and writing back onto the request header, exactly as
+     * {@code SourceHandler#setCorrelationId} does) a new one if the client didn't send one.
+     * <p>
+     * This runs at parse time, before the {@code requestReceived} transport event fires and
+     * {@code SourceHandler#setCorrelationId} resolves the same id for the rest of the request
+     * lifecycle (message context, correlation/trace logs). Resolving it here first - using the
+     * identical header-name lookup - means that by the time {@code SourceHandler} runs, it finds
+     * the header already set and simply reuses this same value, so a single id is used
+     * throughout, and it is also what ties this request's access log line to its response's.
+     *
+     * @param request the just-parsed HTTP request
+     * @return the correlation id to attach to the access log entry
+     */
+    private static String resolveCorrelationId(final HttpRequest request) {
+        String correlationHeaderName = PassThroughConfiguration.getInstance().getCorrelationHeaderName();
+        Header[] correlationHeader = request.getHeaders(correlationHeaderName);
+        if (correlationHeader.length != 0) {
+            return correlationHeader[0].getValue();
+        }
+        String correlationId = UUID.randomUUID().toString();
+        request.setHeader(correlationHeaderName, correlationId);
+        return correlationId;
     }
 
     @Override
@@ -372,6 +402,12 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                     params.setParameter("http.remote.addr",
                             remote.getAddress().getHostAddress());
                 }
+                // SourceHandler#setCorrelationId has already run for this request/response
+                // exchange by the time its response is written, so the id is available here.
+                Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
+                if (correlationId != null) {
+                    params.setParameter(AccessConstants.PARAM_CORRELATION_ID, correlationId.toString());
+                }
 
                 AccessHandler.getAccess().addAccessToQueue(message);
             }
@@ -430,6 +466,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                     params.setParameter("http.remote.addr",
                             remote.getAddress().getHostAddress());
                 }
+                params.setParameter(AccessConstants.PARAM_CORRELATION_ID, resolveCorrelationId(request));
                 AccessHandler.getAccess().addAccessToQueue(message);
             }
 


### PR DESCRIPTION
The PassThrough access log writes a request's entry and its response's entry independently, on separate background threads, with no shared field between them. Under concurrent traffic there is no way to tell which response line belongs to which request line (WSO2-INT-5202).

Adds a new %I pattern element that prints the transport's per-request correlation id (the same one used by correlation/trace logging) on both the request and response log lines, via an HttpParams side-channel - the same local-only mechanism already used to carry http.remote.addr. Opt-in: existing access_log_pattern configs are unaffected until %I is added to the pattern.

$subject