### PR TITLE
Add v2 HTTP access logging with time-taken and correlation ID support

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
@@ -55,6 +55,17 @@ public class Access {
 
     private static LinkedBlockingQueue<HttpRequestWrapper> requestQueue;
     private static LinkedBlockingQueue<HttpResponseWrapper> responseQueue;
+    private static LinkedBlockingQueue<RequestResponsePair> combinedQueue;
+
+    public static class RequestResponsePair {
+        final HttpRequestWrapper request;
+        final HttpResponseWrapper response;
+
+        RequestResponsePair(HttpRequestWrapper req, HttpResponseWrapper res) {
+            this.request = req;
+            this.response = res;
+        }
+    }
 
     private Date date;
 
@@ -70,6 +81,7 @@ public class Access {
         Access.accessLogger = accessLogger;
         requestQueue = new LinkedBlockingQueue<HttpRequestWrapper>();
         responseQueue = new LinkedBlockingQueue<HttpResponseWrapper>();
+        combinedQueue = new LinkedBlockingQueue<RequestResponsePair>();
         logElements = createLogElements();
         logAccesses();
     }
@@ -99,13 +111,56 @@ public class Access {
     }
 
     /**
+     * Adds a correlated request+response pair to the combined queue for single-line logging.
+     *
+     * @param request  - HttpRequest
+     * @param response - HttpResponse
+     */
+    public void addCombinedAccessToQueue(HttpRequest request, HttpResponse response) {
+        HttpRequestWrapper requestWrapper = new HttpRequestWrapper();
+        requestWrapper.setHttpRequest(request);
+        Object reqTimeMs = request.getParams().getParameter("http.request.time.ms");
+        if (reqTimeMs instanceof Long) {
+            requestWrapper.setDate(new Date((Long) reqTimeMs));
+        } else {
+            requestWrapper.setDate(new Date(AccessTimeUtil.getDate().getTime()));
+        }
+
+        HttpResponseWrapper responseWrapper = null;
+        if (response != null) {
+            long responseTimeMs = System.currentTimeMillis();
+            response.getParams().setParameter("http.response.time.ms", responseTimeMs);
+            responseWrapper = new HttpResponseWrapper();
+            responseWrapper.setHttpResponse(response);
+            responseWrapper.setDate(new Date(responseTimeMs));
+        }
+
+        combinedQueue.add(new RequestResponsePair(requestWrapper, responseWrapper));
+    }
+
+    /**
      * logs the request and response accesses.
      */
     public void logAccesses() {
         Thread logRequests = new LogRequests();
         Thread logResponses = new LogResponses();
+        Thread logCombined = new LogCombined();
         logRequests.start();
         logResponses.start();
+        logCombined.start();
+    }
+
+    private class LogCombined extends Thread {
+        public void run() {
+            while (true) {
+                try {
+                    RequestResponsePair pair = combinedQueue.take();
+                    logCombined(pair.request, pair.response);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 
     private class LogRequests extends Thread {
@@ -155,6 +210,26 @@ public class Access {
         log.debug(logString);      //log to the console
         if (accessLogger.isLoggingEnabled) {
             accessLogger.log(logString);      //log to the file
+        }
+    }
+
+    /**
+     * Logs request and response as a single combined log line.
+     *
+     * @param request  - HttpRequestWrapper
+     * @param response - HttpResponseWrapper
+     */
+    public void logCombined(HttpRequestWrapper request, HttpResponseWrapper response) {
+        Date actualDateOfOperation = request.getDate();
+        StringBuilder result = new StringBuilder(128);
+        HttpResponse httpResponse = response != null ? response.getHttpResponse() : null;
+        for (AccessLogElement logElement : logElements) {
+            logElement.addElement(result, actualDateOfOperation, request.getHttpRequest(), httpResponse);
+        }
+        String logString = result.toString();
+        accesslog.info(logString);
+        if (accessLogger.isLoggingEnabled) {
+            accessLogger.log(logString);
         }
     }
 
@@ -667,6 +742,43 @@ public class Access {
     }
 
     /**
+     * write the correlation ID - %I
+     */
+    protected static class CorrelationIdElement implements AccessLogElement {
+        public void addElement(StringBuilder buf, Date date, HttpRequest request,
+                               HttpResponse response) {
+            if (request != null) {
+                Object correlationId = request.getParams().getParameter(
+                        org.apache.synapse.commons.CorrelationConstants.CORRELATION_ID);
+                buf.append(correlationId != null ? correlationId : "-");
+            } else {
+                buf.append('-');
+            }
+        }
+    }
+
+    /**
+     * write time taken to process the request in milliseconds - %D
+     * Only meaningful in combined mode where both request and response are available.
+     */
+    protected static class TimeTakenElement implements AccessLogElement {
+        public void addElement(StringBuilder buf, Date date, HttpRequest request,
+                               HttpResponse response) {
+            if (request != null && response != null) {
+                Object reqTimeMs = request.getParams().getParameter("http.request.time.ms");
+                Object resTimeMs = response.getParams().getParameter("http.response.time.ms");
+                if (reqTimeMs instanceof Long && resTimeMs instanceof Long) {
+                    buf.append((Long) resTimeMs - (Long) reqTimeMs);
+                } else {
+                    buf.append('-');
+                }
+            } else {
+                buf.append('-');
+            }
+        }
+    }
+
+    /**
      * write a specific response header - %{xxx}o
      */
     protected static class ResponseHeaderElement implements AccessLogElement {
@@ -798,6 +910,8 @@ public class Access {
                 return new LocalAddrElement();
             case 'a':
                 return new UserAgentElement();
+            case 'D':
+                return new TimeTakenElement();
             case 'b':
                 return new ByteSentElement(true);     //%b
             case 'B':
@@ -814,6 +928,8 @@ public class Access {
                 return new RefererElement();
             case 'h':
                 return new HostElement();         //%h
+            case 'I':
+                return new CorrelationIdElement();
             case 'k':
                 return new KeepAliveElement();
             case 'l':

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/Access.java
@@ -18,7 +18,9 @@
  */
 package org.apache.synapse.transport.http.access;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.HttpMessage;
@@ -41,6 +43,8 @@ import java.util.concurrent.LinkedBlockingQueue;
  * org.apache.catalina.valves.AccessLogValve with thanks.
  */
 public class Access {
+
+    private static final String THREAD_HTTP_ACCESS_LOG_V2 = "http-access-log-v2";
     private static Log log = LogFactory.getLog(Access.class);
     private final Log accesslog = LogFactory.getLog(LoggingUtils.ACCESS_LOG_ID);
 
@@ -81,7 +85,7 @@ public class Access {
         Access.accessLogger = accessLogger;
         requestQueue = new LinkedBlockingQueue<HttpRequestWrapper>();
         responseQueue = new LinkedBlockingQueue<HttpResponseWrapper>();
-        combinedQueue = new LinkedBlockingQueue<RequestResponsePair>();
+        combinedQueue = new LinkedBlockingQueue<RequestResponsePair>(AccessConstants.getV2QueueSize());
         logElements = createLogElements();
         logAccesses();
     }
@@ -119,23 +123,21 @@ public class Access {
     public void addCombinedAccessToQueue(HttpRequest request, HttpResponse response) {
         HttpRequestWrapper requestWrapper = new HttpRequestWrapper();
         requestWrapper.setHttpRequest(request);
-        Object reqTimeMs = request.getParams().getParameter("http.request.time.ms");
-        if (reqTimeMs instanceof Long) {
-            requestWrapper.setDate(new Date((Long) reqTimeMs));
-        } else {
-            requestWrapper.setDate(new Date(AccessTimeUtil.getDate().getTime()));
-        }
+        requestWrapper.setDate(new Date((Long) request.getParams().getParameter(AccessConstants.HTTP_REQUEST_TIME_MS)));
 
         HttpResponseWrapper responseWrapper = null;
         if (response != null) {
             long responseTimeMs = System.currentTimeMillis();
-            response.getParams().setParameter("http.response.time.ms", responseTimeMs);
+            response.getParams().setParameter(AccessConstants.HTTP_RESPONSE_TIME_MS, responseTimeMs);
             responseWrapper = new HttpResponseWrapper();
             responseWrapper.setHttpResponse(response);
             responseWrapper.setDate(new Date(responseTimeMs));
         }
 
-        combinedQueue.add(new RequestResponsePair(requestWrapper, responseWrapper));
+        if (!combinedQueue.offer(new RequestResponsePair(requestWrapper, responseWrapper))) {
+            Object correlationId = request.getParams().getParameter(CorrelationConstants.CORRELATION_ID);
+            log.warn("Combined access log queue is full, dropping entry. correlation_id=" + correlationId);
+        }
     }
 
     /**
@@ -144,10 +146,13 @@ public class Access {
     public void logAccesses() {
         Thread logRequests = new LogRequests();
         Thread logResponses = new LogResponses();
-        Thread logCombined = new LogCombined();
         logRequests.start();
         logResponses.start();
-        logCombined.start();
+        if (AccessConstants.isV2LoggingEnabled()) {
+            Thread logCombined = new LogCombined();
+            logCombined.setName(THREAD_HTTP_ACCESS_LOG_V2);
+            logCombined.start();
+        }
     }
 
     private class LogCombined extends Thread {
@@ -742,15 +747,16 @@ public class Access {
     }
 
     /**
-     * write the correlation ID - %I
+     * write the correlation ID - %X
      */
     protected static class CorrelationIdElement implements AccessLogElement {
         public void addElement(StringBuilder buf, Date date, HttpRequest request,
                                HttpResponse response) {
             if (request != null) {
                 Object correlationId = request.getParams().getParameter(
-                        org.apache.synapse.commons.CorrelationConstants.CORRELATION_ID);
-                buf.append(correlationId != null ? correlationId : "-");
+                        CorrelationConstants.CORRELATION_ID);
+                String corrId = correlationId != null ? correlationId.toString() : null;
+                buf.append(StringUtils.isNotBlank(corrId) ? corrId : "-");
             } else {
                 buf.append('-');
             }
@@ -765,8 +771,8 @@ public class Access {
         public void addElement(StringBuilder buf, Date date, HttpRequest request,
                                HttpResponse response) {
             if (request != null && response != null) {
-                Object reqTimeMs = request.getParams().getParameter("http.request.time.ms");
-                Object resTimeMs = response.getParams().getParameter("http.response.time.ms");
+                Object reqTimeMs = request.getParams().getParameter(AccessConstants.HTTP_REQUEST_TIME_MS);
+                Object resTimeMs = response.getParams().getParameter(AccessConstants.HTTP_RESPONSE_TIME_MS);
                 if (reqTimeMs instanceof Long && resTimeMs instanceof Long) {
                     buf.append((Long) resTimeMs - (Long) reqTimeMs);
                 } else {
@@ -928,7 +934,7 @@ public class Access {
                 return new RefererElement();
             case 'h':
                 return new HostElement();         //%h
-            case 'I':
+            case 'X':
                 return new CorrelationIdElement();
             case 'k':
                 return new KeepAliveElement();

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
@@ -18,10 +18,15 @@
  */
 package org.apache.synapse.transport.http.access;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**
  * Constants used in the Access Class
  */
 public class AccessConstants {
+
+    private static final Log log = LogFactory.getLog(AccessConstants.class);
 
     /**
      * Pattern used to log - Default is COMBINED_PATTERN given below.
@@ -44,6 +49,8 @@ public class AccessConstants {
     public static final String MONTHS[] =
             {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
              "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    public static final String HTTP_REQUEST_TIME_MS = "http.request.time.ms";
+    public static final String HTTP_RESPONSE_TIME_MS = "http.response.time.ms";
 
     /**
      * The directory in which log files are created.
@@ -77,8 +84,14 @@ public class AccessConstants {
 
     public static final String CONFIG_ENABLE_LOGGING = "access_log_enable";
 
-    public static final String CONFIG_V2_LOGGING = "access_log_v2";
+    private static final String CONFIG_V2_LOGGING = "access_log_v2";
 
+    private static final String CONFIG_V2_QUEUE_SIZE = "access_log_v2_queue_size";
+
+    private static final int DEFAULT_V2_QUEUE_SIZE = 2000;
+
+    private static final boolean V2_LOGGING_ENABLED =
+            AccessConfiguration.getInstance().getBooleanProperty(CONFIG_V2_LOGGING, Boolean.FALSE);
 
     public static String getLogPattern() {
         return AccessConfiguration.getInstance().getStringProperty(CONFIG_PATTERN, LOG_PATTERN);
@@ -101,7 +114,17 @@ public class AccessConstants {
     }
 
     public static boolean isV2LoggingEnabled() {
-        return AccessConfiguration.getInstance().getBooleanProperty(CONFIG_V2_LOGGING, Boolean.FALSE);
+        return V2_LOGGING_ENABLED;
+    }
+
+    public static int getV2QueueSize() {
+        int size = AccessConfiguration.getInstance().getIntProperty(CONFIG_V2_QUEUE_SIZE, DEFAULT_V2_QUEUE_SIZE);
+        if (size <= 0) {
+            log.warn("Invalid value for " + CONFIG_V2_QUEUE_SIZE + ": " + size +
+                    ". Using default value: " + DEFAULT_V2_QUEUE_SIZE);
+            return DEFAULT_V2_QUEUE_SIZE;
+        }
+        return size;
     }
 
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/access/AccessConstants.java
@@ -77,6 +77,8 @@ public class AccessConstants {
 
     public static final String CONFIG_ENABLE_LOGGING = "access_log_enable";
 
+    public static final String CONFIG_V2_LOGGING = "access_log_v2";
+
 
     public static String getLogPattern() {
         return AccessConfiguration.getInstance().getStringProperty(CONFIG_PATTERN, LOG_PATTERN);
@@ -96,6 +98,10 @@ public class AccessConstants {
 
     public static String getDirectory() {
         return AccessConfiguration.getInstance().getStringProperty(CONFIG_DIRECTORY, DIRECTORY);
+    }
+
+    public static boolean isV2LoggingEnabled() {
+        return AccessConfiguration.getInstance().getBooleanProperty(CONFIG_V2_LOGGING, Boolean.FALSE);
     }
 
 }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseFactory;
+import org.apache.http.HttpStatus;
 import org.apache.http.impl.nio.DefaultNHttpClientConnection;
 import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.nio.NHttpClientEventHandler;
@@ -389,7 +390,7 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
             if (message != null && accesslog.isInfoEnabled()) {
                 HttpRequest request = (HttpRequest) message;
                 HttpParams params = request.getParams();
-                params.setParameter("http.request.time.ms", System.currentTimeMillis());
+                params.setParameter(AccessConstants.HTTP_REQUEST_TIME_MS, System.currentTimeMillis());
 
                 final SocketAddress remoteAddress = session.getRemoteAddress();
                 if (remoteAddress instanceof InetSocketAddress) {
@@ -466,9 +467,11 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
                 }
 
                 if (AccessConstants.isV2LoggingEnabled()) {
-                    HttpRequest request = pendingAccessLogRequest.getAndSet(null);
-                    if (request != null) {
-                        AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
+                    if (response.getStatusLine().getStatusCode() >= HttpStatus.SC_OK) {
+                        HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+                        if (request != null) {
+                            AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
+                        }
                     }
                 } else {
                     AccessHandler.getAccess().addAccessToQueue(message);

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpClientConnection.java
@@ -38,6 +38,8 @@ import org.apache.http.nio.reactor.SessionOutputBuffer;
 import org.apache.http.nio.util.ByteBufferAllocator;
 import org.apache.http.params.HttpParams;
 import org.apache.synapse.commons.util.MiscellaneousUtil;
+import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.transport.http.access.AccessConstants;
 import org.apache.synapse.transport.http.access.AccessHandler;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.TargetHandler;
@@ -49,6 +51,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectionKey;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
@@ -69,6 +72,7 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
     private static final Properties props = MiscellaneousUtil.loadProperties(PROPERTY_FILE);
     private static final boolean REPLAY_TXN_ENABLED = Boolean.parseBoolean(
             MiscellaneousUtil.getProperty(props, PassThroughConstants.REPLAY_TXN_ENABLED_KEY, "false"));
+    private final AtomicReference<HttpRequest> pendingAccessLogRequest = new AtomicReference<>();
 
     public LoggingNHttpClientConnection(
             final IOSession session,
@@ -96,6 +100,7 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
         if (this.log.isDebugEnabled()) {
             this.log.debug(this.id + ": Close connection");
         }
+        logPendingRequestOnConnectionEnd();
         super.close();
     }
 
@@ -104,7 +109,15 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
         if (this.log.isDebugEnabled()) {
             this.log.debug(this.id + ": Shutdown connection");
         }
+        logPendingRequestOnConnectionEnd();
         super.shutdown();
+    }
+
+    private void logPendingRequestOnConnectionEnd() {
+        HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+        if (request != null) {
+            AccessHandler.getAccess().addCombinedAccessToQueue(request, null);
+        }
     }
 
     @Override
@@ -376,6 +389,7 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
             if (message != null && accesslog.isInfoEnabled()) {
                 HttpRequest request = (HttpRequest) message;
                 HttpParams params = request.getParams();
+                params.setParameter("http.request.time.ms", System.currentTimeMillis());
 
                 final SocketAddress remoteAddress = session.getRemoteAddress();
                 if (remoteAddress instanceof InetSocketAddress) {
@@ -384,7 +398,16 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
                             remote.getAddress().getHostAddress());
                 }
 
-                AccessHandler.getAccess().addAccessToQueue(message);
+                Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
+                if (correlationId != null) {
+                    params.setParameter(CorrelationConstants.CORRELATION_ID, correlationId.toString());
+                }
+
+                if (AccessConstants.isV2LoggingEnabled()) {
+                    pendingAccessLogRequest.set(request);
+                } else {
+                    AccessHandler.getAccess().addAccessToQueue(message);
+                }
             }
             this.writer.write(message);
         }
@@ -442,7 +465,14 @@ public class LoggingNHttpClientConnection extends DefaultNHttpClientConnection
                             remote.getAddress().getHostAddress());
                 }
 
-                AccessHandler.getAccess().addAccessToQueue(message);
+                if (AccessConstants.isV2LoggingEnabled()) {
+                    HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+                    if (request != null) {
+                        AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
+                    }
+                } else {
+                    AccessHandler.getAccess().addAccessToQueue(message);
+                }
             }
             return message;
         }

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
@@ -36,6 +36,7 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestFactory;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.impl.nio.DefaultNHttpServerConnection;
 import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.nio.NHttpMessageParser;
@@ -391,19 +392,21 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                 }
 
                 if (AccessConstants.isV2LoggingEnabled()) {
-                    HttpRequest request = pendingAccessLogRequest.getAndSet(null);
-                    if (request != null) {
-                        HttpParams reqParams = request.getParams();
-                        if (remoteAddress instanceof InetSocketAddress) {
-                            final InetSocketAddress remote = ((InetSocketAddress) remoteAddress);
-                            reqParams.setParameter("http.remote.addr",
-                                    remote.getAddress().getHostAddress());
+                    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CONTINUE) {
+                        HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+                        if (request != null) {
+                            HttpParams reqParams = request.getParams();
+                            if (remoteAddress instanceof InetSocketAddress) {
+                                final InetSocketAddress remote = ((InetSocketAddress) remoteAddress);
+                                reqParams.setParameter("http.remote.addr",
+                                        remote.getAddress().getHostAddress());
+                            }
+                            Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
+                            if (correlationId != null) {
+                                reqParams.setParameter(CorrelationConstants.CORRELATION_ID, correlationId.toString());
+                            }
+                            AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
                         }
-                        Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
-                        if (correlationId != null) {
-                            reqParams.setParameter(CorrelationConstants.CORRELATION_ID, correlationId.toString());
-                        }
-                        AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
                     }
                 } else {
                     AccessHandler.getAccess().addAccessToQueue(message);
@@ -457,7 +460,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
             if (message != null && accesslog.isInfoEnabled()) {
                 HttpRequest request = (HttpRequest) message;
                 HttpParams params = request.getParams();
-                params.setParameter("http.request.time.ms", System.currentTimeMillis());
+                params.setParameter(AccessConstants.HTTP_REQUEST_TIME_MS, System.currentTimeMillis());
 
                 final SocketAddress remoteAddress = session.getRemoteAddress();
                 if (remoteAddress instanceof InetSocketAddress) {

--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/http/conn/LoggingNHttpServerConnection.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectionKey;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
@@ -46,6 +47,8 @@ import org.apache.http.nio.reactor.SessionInputBuffer;
 import org.apache.http.nio.reactor.SessionOutputBuffer;
 import org.apache.http.nio.util.ByteBufferAllocator;
 import org.apache.http.params.HttpParams;
+import org.apache.synapse.commons.CorrelationConstants;
+import org.apache.synapse.transport.http.access.AccessConstants;
 import org.apache.synapse.transport.http.access.AccessHandler;
 
 public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
@@ -61,6 +64,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
     private final String id;
 
     private IOSession original;
+    private final AtomicReference<HttpRequest> pendingAccessLogRequest = new AtomicReference<>();
 
     public LoggingNHttpServerConnection(
             final IOSession session,
@@ -85,6 +89,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
         if (this.log.isDebugEnabled()) {
             this.log.debug(this.id + ": Close connection");
         }
+        logPendingRequestOnConnectionEnd();
         super.close();
     }
 
@@ -93,7 +98,19 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
         if (this.log.isDebugEnabled()) {
             this.log.debug(this.id + ": Shutdown connection");
         }
+        logPendingRequestOnConnectionEnd();
         super.shutdown();
+    }
+
+    private void logPendingRequestOnConnectionEnd() {
+        HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+        if (request != null) {
+            Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
+            if (correlationId != null) {
+                request.getParams().setParameter(CorrelationConstants.CORRELATION_ID, correlationId.toString());
+            }
+            AccessHandler.getAccess().addCombinedAccessToQueue(request, null);
+        }
     }
 
     @Override
@@ -373,7 +390,24 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                             remote.getAddress().getHostAddress());
                 }
 
-                AccessHandler.getAccess().addAccessToQueue(message);
+                if (AccessConstants.isV2LoggingEnabled()) {
+                    HttpRequest request = pendingAccessLogRequest.getAndSet(null);
+                    if (request != null) {
+                        HttpParams reqParams = request.getParams();
+                        if (remoteAddress instanceof InetSocketAddress) {
+                            final InetSocketAddress remote = ((InetSocketAddress) remoteAddress);
+                            reqParams.setParameter("http.remote.addr",
+                                    remote.getAddress().getHostAddress());
+                        }
+                        Object correlationId = getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
+                        if (correlationId != null) {
+                            reqParams.setParameter(CorrelationConstants.CORRELATION_ID, correlationId.toString());
+                        }
+                        AccessHandler.getAccess().addCombinedAccessToQueue(request, response);
+                    }
+                } else {
+                    AccessHandler.getAccess().addAccessToQueue(message);
+                }
             }
 
             this.writer.write(message);
@@ -423,6 +457,7 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
             if (message != null && accesslog.isInfoEnabled()) {
                 HttpRequest request = (HttpRequest) message;
                 HttpParams params = request.getParams();
+                params.setParameter("http.request.time.ms", System.currentTimeMillis());
 
                 final SocketAddress remoteAddress = session.getRemoteAddress();
                 if (remoteAddress instanceof InetSocketAddress) {
@@ -430,7 +465,11 @@ public class LoggingNHttpServerConnection extends DefaultNHttpServerConnection
                     params.setParameter("http.remote.addr",
                             remote.getAddress().getHostAddress());
                 }
-                AccessHandler.getAccess().addAccessToQueue(message);
+                if (AccessConstants.isV2LoggingEnabled()) {
+                    pendingAccessLogRequest.set(request);
+                } else {
+                    AccessHandler.getAccess().addAccessToQueue(message);
+                }
             }
 
             return message;


### PR DESCRIPTION
## Purpose

Introduce v2 access log mode (access_log_v2=true) that emits a single log line per request-response pair, with time-taken in milliseconds(%D) and correlation ID(%X) pattern elements.

Fixes: Fixes: https://github.com/wso2/product-integrator-mi/issues/5004