### PR TITLE
Fix PayloadFactoryMediatorSerializer crash on unwrapped XML format

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -90,8 +90,7 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
         if(!mediator.isFormatDynamic()){
             if (mediator.getFormat() != null) {
 
-                try {
-                    OMElement formatElem = fac.createOMElement(FORMAT, synNS);
+                OMElement formatElem = fac.createOMElement(FORMAT, synNS);
                 String type = mediator.getType();
                 if(type!=null && (type.contains(JSON_TYPE) || type.contains(TEXT))) {
                     if (isFreeMarkerTemplate(mediator)) {
@@ -107,22 +106,20 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
                             // Pad with a temporary root so non-XML formats (e.g. "$1") still parse.
                             OMElement paddedFormatElem = AXIOMUtil.stringToOM(
                                     "<pfPadding>" + mediator.getFormat() + "</pfPadding>");
-                            Iterator childIt = paddedFormatElem.getChildren();
+                            Iterator<?> childIt = paddedFormatElem.getChildren();
                             while (childIt.hasNext()) {
                                 OMNode child = (OMNode) childIt.next();
                                 childIt.remove();
                                 formatElem.addChild(child);
                             }
-                        } catch (OMException e) {
+                        } catch (OMException | XMLStreamException e) {
                             // Still not parseable even padded - fall back to plain text.
+                            log.warn("PayloadFactory format could not be parsed - falling back to plain text: ", e);
                             formatElem.setText(mediator.getFormat());
                         }
                     }
                 }
-                    payloadFactoryElem.addChild(formatElem);
-                } catch (XMLStreamException e) {
-                    handleException("Error while serializing payloadFactory mediator", e);
-                }
+                payloadFactoryElem.addChild(formatElem);
             } else {
                 handleException("Invalid payloadFactory mediator, format is required");
             }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializer.java
@@ -20,6 +20,8 @@
 package org.apache.synapse.config.xml;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMException;
+import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.impl.llom.OMTextImpl;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.synapse.Mediator;
@@ -29,6 +31,7 @@ import org.apache.synapse.mediators.transform.PayloadFactoryMediator;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
+import java.util.Iterator;
 import java.util.List;
 
 public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer {
@@ -99,9 +102,22 @@ public class PayloadFactoryMediatorSerializer extends AbstractMediatorSerializer
                 } else {
                     if (isFreeMarkerTemplate(mediator)) {
                         createCdataTag(mediator, formatElem);
-                    } else {    
-                    formatElem.addChild(AXIOMUtil.stringToOM(mediator.getFormat()));
-                }
+                    } else {
+                        try {
+                            // Pad with a temporary root so non-XML formats (e.g. "$1") still parse.
+                            OMElement paddedFormatElem = AXIOMUtil.stringToOM(
+                                    "<pfPadding>" + mediator.getFormat() + "</pfPadding>");
+                            Iterator childIt = paddedFormatElem.getChildren();
+                            while (childIt.hasNext()) {
+                                OMNode child = (OMNode) childIt.next();
+                                childIt.remove();
+                                formatElem.addChild(child);
+                            }
+                        } catch (OMException e) {
+                            // Still not parseable even padded - fall back to plain text.
+                            formatElem.setText(mediator.getFormat());
+                        }
+                    }
                 }
                     payloadFactoryElem.addChild(formatElem);
                 } catch (XMLStreamException e) {

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializerTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/PayloadFactoryMediatorSerializerTest.java
@@ -134,5 +134,25 @@ public class PayloadFactoryMediatorSerializerTest {
         );
     }
 
+    /**
+     * Test SerializeSpecificMediator method with a bare, unwrapped placeholder format (e.g. "$1",
+     * with no surrounding XML element) and assert that serialization succeeds (instead of
+     * throwing, as the raw format is not itself well-formed XML) and the format round-trips
+     * correctly.
+     */
+    @Test
+    public void testSerializeSpecificMediator6() {
+        PayloadFactoryMediatorSerializer serializer = new PayloadFactoryMediatorSerializer();
+        PayloadFactoryMediator payloadFactoryMediator = new PayloadFactoryMediator();
+        payloadFactoryMediator.setTemplateProcessor(new RegexTemplateProcessor());
+        payloadFactoryMediator.setFormat("$1");
+        OMElement element = serializer.serializeSpecificMediator(payloadFactoryMediator);
+        Assert.assertNotNull(element);
+        MediatorFactory mediatorFactory = new PayloadFactoryMediatorFactory();
+        Mediator mediator = mediatorFactory.createMediator(element, null);
+        Assert.assertEquals("Bare placeholder format is not serialized correctly", "$1",
+                ((PayloadFactoryMediator) mediator).getFormat());
+    }
+
 }
 


### PR DESCRIPTION
Pad the raw format in a temporary root before parsing, so formats that aren't themselves well-formed XML (e.g. a bare "$1" or "${expr}" placeholder) no longer crash the Management API's config serializer.
Fall back to plain text if the padded content still doesn't parse.

Fixes: https://github.com/wso2/product-integrator-mi/issues/5018