### PR TITLE
Fix PayloadFactoryMediatorSerializer crash on unwrapped XML format

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -20,6 +20,7 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.synapse.Mediator;
@@ -29,6 +30,7 @@ import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
+import java.util.Iterator;
 import java.util.List;
 
 public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer {
@@ -99,9 +101,15 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
                 } else {
                     if (isFreeMarkerTemplate(mediator)) {
                         createCdataTag(mediator, formatElem);
-                    } else {    
-                    formatElem.addChild(AXIOMUtil.stringToOM(mediator.getFormat()));
-                }
+                    } else {
+                        OMElement paddedFormatElem = AXIOMUtil.stringToOM("<pfPadding>" + mediator.getFormat() + "</pfPadding>");
+                        Iterator childIt = paddedFormatElem.getChildren();
+                        while (childIt.hasNext()) {
+                            Object child = childIt.next();
+                            childIt.remove();
+                            formatElem.addChild((OMNode) child);
+                        }
+                    }
                 }
                     payloadFactoryElem.addChild(formatElem);
                 } catch (XMLStreamException e) {


### PR DESCRIPTION
## Purpose
When a `PayloadFactory` mediator's `<format>` (media-type="xml") isn't itself a single well-formed XML fragment - e.g. a bare `$1` placeholder, or an inline expression like `${payload}` with no wrapping element - any Management API call that needs to re-serialize the proxy/API config (e.g. `GET /management/proxy-services?proxyServiceName=...`) crashes with `OMException: WstxUnexpectedCharException` and never returns a response, leaving the client hanging until socket timeout. Actual message mediation is unaffected. Found via a customer support case; no public tracking issue exists yet - will link once filed.

## Goals
Make `PayloadFactoryMediatorSerializer` handle any `<format>` content that mediates correctly at runtime, without requiring it to also be a standalone well-formed XML document - matching the leniency the runtime engine already provides - while returning a proper error instead of hanging if serialization genuinely fails.

## Approach
`serializeSpecificMediator()` currently calls `AXIOMUtil.stringToOM(mediator.getFormat())` directly on the raw, un-substituted format text. A bare `$1` fails this because a document can't start with `$`. The fix wraps the raw text in a temporary `<pfPadding>` root before parsing, then unwraps it - taking `<pfPadding>`'s children and attaching those directly to the `<format>` element - so the final serialized output is unchanged for anything that already worked, and no longer throws for previously-unwrapped content.

This isn't a new technique: `RegexTemplateProcessor` (the runtime template engine) already pads with `<pfPadding>` before parsing for exactly this reason, and this same serializer already has a separate `createCdataTag()` fallback for FreeMarker templates that don't parse as XML either. This change brings the default (non-FreeMarker) XML branch in line with both existing precedents.

Validated locally: decompiled the affected class, patched it, recompiled, and swapped it into a running MI instance (via patched jar) to confirm the crash is resolved and previously-working configs serialize identically (byte-for-byte round-trip on `<format><test>$1</test></format>`).

## User stories
As an integration developer using PayloadFactory with an unwrapped placeholder format, I want Management API calls (or any tooling that reads proxy/API config, e.g. the VS Code MI extension) against my service to succeed instead of hanging, without having to change my mediation logic.

## Release note
Fixed an issue where Management API requests (and other config-serialization paths) would hang/crash for a proxy or API containing a `PayloadFactory` mediator whose `media-type="xml"` format wasn't itself a well-formed XML fragment (e.g. a bare `$1` or inline expression placeholder).

## Automation tests
- **Integration tests**
  Manually verified end-to-end against running MI instances: deployed a proxy with `<format>$1</format>`, confirmed runtime mediation (`curl` to the proxy) is unaffected before and after the patch, and confirmed the Management API call that previously hung now returns a valid `200 OK` with the original format text preserved exactly in the returned config.

## Test environment
- WSO2 MI 4.4.0
- WSO2 MI 4.6.0 (latest available update)
- OS: macOS (Darwin, arm64)