### PR TITLE
Fix passthru config test failures caused by singleton test order dependency

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/config/PassThroughConfiguration.java
@@ -92,6 +92,16 @@ public class PassThroughConfiguration {
         return _instance;
     }
 
+    /**
+     * Reloads properties from "passthru-http.properties", picking up the current CONF_LOCATION.
+     */
+    public void reload() {
+        props = loadProperties("passthru-http.properties");
+        isKeepAliveDisabled = null;
+        isTLSGracefulConnectionTerminationEnabled = null;
+        passThroughDefaultServiceName = null;
+    }
+
     public int getWorkerPoolCoreSize() {
         return ConfigurationBuilderUtil.getIntProperty(PassThroughConfigPNames.WORKER_POOL_SIZE_CORE,
                 DEFAULT_WORKER_POOL_SIZE_CORE, props);
@@ -328,8 +338,8 @@ public class PassThroughConfiguration {
              }
          }
          if (in != null) {
-             try {
-                 properties.load(in);
+             try (InputStream inputStream = in) {
+                 properties.load(inputStream);
              } catch (IOException e) {
                  String msg = "Error loading properties from a file at : " + filePath;
                  log.error(msg, e);

--- a/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/util/PassThroughTestUtils.java
+++ b/modules/transports/core/nhttp/src/test/java/org/apache/synapse/transport/passthru/util/PassThroughTestUtils.java
@@ -42,7 +42,10 @@ public class PassThroughTestUtils {
     public static PassThroughConfiguration getPassThroughConfiguration() {
         String testConfLocation = System.getProperty("user.dir") + PASSTHROUGH_RESOURCE_PATH;
         System.setProperty(PassThroughConstants.CONF_LOCATION, testConfLocation);
-        return PassThroughConfiguration.getInstance();
+        // Force a reload since the singleton may already be initialized by another test.
+        PassThroughConfiguration configuration = PassThroughConfiguration.getInstance();
+        configuration.reload();
+        return configuration;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Fixes failing tests in the Apache Synapse Non-blocking HTTP/s Transport module that started failing on Jenkins after the build moved to the US data center. 

### Root cause

`PassThroughConfiguration` is a singleton that loads `passthru-http.properties` only once, the first time it's used. Test setup relies on setting a system property (`CONF_LOCATION`) right before that first use to point it at the test config file. But some other tests use this singleton too, and if one of them runs first, the properties get loaded before the test config location is set, so the singleton is stuck with default values for the rest of the run, breaking the tests above.

This test ordering isn't fixed, and it depends on the OS/filesystem the build runs on. Moving to a new build agent (the US data center) changed that ordering, which is why previously-passing tests started failing.

### Fix

- Added `PassThroughConfiguration.reload()` to re-read the properties file on demand.
- `PassThroughTestUtils.getPassThroughConfiguration()` now calls `reload()` after setting `CONF_LOCATION`, so the test configuration is always applied regardless of what already touched the singleton first.

