### PR TITLE
Apply mediator access control to the class resolved by the class mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ClassMediatorFactory.java
@@ -117,6 +117,13 @@ public class ClassMediatorFactory extends AbstractMediatorFactory {
             }
         }
 
+        // Enforce mediator access control against the class actually resolved, before it is
+        // instantiated. Instantiation runs static initialisers and the constructor, so a class
+        // that is not permitted must never reach newInstance(). Applying the check here covers
+        // every resolution path above (Synapse library loader, dynamic class mediator loaders and
+        // the default class loader).
+        MediatorAccessControl.checkByClass(clazz);
+
         try {
             mediator = (Mediator) clazz.newInstance();
             if (mediator instanceof AbstractMediator && FactoryUtils.isVersionedDeployment(properties)) {

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
@@ -22,9 +22,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.config.SynapsePropertiesLoader;
 
+import javax.xml.namespace.QName;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -67,7 +70,33 @@ public final class MediatorAccessControl {
         }
     }
 
+    /** Namespace of the Synapse mediator implementations that the name fallback covers. */
+    private static final String SYNAPSE_MEDIATOR_PACKAGE = "org.apache.synapse.mediators.";
+
     private static MediatorAccessControlConfig config = MediatorAccessControlConfig.NONE;
+
+    /**
+     * Resolves a mediator implementation class to the XML element it is registered under.
+     *
+     * Two lookups are held. byClassName is keyed on the fully qualified class name each mediator
+     * serializer declares through getMediatorClassName(), which is authoritative - the serializer
+     * names the implementation class directly rather than it being inferred. bySimpleName is a
+     * fallback for the few registered mediators that have a factory but no serializer, and is keyed
+     * on the implementation name derived from the factory class name.
+     */
+    private static final class MediatorElementIndex {
+
+        final Map<String, String> byClassName;
+        final Map<String, String> bySimpleName;
+
+        MediatorElementIndex(Map<String, String> byClassName, Map<String, String> bySimpleName) {
+            this.byClassName = byClassName;
+            this.bySimpleName = bySimpleName;
+        }
+    }
+
+    /** Built lazily and invalidated by init(), so a MediatorFactoryFinder.reset() is picked up. */
+    private static volatile MediatorElementIndex elementIndex = null;
 
     private MediatorAccessControl() {
     }
@@ -114,6 +143,66 @@ public final class MediatorAccessControl {
         } else {
             config = MediatorAccessControlConfig.NONE;
         }
+
+        // Drop any index built against a previous factory registry.
+        elementIndex = null;
+    }
+
+    /**
+     * Checks whether the class named by a &lt;class&gt; element may be used.
+     *
+     * The class mediator resolves an arbitrary fully qualified class name, so without this check
+     * the configured policy is applied to the surface element only: a mediator excluded from the
+     * access control list stays reachable by naming its implementation class through an allowed
+     * &lt;class&gt; element. This applies the decision already configured for the element that the
+     * implementation is registered under, so &lt;transaction/&gt; and
+     * &lt;class name="...TransactionMediator"/&gt; resolve identically.
+     *
+     * Only implementations that back a registered mediator element are considered. Classes with no
+     * registered element - customer mediators, and the gateway mediators that API Manager itself
+     * invokes through &lt;class&gt; - are unaffected, because the mediator access control list never
+     * governed them.
+     *
+     * MUST be called after the class is resolved but BEFORE it is instantiated: constructing a
+     * class runs its static initialisers and constructor.
+     *
+     * @param resolved the class named by the &lt;class&gt; element
+     * @throws MediatorAccessControlException if the implementation backs an element that is not permitted
+     */
+    public static void checkByClass(Class<?> resolved) {
+
+        MediatorAccessControlConfig mediatorAccessControlConfig = config;
+        if (resolved == null || AccessControlListType.NONE == mediatorAccessControlConfig.listType) {
+            return;
+        }
+
+        MediatorElementIndex index = getElementIndex();
+        String elementName = index.byClassName.get(resolved.getName());
+
+        if (elementName == null && resolved.getName().startsWith(SYNAPSE_MEDIATOR_PACKAGE)) {
+            // Mediators that have a factory but no serializer cannot be matched by class name, so
+            // they fall back to the name derived from the factory. Restricted to Synapse's own
+            // mediator package, since a name derived from a factory is not an identity: without the
+            // restriction a customer class that happened to share the name would inherit a decision
+            // meant for the Synapse implementation.
+            elementName = index.bySimpleName.get(resolved.getSimpleName().toLowerCase(Locale.ROOT));
+        }
+
+        if (elementName == null) {
+            // Not the implementation of any registered mediator element.
+            return;
+        }
+
+        if (isBlocked(mediatorAccessControlConfig, elementName.toLowerCase(Locale.ROOT))) {
+            String msg = "Mediator implementation '" + resolved.getName()
+                    + "' is registered under the mediator element '" + elementName
+                    + "', which is not permitted by mediator access control. It cannot be reached "
+                    + "through a class mediator either.";
+            // Logged at WARN because the aggregated error raised by the caller reports only the
+            // element name, which is indistinguishable from a direct element rejection.
+            log.warn(msg);
+            throw new MediatorAccessControlException(msg, elementName);
+        }
     }
 
     /**
@@ -157,6 +246,118 @@ public final class MediatorAccessControl {
                 throw new MediatorAccessControlException(msg, displayName);
             }
         }
+    }
+
+    /**
+    * Evaluates the configured allowlist or blocklist without throwing.
+    *
+    * @param mediatorAccessControlConfig the current access control configuration
+    * @param normalizedName the mediator element name, lowercased
+    * @return true if the name is not permitted
+    */
+    private static boolean isBlocked(MediatorAccessControlConfig mediatorAccessControlConfig,
+                                     String normalizedName) {
+
+        if (AccessControlListType.BLOCK_LIST == mediatorAccessControlConfig.listType) {
+            return mediatorAccessControlConfig.mediators.contains(normalizedName);
+        } else if (AccessControlListType.ALLOW_LIST == mediatorAccessControlConfig.listType) {
+            return !mediatorAccessControlConfig.mediators.contains(normalizedName);
+        }
+        return false;
+    }
+
+    /**
+    * Builds the implementation to element index by joining the two registries Synapse already
+    * maintains.
+    *
+    * MediatorFactoryFinder maps an element QName to its factory class, giving the element name.
+    * MediatorSerializerFinder maps a fully qualified implementation class name - declared by each
+    * serializer through getMediatorClassName() - to that serializer, giving the implementation
+    * class. The two are joined on the stem shared by a mediator's factory and serializer class
+    * names, for example TransactionMediatorFactory and TransactionMediatorSerializer both reducing
+    * to "TransactionMediator".
+    *
+    * Taking the class from the serializer rather than inferring it from the factory name matters
+    * where a mediator does not follow the naming convention: ThrowErrorMediatorSerializer declares
+    * org.apache.synapse.mediators.v2.ThrowError, which no derivation from
+    * ThrowErrorMediatorFactory would produce. It also keys the result on the fully qualified name,
+    * so a customer class cannot inherit a decision by sharing a simple name.
+    *
+    * A mediator that has a factory but no serializer cannot be resolved this way and is recorded in
+    * the fallback map under the name derived from its factory.
+    *
+    * @return the index, never null
+    */
+    private static MediatorElementIndex getElementIndex() {
+
+        MediatorElementIndex existing = elementIndex;
+        if (existing != null) {
+            return existing;
+        }
+
+        Map<String, String> byClassName = new HashMap<>();
+        Map<String, String> bySimpleName = new HashMap<>();
+        try {
+            // stem -> implementation class name, from the serializers
+            Map<String, String> stemToClassName = new HashMap<>();
+            for (Map.Entry<String, MediatorSerializer> entry :
+                    MediatorSerializerFinder.getInstance().getSerializerMap().entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) {
+                    continue;
+                }
+                String stem = stripSuffix(entry.getValue().getClass().getSimpleName(), "Serializer");
+                if (stem != null) {
+                    stemToClassName.put(stem, entry.getKey());
+                }
+            }
+
+            // stem -> element name, from the factories
+            for (Map.Entry<QName, Class> entry :
+                    MediatorFactoryFinder.getInstance().getFactoryMap().entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) {
+                    continue;
+                }
+                String stem = stripSuffix(entry.getValue().getSimpleName(), "Factory");
+                if (stem == null) {
+                    continue;
+                }
+                String elementName = entry.getKey().getLocalPart();
+                String className = stemToClassName.get(stem);
+                if (className != null) {
+                    byClassName.put(className, elementName);
+                } else {
+                    bySimpleName.put(stem.toLowerCase(Locale.ROOT), elementName);
+                }
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Mediator element index built. Resolved by class name: " + byClassName.size()
+                        + ", resolved by factory-derived name: " + bySimpleName.size()
+                        + " " + bySimpleName.keySet());
+            }
+        } catch (Exception e) {
+            // Never let index construction break deployment.
+            log.warn("Could not build the mediator implementation to element index. Class mediator "
+                    + "access control checks will be skipped this cycle.", e);
+        }
+
+        MediatorElementIndex built = new MediatorElementIndex(
+                Collections.unmodifiableMap(byClassName), Collections.unmodifiableMap(bySimpleName));
+        elementIndex = built;
+        return built;
+    }
+
+    /**
+    * @param name a class simple name
+    * @param suffix the suffix to remove
+    * @return name without the suffix, or null if it does not end with it or nothing would remain
+    */
+    private static String stripSuffix(String name, String suffix) {
+
+        if (name == null || !name.endsWith(suffix) || name.length() == suffix.length()) {
+            return null;
+        }
+        return name.substring(0, name.length() - suffix.length());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
@@ -84,18 +84,24 @@ public final class MediatorAccessControl {
      * fallback for the few registered mediators that have a factory but no serializer, and is keyed
      * on the implementation name derived from the factory class name.
      */
-    private static final class MediatorElementIndex {
+    static final class MediatorElementIndex {
 
         /** Returned, and deliberately not cached, when the index cannot be built. */
         static final MediatorElementIndex EMPTY = new MediatorElementIndex(
-            Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap());
+            Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), -1, -1);
 
         final Map<String, String> byClassName;
         final Map<String, String> bySimpleName;
+        /** Registry sizes this index was built from, used to detect runtime registration. */
+        final int serializerCount;
+        final int factoryCount;
 
-        MediatorElementIndex(Map<String, String> byClassName, Map<String, String> bySimpleName) {
+        MediatorElementIndex(Map<String, String> byClassName, Map<String, String> bySimpleName,
+                             int serializerCount, int factoryCount) {
             this.byClassName = byClassName;
             this.bySimpleName = bySimpleName;
+            this.serializerCount = serializerCount;
+            this.factoryCount = factoryCount;
         }
     }
 
@@ -266,145 +272,221 @@ public final class MediatorAccessControl {
     }
 
     /**
-    * Builds the implementation to element index by joining the two registries Synapse already
-    * maintains.
+    * Returns the implementation to element index, building it if it is absent or if either
+    * registry has changed size since it was built.
     *
-    * MediatorFactoryFinder maps an element QName to its factory class, giving the element name.
-    * MediatorSerializerFinder maps a fully qualified implementation class name - declared by each
+    * MediatorFactoryFinder and MediatorSerializerFinder are both mutated at runtime by
+    * ExtensionDeployer when a mediator extension is deployed, outside the initialisation that
+    * init() hooks. Comparing the registry sizes the index was built from means such a registration
+    * is picked up, rather than leaving the new implementation ungoverned for the lifetime of the
+    * JVM.
+    *
+    * The factory registry is copied under the MediatorFactoryFinder class monitor, which is the
+    * lock reset() and loadMediatorFactories() hold. That does not make the copy atomic against
+    * ExtensionDeployer, which puts into the map without holding it, so a concurrent registration
+    * can still surface as a ConcurrentModificationException. That is handled rather than prevented:
+    * the build fails, no index is cached, and the next class mediator retries.
+    *
+    * The serializer registry is copied outside that monitor deliberately. The factory monitor does
+    * not guard it, and MediatorSerializerFinder.getInstance() can trigger class initialisation that
+    * runs ServiceLoader over extension serializers; holding the factory monitor across that would
+    * establish a lock order between the two finders for no benefit.
+    *
+    * @return the index, or MediatorElementIndex.EMPTY if it could not be built. The empty result is
+    *         deliberately not cached, so a transient failure is retried rather than disabling this
+    *         check for the lifetime of the JVM.
+    */
+    private static MediatorElementIndex getElementIndex() {
+
+        int serializerCount;
+        int factoryCount;
+        try {
+            serializerCount = MediatorSerializerFinder.getInstance().getSerializerMap().size();
+            factoryCount = MediatorFactoryFinder.getInstance().getFactoryMap().size();
+        } catch (Throwable t) {
+            logIndexFailure(t);
+            return MediatorElementIndex.EMPTY;
+        }
+
+        MediatorElementIndex existing = elementIndex;
+        if (existing != null && existing.serializerCount == serializerCount
+                && existing.factoryCount == factoryCount) {
+            return existing;
+        }
+
+        MediatorElementIndex built;
+        try {
+            Map<String, MediatorSerializer> serializers =
+                    new HashMap<>(MediatorSerializerFinder.getInstance().getSerializerMap());
+            Map<QName, Class> factories;
+            synchronized (MediatorFactoryFinder.class) {
+                factories = new HashMap<>(MediatorFactoryFinder.getInstance().getFactoryMap());
+            }
+            built = buildIndex(serializers, factories);
+        } catch (Throwable t) {
+            // Throwable, not Exception: MediatorSerializerFinder builds its singleton in a static
+            // field initialiser, so a failing extension serializer surfaces as
+            // ExceptionInInitializerError or NoClassDefFoundError.
+            logIndexFailure(t);
+            return MediatorElementIndex.EMPTY;
+        }
+
+        elementIndex = built;
+        return built;
+    }
+
+    private static void logIndexFailure(Throwable t) {
+
+        log.error("Could not build the mediator implementation to element index. Class mediator "
+                + "access control cannot evaluate the resolved class until it can be built, so "
+                + "class mediators are permitted in the meantime; the build is retried on the next "
+                + "class mediator.", t);
+    }
+
+    /**
+    * Joins the two registries Synapse already maintains into an implementation to element index.
+    *
+    * The serializer registry maps a fully qualified implementation class name - declared by each
     * serializer through getMediatorClassName() - to that serializer, giving the implementation
-    * class. The two are joined on the stem shared by a mediator's factory and serializer class
+    * class. The factory registry maps an element QName to its factory class, giving the element
+    * name. The two are joined on the stem shared by a mediator's factory and serializer class
     * names, for example TransactionMediatorFactory and TransactionMediatorSerializer both reducing
     * to "TransactionMediator".
     *
     * Taking the class from the serializer rather than inferring it from the factory name matters
     * where a mediator does not follow the naming convention: ThrowErrorMediatorSerializer declares
     * org.apache.synapse.mediators.v2.ThrowError, which no derivation from
-    * ThrowErrorMediatorFactory would produce. It also keys the result on the fully qualified name,
-    * so a customer class cannot inherit a decision by sharing a simple name.
+    * ThrowErrorMediatorFactory would produce. Keying on the fully qualified name also means a class
+    * cannot inherit a decision by sharing a simple name.
     *
-    * One element may be served by more than one implementation - the foreach element is built as
-    * either ForEachMediator or ForEachMediatorV2 depending on its attributes - so a serializer stem
-    * that matches no factory is resolved against the longest factory stem it is prefixed by, rather
-    * than being discarded. Anything still unresolved is reported, because a silently dropped entry
-    * is exactly a class this check would fail to govern.
+    * One element may be served by more than one implementation - foreach is built as either
+    * ForEachMediator or ForEachMediatorV2 depending on its attributes - so a serializer stem that
+    * matches no factory is resolved against the longest factory stem it is prefixed by. Anything
+    * still unresolved is reported, because a silently dropped entry is exactly a class this check
+    * would fail to govern.
     *
-    * A mediator that has a factory but no serializer cannot be resolved by class name and is
-    * recorded in the fallback map under the name derived from its factory.
+    * A name that resolves to more than one element is excluded rather than guessed at, on either
+    * side of the join. Guessing risks both failing to govern a restricted class and refusing a
+    * legitimate one.
     *
-    * The registries are read under the MediatorFactoryFinder class monitor, the lock that
-    * reset() and loadMediatorFactories() mutate the factory map under. The index is built once, so
-    * holding it briefly costs nothing, and iterating those live maps unlocked risks a
-    * ConcurrentModificationException during a configuration or tenant reload.
+    * Package private and free of static state so the join can be tested directly.
     *
-    * @return the index, or MediatorElementIndex.EMPTY if it could not be built. The empty result is
-    *         deliberately not cached, so a transient failure is retried on the next call rather
-    *         than disabling this check for the lifetime of the JVM.
+    * @param serializers implementation class name to serializer
+    * @param factories element QName to factory class
+    * @return the index, never null
     */
-    private static MediatorElementIndex getElementIndex() {
+    static MediatorElementIndex buildIndex(Map<String, MediatorSerializer> serializers,
+                                           Map<QName, Class> factories) {
 
-        MediatorElementIndex existing = elementIndex;
-        if (existing != null) {
-            return existing;
+        Map<String, String> stemToClassName = new HashMap<>();
+        Set<String> ambiguousStems = new HashSet<>();
+        for (Map.Entry<String, MediatorSerializer> entry : serializers.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            String serializerName = entry.getValue().getClass().getSimpleName();
+            String stem = stripSuffix(serializerName, "Serializer");
+            if (stem == null) {
+                log.debug("Mediator serializer '" + serializerName + "' does not follow the "
+                        + "<Mediator>Serializer naming convention, so '" + entry.getKey()
+                        + "' cannot be resolved to a mediator element by class name.");
+                continue;
+            }
+            String previous = stemToClassName.put(stem, entry.getKey());
+            if (previous != null && !previous.equals(entry.getKey())) {
+                ambiguousStems.add(stem);
+                log.warn("Mediator serializers for '" + previous + "' and '" + entry.getKey()
+                        + "' share the simple name '" + serializerName + "'. Neither class will be "
+                        + "resolved to a mediator element by class mediator access control.");
+            }
         }
 
         Map<String, String> byClassName = new HashMap<>();
         Map<String, String> bySimpleName = new HashMap<>();
-        try {
-            Map<String, String> stemToClassName = new HashMap<>();
-            Set<String> ambiguousStems = new HashSet<>();
-            Map<QName, Class> factories;
+        Set<String> ambiguousClasses = new HashSet<>();
+        Set<String> ambiguousSimpleNames = new HashSet<>();
+        Set<String> consumedStems = new HashSet<>();
 
-            synchronized (MediatorFactoryFinder.class) {
-                for (Map.Entry<String, MediatorSerializer> entry :
-                        MediatorSerializerFinder.getInstance().getSerializerMap().entrySet()) {
-                    if (entry.getKey() == null || entry.getValue() == null) {
-                        continue;
-                    }
-                    String stem = stripSuffix(entry.getValue().getClass().getSimpleName(), "Serializer");
-                    if (stem == null) {
-                        continue;
-                    }
-                    String previous = stemToClassName.put(stem, entry.getKey());
-                    if (previous != null && !previous.equals(entry.getKey())) {
-                        // Two serializers in different packages share a simple name. Either could be
-                        // the one a factory means, so neither is used: guessing risks both failing to
-                        // govern a restricted class and refusing a legitimate one.
-                        ambiguousStems.add(stem);
-                        log.warn("Mediator serializers for '" + previous + "' and '" + entry.getKey()
-                                + "' share the simple name '" + stem + "Serializer'. Neither class "
-                                + "will be resolved to a mediator element by class mediator access "
-                                + "control.");
-                    }
-                }
-                factories = new HashMap<>(MediatorFactoryFinder.getInstance().getFactoryMap());
+        for (Map.Entry<QName, Class> entry : factories.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
             }
-
-            Set<String> consumedStems = new HashSet<>();
-            for (Map.Entry<QName, Class> entry : factories.entrySet()) {
-                if (entry.getKey() == null || entry.getValue() == null) {
-                    continue;
+            String factoryName = entry.getValue().getSimpleName();
+            String stem = stripSuffix(factoryName, "Factory");
+            if (stem == null) {
+                log.debug("Mediator factory '" + factoryName + "' does not follow the "
+                        + "<Mediator>Factory naming convention, so element '"
+                        + entry.getKey().getLocalPart() + "' has no implementation mapping.");
+                continue;
+            }
+            String elementName = entry.getKey().getLocalPart();
+            String className = ambiguousStems.contains(stem) ? null : stemToClassName.get(stem);
+            if (className != null) {
+                String previous = byClassName.put(className, elementName);
+                if (previous != null && !previous.equals(elementName)) {
+                    // Two factories share a simple name under different elements, so the class they
+                    // both reduce to would bind to whichever was written last.
+                    ambiguousClasses.add(className);
+                    log.warn("Mediator implementation '" + className + "' is claimed by more than "
+                            + "one mediator element ('" + previous + "' and '" + elementName
+                            + "'). It will not be resolved to an element by class mediator access "
+                            + "control.");
                 }
-                String stem = stripSuffix(entry.getValue().getSimpleName(), "Factory");
-                if (stem == null) {
-                    continue;
-                }
-                String elementName = entry.getKey().getLocalPart();
-                String className = ambiguousStems.contains(stem) ? null : stemToClassName.get(stem);
-                if (className != null) {
-                    byClassName.put(className, elementName);
-                    consumedStems.add(stem);
-                } else {
-                    bySimpleName.put(stem.toLowerCase(Locale.ROOT), elementName);
+                consumedStems.add(stem);
+            } else {
+                String key = stem.toLowerCase(Locale.ROOT);
+                String previous = bySimpleName.put(key, elementName);
+                if (previous != null && !previous.equals(elementName)) {
+                    ambiguousSimpleNames.add(key);
+                    log.warn("Mediator name '" + stem + "' is claimed by more than one mediator "
+                            + "element ('" + previous + "' and '" + elementName + "'). It will not "
+                            + "be resolved to an element by class mediator access control.");
                 }
             }
-
-            // Additional implementations of an element already resolved above: match the leftover
-            // serializer stem to the longest factory stem it extends.
-            for (Map.Entry<String, String> leftover : stemToClassName.entrySet()) {
-                String stem = leftover.getKey();
-                if (consumedStems.contains(stem) || ambiguousStems.contains(stem)
-                        || byClassName.containsKey(leftover.getValue())) {
-                    continue;
-                }
-                String bestStem = null;
-                for (String candidate : consumedStems) {
-                    if (stem.startsWith(candidate)
-                            && (bestStem == null || candidate.length() > bestStem.length())) {
-                        bestStem = candidate;
-                    }
-                }
-                if (bestStem != null) {
-                    String elementName = byClassName.get(stemToClassName.get(bestStem));
-                    if (elementName != null) {
-                        byClassName.put(leftover.getValue(), elementName);
-                        continue;
-                    }
-                }
-                log.warn("Mediator implementation '" + leftover.getValue() + "' could not be "
-                        + "resolved to a mediator element, because its serializer name '" + stem
-                        + "Serializer' matches no registered mediator factory. Class mediator "
-                        + "access control will not govern this class.");
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("Mediator element index built. Resolved by class name: " + byClassName.size()
-                        + ", resolved by factory-derived name: " + bySimpleName.size()
-                        + " " + bySimpleName.keySet());
-            }
-        } catch (Throwable t) {
-            // Throwable, not Exception: MediatorSerializerFinder builds its singleton in a static
-            // initialiser, so a failing extension serializer surfaces as ExceptionInInitializerError
-            // or NoClassDefFoundError.
-            log.warn("Could not build the mediator implementation to element index. Class mediator "
-                    + "access control checks are skipped until it can be built, and will be "
-                    + "retried on the next class mediator.", t);
-            return MediatorElementIndex.EMPTY;
         }
 
-        MediatorElementIndex built = new MediatorElementIndex(
-                Collections.unmodifiableMap(byClassName), Collections.unmodifiableMap(bySimpleName));
-        elementIndex = built;
-        return built;
+        byClassName.keySet().removeAll(ambiguousClasses);
+        bySimpleName.keySet().removeAll(ambiguousSimpleNames);
+
+        // Additional implementations of an element already resolved above: match the leftover
+        // serializer stem to the longest factory stem it extends.
+        for (Map.Entry<String, String> leftover : stemToClassName.entrySet()) {
+            String stem = leftover.getKey();
+            String className = leftover.getValue();
+            if (consumedStems.contains(stem) || ambiguousStems.contains(stem)
+                    || byClassName.containsKey(className)) {
+                continue;
+            }
+            String bestStem = null;
+            for (String candidate : consumedStems) {
+                if (stem.startsWith(candidate)
+                        && (bestStem == null || candidate.length() > bestStem.length())) {
+                    bestStem = candidate;
+                }
+            }
+            String elementName = bestStem == null
+                    ? null : byClassName.get(stemToClassName.get(bestStem));
+            if (elementName != null) {
+                byClassName.put(className, elementName);
+                log.debug("Mediator implementation '" + className + "' resolved to element '"
+                        + elementName + "' because its serializer name extends '" + bestStem
+                        + "Serializer'.");
+            } else {
+                log.warn("Mediator implementation '" + className + "' could not be resolved to a "
+                        + "mediator element, because its serializer name '" + stem + "Serializer' "
+                        + "matches no registered mediator factory. Class mediator access control "
+                        + "will not govern this class.");
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Mediator element index built. Resolved by class name: " + byClassName.size()
+                    + ", resolved by factory-derived name: " + bySimpleName.size()
+                    + " " + bySimpleName.keySet());
+        }
+
+        return new MediatorElementIndex(Collections.unmodifiableMap(byClassName),
+                Collections.unmodifiableMap(bySimpleName), serializers.size(), factories.size());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
@@ -86,6 +86,10 @@ public final class MediatorAccessControl {
      */
     private static final class MediatorElementIndex {
 
+        /** Returned, and deliberately not cached, when the index cannot be built. */
+        static final MediatorElementIndex EMPTY = new MediatorElementIndex(
+            Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap());
+
         final Map<String, String> byClassName;
         final Map<String, String> bySimpleName;
 
@@ -233,19 +237,14 @@ public final class MediatorAccessControl {
     private static void checkMediatorName(MediatorAccessControlConfig mediatorAccessControlConfig,
                                           String normalizedName, String displayName) {
 
-        if (AccessControlListType.BLOCK_LIST == mediatorAccessControlConfig.listType) {
-            if (mediatorAccessControlConfig.mediators.contains(normalizedName)) {
-                String msg = "Mediator '" + displayName + "' is blocked by mediator access control.";
-                log.debug(msg);
-                throw new MediatorAccessControlException(msg, displayName);
-            }
-        } else if (AccessControlListType.ALLOW_LIST == mediatorAccessControlConfig.listType) {
-            if (!mediatorAccessControlConfig.mediators.contains(normalizedName)) {
-                String msg = "Mediator '" + displayName + "' is not in the allowed mediators list.";
-                log.debug(msg);
-                throw new MediatorAccessControlException(msg, displayName);
-            }
+        if (!isBlocked(mediatorAccessControlConfig, normalizedName)) {
+            return;
         }
+        String msg = AccessControlListType.BLOCK_LIST == mediatorAccessControlConfig.listType
+                ? "Mediator '" + displayName + "' is blocked by mediator access control."
+                : "Mediator '" + displayName + "' is not in the allowed mediators list.";
+        log.debug(msg);
+        throw new MediatorAccessControlException(msg, displayName);
     }
 
     /**
@@ -283,10 +282,23 @@ public final class MediatorAccessControl {
     * ThrowErrorMediatorFactory would produce. It also keys the result on the fully qualified name,
     * so a customer class cannot inherit a decision by sharing a simple name.
     *
-    * A mediator that has a factory but no serializer cannot be resolved this way and is recorded in
-    * the fallback map under the name derived from its factory.
+    * One element may be served by more than one implementation - the foreach element is built as
+    * either ForEachMediator or ForEachMediatorV2 depending on its attributes - so a serializer stem
+    * that matches no factory is resolved against the longest factory stem it is prefixed by, rather
+    * than being discarded. Anything still unresolved is reported, because a silently dropped entry
+    * is exactly a class this check would fail to govern.
     *
-    * @return the index, never null
+    * A mediator that has a factory but no serializer cannot be resolved by class name and is
+    * recorded in the fallback map under the name derived from its factory.
+    *
+    * The registries are read under the MediatorFactoryFinder class monitor, the lock that
+    * reset() and loadMediatorFactories() mutate the factory map under. The index is built once, so
+    * holding it briefly costs nothing, and iterating those live maps unlocked risks a
+    * ConcurrentModificationException during a configuration or tenant reload.
+    *
+    * @return the index, or MediatorElementIndex.EMPTY if it could not be built. The empty result is
+    *         deliberately not cached, so a transient failure is retried on the next call rather
+    *         than disabling this check for the lifetime of the JVM.
     */
     private static MediatorElementIndex getElementIndex() {
 
@@ -298,22 +310,37 @@ public final class MediatorAccessControl {
         Map<String, String> byClassName = new HashMap<>();
         Map<String, String> bySimpleName = new HashMap<>();
         try {
-            // stem -> implementation class name, from the serializers
             Map<String, String> stemToClassName = new HashMap<>();
-            for (Map.Entry<String, MediatorSerializer> entry :
-                    MediatorSerializerFinder.getInstance().getSerializerMap().entrySet()) {
-                if (entry.getKey() == null || entry.getValue() == null) {
-                    continue;
+            Set<String> ambiguousStems = new HashSet<>();
+            Map<QName, Class> factories;
+
+            synchronized (MediatorFactoryFinder.class) {
+                for (Map.Entry<String, MediatorSerializer> entry :
+                        MediatorSerializerFinder.getInstance().getSerializerMap().entrySet()) {
+                    if (entry.getKey() == null || entry.getValue() == null) {
+                        continue;
+                    }
+                    String stem = stripSuffix(entry.getValue().getClass().getSimpleName(), "Serializer");
+                    if (stem == null) {
+                        continue;
+                    }
+                    String previous = stemToClassName.put(stem, entry.getKey());
+                    if (previous != null && !previous.equals(entry.getKey())) {
+                        // Two serializers in different packages share a simple name. Either could be
+                        // the one a factory means, so neither is used: guessing risks both failing to
+                        // govern a restricted class and refusing a legitimate one.
+                        ambiguousStems.add(stem);
+                        log.warn("Mediator serializers for '" + previous + "' and '" + entry.getKey()
+                                + "' share the simple name '" + stem + "Serializer'. Neither class "
+                                + "will be resolved to a mediator element by class mediator access "
+                                + "control.");
+                    }
                 }
-                String stem = stripSuffix(entry.getValue().getClass().getSimpleName(), "Serializer");
-                if (stem != null) {
-                    stemToClassName.put(stem, entry.getKey());
-                }
+                factories = new HashMap<>(MediatorFactoryFinder.getInstance().getFactoryMap());
             }
 
-            // stem -> element name, from the factories
-            for (Map.Entry<QName, Class> entry :
-                    MediatorFactoryFinder.getInstance().getFactoryMap().entrySet()) {
+            Set<String> consumedStems = new HashSet<>();
+            for (Map.Entry<QName, Class> entry : factories.entrySet()) {
                 if (entry.getKey() == null || entry.getValue() == null) {
                     continue;
                 }
@@ -322,12 +349,41 @@ public final class MediatorAccessControl {
                     continue;
                 }
                 String elementName = entry.getKey().getLocalPart();
-                String className = stemToClassName.get(stem);
+                String className = ambiguousStems.contains(stem) ? null : stemToClassName.get(stem);
                 if (className != null) {
                     byClassName.put(className, elementName);
+                    consumedStems.add(stem);
                 } else {
                     bySimpleName.put(stem.toLowerCase(Locale.ROOT), elementName);
                 }
+            }
+
+            // Additional implementations of an element already resolved above: match the leftover
+            // serializer stem to the longest factory stem it extends.
+            for (Map.Entry<String, String> leftover : stemToClassName.entrySet()) {
+                String stem = leftover.getKey();
+                if (consumedStems.contains(stem) || ambiguousStems.contains(stem)
+                        || byClassName.containsKey(leftover.getValue())) {
+                    continue;
+                }
+                String bestStem = null;
+                for (String candidate : consumedStems) {
+                    if (stem.startsWith(candidate)
+                            && (bestStem == null || candidate.length() > bestStem.length())) {
+                        bestStem = candidate;
+                    }
+                }
+                if (bestStem != null) {
+                    String elementName = byClassName.get(stemToClassName.get(bestStem));
+                    if (elementName != null) {
+                        byClassName.put(leftover.getValue(), elementName);
+                        continue;
+                    }
+                }
+                log.warn("Mediator implementation '" + leftover.getValue() + "' could not be "
+                        + "resolved to a mediator element, because its serializer name '" + stem
+                        + "Serializer' matches no registered mediator factory. Class mediator "
+                        + "access control will not govern this class.");
             }
 
             if (log.isDebugEnabled()) {
@@ -335,10 +391,14 @@ public final class MediatorAccessControl {
                         + ", resolved by factory-derived name: " + bySimpleName.size()
                         + " " + bySimpleName.keySet());
             }
-        } catch (Exception e) {
-            // Never let index construction break deployment.
+        } catch (Throwable t) {
+            // Throwable, not Exception: MediatorSerializerFinder builds its singleton in a static
+            // initialiser, so a failing extension serializer surfaces as ExceptionInInitializerError
+            // or NoClassDefFoundError.
             log.warn("Could not build the mediator implementation to element index. Class mediator "
-                    + "access control checks will be skipped this cycle.", e);
+                    + "access control checks are skipped until it can be built, and will be "
+                    + "retried on the next class mediator.", t);
+            return MediatorElementIndex.EMPTY;
         }
 
         MediatorElementIndex built = new MediatorElementIndex(

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MediatorAccessControl.java
@@ -23,7 +23,10 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.config.SynapsePropertiesLoader;
 
 import javax.xml.namespace.QName;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -112,6 +115,21 @@ public final class MediatorAccessControl {
     }
 
     /**
+     * Discards the cached implementation to element index so that it is rebuilt on next use.
+     *
+     * Called when a mediator factory or serializer is registered at runtime. The size comparison in
+     * getElementIndex() catches a registration that grows a registry, but a registration that
+     * replaces an existing entry - an extension supplying its own factory for an element that
+     * already exists, or a redeployed extension jar, which is always a replacement because
+     * ExtensionDeployer does not remove entries on undeploy - leaves the size unchanged. Being told
+     * is exact where comparing sizes is only a proxy.
+     */
+    public static void invalidateIndex() {
+
+        elementIndex = null;
+    }
+
+    /**
      * Loads access control configuration from synapse.properties.
      * Called once during MediatorFactoryFinder initialization.
      */
@@ -159,6 +177,30 @@ public final class MediatorAccessControl {
     }
 
     /**
+    * Resolves a mediator implementation class to the element it is registered under.
+    *
+    * An exact match on the fully qualified name is preferred. Mediators that have a factory but no
+    * serializer cannot be matched that way and fall back to the name derived from the factory; that
+    * fallback is restricted to Synapse's own mediator package, because a name derived from a
+    * factory is not an identity and without the restriction a customer class sharing the name would
+    * inherit a decision meant for the Synapse implementation.
+    *
+    * Package private so the resolution, including that package gate, can be tested directly.
+    *
+    * @param index the implementation to element index
+    * @param resolved the class named by the &lt;class&gt; element
+    * @return the element name, or null if the class backs no registered mediator element
+    */
+    static String resolveElement(MediatorElementIndex index, Class<?> resolved) {
+
+        String elementName = index.byClassName.get(resolved.getName());
+        if (elementName == null && resolved.getName().startsWith(SYNAPSE_MEDIATOR_PACKAGE)) {
+            elementName = index.bySimpleName.get(resolved.getSimpleName().toLowerCase(Locale.ROOT));
+        }
+        return elementName;
+    }
+
+    /**
      * Checks whether the class named by a &lt;class&gt; element may be used.
      *
      * The class mediator resolves an arbitrary fully qualified class name, so without this check
@@ -186,17 +228,7 @@ public final class MediatorAccessControl {
             return;
         }
 
-        MediatorElementIndex index = getElementIndex();
-        String elementName = index.byClassName.get(resolved.getName());
-
-        if (elementName == null && resolved.getName().startsWith(SYNAPSE_MEDIATOR_PACKAGE)) {
-            // Mediators that have a factory but no serializer cannot be matched by class name, so
-            // they fall back to the name derived from the factory. Restricted to Synapse's own
-            // mediator package, since a name derived from a factory is not an identity: without the
-            // restriction a customer class that happened to share the name would inherit a decision
-            // meant for the Synapse implementation.
-            elementName = index.bySimpleName.get(resolved.getSimpleName().toLowerCase(Locale.ROOT));
-        }
+        String elementName = resolveElement(getElementIndex(), resolved);
 
         if (elementName == null) {
             // Not the implementation of any registered mediator element.
@@ -387,9 +419,11 @@ public final class MediatorAccessControl {
             String serializerName = entry.getValue().getClass().getSimpleName();
             String stem = stripSuffix(serializerName, "Serializer");
             if (stem == null) {
-                log.debug("Mediator serializer '" + serializerName + "' does not follow the "
+                if (log.isDebugEnabled()) {
+                    log.debug("Mediator serializer '" + serializerName + "' does not follow the "
                         + "<Mediator>Serializer naming convention, so '" + entry.getKey()
                         + "' cannot be resolved to a mediator element by class name.");
+                }
                 continue;
             }
             String previous = stemToClassName.put(stem, entry.getKey());
@@ -397,7 +431,8 @@ public final class MediatorAccessControl {
                 ambiguousStems.add(stem);
                 log.warn("Mediator serializers for '" + previous + "' and '" + entry.getKey()
                         + "' share the simple name '" + serializerName + "'. Neither class will be "
-                        + "resolved to a mediator element by class mediator access control.");
+                        + "resolved to a mediator element by class name; a Synapse mediator may "
+                        + "still resolve through the factory-derived name.");
             }
         }
 
@@ -414,9 +449,11 @@ public final class MediatorAccessControl {
             String factoryName = entry.getValue().getSimpleName();
             String stem = stripSuffix(factoryName, "Factory");
             if (stem == null) {
-                log.debug("Mediator factory '" + factoryName + "' does not follow the "
+                if (log.isDebugEnabled()) {
+                    log.debug("Mediator factory '" + factoryName + "' does not follow the "
                         + "<Mediator>Factory naming convention, so element '"
                         + entry.getKey().getLocalPart() + "' has no implementation mapping.");
+                }
                 continue;
             }
             String elementName = entry.getKey().getLocalPart();
@@ -457,25 +494,37 @@ public final class MediatorAccessControl {
                     || byClassName.containsKey(className)) {
                 continue;
             }
-            String bestStem = null;
-            for (String candidate : consumedStems) {
-                if (stem.startsWith(candidate)
-                        && (bestStem == null || candidate.length() > bestStem.length())) {
-                    bestStem = candidate;
+            // Longest first, falling through when a candidate's class was excluded as ambiguous.
+            List<String> candidates = new ArrayList<>(consumedStems);
+            Collections.sort(candidates, new Comparator<String>() {
+                public int compare(String a, String b) { return b.length() - a.length(); }
+            });
+            String elementName = null;
+            String matchedStem = null;
+            for (String candidate : candidates) {
+                if (!stem.startsWith(candidate)) {
+                    continue;
+                }
+                String candidateElement = byClassName.get(stemToClassName.get(candidate));
+                if (candidateElement != null) {
+                    elementName = candidateElement;
+                    matchedStem = candidate;
+                    break;
                 }
             }
-            String elementName = bestStem == null
-                    ? null : byClassName.get(stemToClassName.get(bestStem));
             if (elementName != null) {
                 byClassName.put(className, elementName);
-                log.debug("Mediator implementation '" + className + "' resolved to element '"
-                        + elementName + "' because its serializer name extends '" + bestStem
-                        + "Serializer'.");
+                if (log.isDebugEnabled()) {
+                    log.debug("Mediator implementation '" + className + "' resolved to element '"
+                            + elementName + "' because its serializer name extends '" + matchedStem
+                            + "Serializer'.");
+                }
             } else {
                 log.warn("Mediator implementation '" + className + "' could not be resolved to a "
-                        + "mediator element, because its serializer name '" + stem + "Serializer' "
-                        + "matches no registered mediator factory. Class mediator access control "
-                        + "will not govern this class.");
+                        + "mediator element: its serializer name '" + stem + "Serializer' matches "
+                        + "no registered mediator factory, and no factory it extends resolves to an "
+                        + "unambiguous element. Class mediator access control will not govern this "
+                        + "class.");
             }
         }
 

--- a/modules/core/src/main/java/org/apache/synapse/deployers/ExtensionDeployer.java
+++ b/modules/core/src/main/java/org/apache/synapse/deployers/ExtensionDeployer.java
@@ -39,6 +39,7 @@ import org.apache.axis2.deployment.repository.util.DeploymentFileData;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.config.xml.MediatorFactory;
+import org.apache.synapse.config.xml.MediatorAccessControl;
 import org.apache.synapse.config.xml.MediatorFactoryFinder;
 import org.apache.synapse.config.xml.MediatorSerializer;
 import org.apache.synapse.config.xml.MediatorSerializerFinder;
@@ -123,6 +124,12 @@ public class ExtensionDeployer extends AbstractDeployer {
                 log.info("Registered mediator serializer " + serializer.getClass().getName()
                         + " for " + mediatorClassName);
             }
+
+            // The mediator access control index is derived from these two registries. Registration
+            // here happens outside MediatorFactoryFinder initialisation, and replacing an existing
+            // entry leaves the registry size unchanged, so the index has to be told rather than
+            // left to notice.
+            MediatorAccessControl.invalidateIndex();
             
         } catch (IOException e) {
             handleException("I/O error in reading the mediator jar file", e);

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorAccessControlIndexTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorAccessControlIndexTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.config.xml;
+
+import junit.framework.TestCase;
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.Mediator;
+
+import javax.xml.namespace.QName;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Covers the join that resolves a mediator implementation class to the XML element it is registered
+ * under. A regression here silently stops class mediator access control from governing a class, so
+ * the join is exercised directly rather than through a deployed configuration.
+ */
+public class MediatorAccessControlIndexTest extends TestCase {
+
+    // --- stand-ins whose simple names drive the join -------------------------------------------
+
+    private abstract static class StubSerializer implements MediatorSerializer {
+        private final String className;
+        StubSerializer(String className) { this.className = className; }
+        public OMElement serializeMediator(OMElement parent, Mediator m) { return null; }
+        public String getMediatorClassName() { return className; }
+    }
+
+    private static class AlphaMediatorSerializer extends StubSerializer {
+        AlphaMediatorSerializer(String c) { super(c); }
+    }
+    private static class AlphaMediatorV2Serializer extends StubSerializer {
+        AlphaMediatorV2Serializer(String c) { super(c); }
+    }
+    private static class BetaMediatorSerializer extends StubSerializer {
+        BetaMediatorSerializer(String c) { super(c); }
+    }
+    private static class NotFollowingConvention extends StubSerializer {
+        NotFollowingConvention(String c) { super(c); }
+    }
+
+    private static class AlphaMediatorFactory { }
+    private static class BetaMediatorFactory { }
+    private static class GammaMediatorFactory { }
+
+    private static QName q(String local) { return new QName("http://ws.apache.org/ns/synapse", local); }
+
+    private static Map<String, MediatorSerializer> serializers(MediatorSerializer... entries) {
+        Map<String, MediatorSerializer> m = new HashMap<String, MediatorSerializer>();
+        for (MediatorSerializer s : entries) {
+            m.put(s.getMediatorClassName(), s);
+        }
+        return m;
+    }
+
+    // --- tests ---------------------------------------------------------------------------------
+
+    /** The ordinary case: one factory, one serializer, joined on the shared stem. */
+    public void testResolvesImplementationToItsElement() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new AlphaMediatorSerializer("com.example.AlphaMediator")), factories);
+
+        assertEquals("alpha", index.byClassName.get("com.example.AlphaMediator"));
+    }
+
+    /**
+     * An element served by more than one implementation. ForEachMediatorV2Serializer matches no
+     * factory of its own, so without the prefix sweep its class is dropped and left ungoverned.
+     */
+    public void testAdditionalImplementationOfTheSameElementIsResolved() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new AlphaMediatorSerializer("com.example.AlphaMediator"),
+                            new AlphaMediatorV2Serializer("com.example.v2.AlphaMediatorV2")),
+                factories);
+
+        assertEquals("alpha", index.byClassName.get("com.example.AlphaMediator"));
+        assertEquals("the additional implementation must inherit the same element",
+                "alpha", index.byClassName.get("com.example.v2.AlphaMediatorV2"));
+    }
+
+    /**
+     * Two factories sharing a simple name under different elements. The class they both reduce to
+     * must be excluded rather than bound to whichever was written last, which would let a
+     * restricted implementation inherit a permitted element.
+     */
+    public void testClassClaimedByTwoElementsIsExcluded() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+        factories.put(q("shadow"), org.apache.synapse.config.xml.other.AlphaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new AlphaMediatorSerializer("com.example.AlphaMediator")), factories);
+
+        assertFalse("an ambiguous class must not resolve to any element",
+                index.byClassName.containsKey("com.example.AlphaMediator"));
+    }
+
+    /** Two serializers sharing a simple name: neither class may be resolved. */
+    public void testAmbiguousSerializerStemResolvesNothing() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+
+        Map<String, MediatorSerializer> sers = serializers(
+                new AlphaMediatorSerializer("com.example.AlphaMediator"));
+        sers.put("com.other.AlphaMediator", new AlphaMediatorSerializer("com.other.AlphaMediator"));
+
+        MediatorAccessControl.MediatorElementIndex index =
+                MediatorAccessControl.buildIndex(sers, factories);
+
+        assertFalse(index.byClassName.containsKey("com.example.AlphaMediator"));
+        assertFalse(index.byClassName.containsKey("com.other.AlphaMediator"));
+    }
+
+    /** A factory with no serializer falls back to the name derived from the factory. */
+    public void testFactoryWithoutSerializerFallsBackToDerivedName() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("gamma"), GammaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index =
+                MediatorAccessControl.buildIndex(serializers(), factories);
+
+        assertEquals("gamma", index.bySimpleName.get("gammamediator"));
+    }
+
+    /** A serializer not following the naming convention must not derail the rest of the join. */
+    public void testUnconventionalSerializerNameIsSkippedNotFatal() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("beta"), BetaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new NotFollowingConvention("com.example.Odd"),
+                            new BetaMediatorSerializer("com.example.BetaMediator")), factories);
+
+        assertEquals("beta", index.byClassName.get("com.example.BetaMediator"));
+        assertFalse(index.byClassName.containsKey("com.example.Odd"));
+    }
+
+    /** The index records the registry sizes it was built from, so later registration is detected. */
+    public void testIndexRecordsRegistrySizes() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+        factories.put(q("beta"), BetaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new AlphaMediatorSerializer("com.example.AlphaMediator")), factories);
+
+        assertEquals(1, index.serializerCount);
+        assertEquals(2, index.factoryCount);
+    }
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorAccessControlIndexTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/MediatorAccessControlIndexTest.java
@@ -56,6 +56,9 @@ public class MediatorAccessControlIndexTest extends TestCase {
     }
 
     private static class AlphaMediatorFactory { }
+    /** Simple name collides with a Synapse mediator, but the package does not. */
+    private static class GammaMediator { }
+    private static class Alpha { }
     private static class BetaMediatorFactory { }
     private static class GammaMediatorFactory { }
 
@@ -120,8 +123,12 @@ public class MediatorAccessControlIndexTest extends TestCase {
                 index.byClassName.containsKey("com.example.AlphaMediator"));
     }
 
-    /** Two serializers sharing a simple name: neither class may be resolved. */
-    public void testAmbiguousSerializerStemResolvesNothing() {
+    /**
+     * Two serializers sharing a simple name: neither class may be resolved by class name. A
+     * Synapse mediator of that name can still resolve through the factory-derived fallback, which
+     * is what the warning now says and what this asserts.
+     */
+    public void testAmbiguousSerializerStemResolvesNothingByClassName() {
 
         Map<QName, Class> factories = new HashMap<QName, Class>();
         factories.put(q("alpha"), AlphaMediatorFactory.class);
@@ -135,6 +142,8 @@ public class MediatorAccessControlIndexTest extends TestCase {
 
         assertFalse(index.byClassName.containsKey("com.example.AlphaMediator"));
         assertFalse(index.byClassName.containsKey("com.other.AlphaMediator"));
+        assertEquals("the factory falls through to the derived-name map",
+                "alpha", index.bySimpleName.get("alphamediator"));
     }
 
     /** A factory with no serializer falls back to the name derived from the factory. */
@@ -175,5 +184,60 @@ public class MediatorAccessControlIndexTest extends TestCase {
 
         assertEquals(1, index.serializerCount);
         assertEquals(2, index.factoryCount);
+    }
+
+    /**
+     * The other half of the ambiguity fix: two factories with no serializer sharing a simple name.
+     * This is the branch that governs the AnnotatedCommandMediator fallback.
+     */
+    public void testDerivedNameClaimedByTwoElementsIsExcluded() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("gamma"), GammaMediatorFactory.class);
+        factories.put(q("shadow"), org.apache.synapse.config.xml.other.GammaMediatorFactory.class);
+
+        MediatorAccessControl.MediatorElementIndex index =
+                MediatorAccessControl.buildIndex(serializers(), factories);
+
+        assertFalse("an ambiguous derived name must not resolve to any element",
+                index.bySimpleName.containsKey("gammamediator"));
+    }
+
+    /** An exact class-name match resolves regardless of package. */
+    public void testResolveElementMatchesExactClassName() {
+
+        Map<QName, Class> factories = new HashMap<QName, Class>();
+        factories.put(q("alpha"), AlphaMediatorFactory.class);
+        MediatorAccessControl.MediatorElementIndex index = MediatorAccessControl.buildIndex(
+                serializers(new AlphaMediatorSerializer(Alpha.class.getName())), factories);
+
+        assertEquals("alpha", MediatorAccessControl.resolveElement(index, Alpha.class));
+    }
+
+    /**
+     * The package gate. A class outside org.apache.synapse.mediators must not inherit a decision
+     * through the derived-name fallback merely by sharing a simple name with a Synapse mediator.
+     */
+    public void testResolveElementAppliesThePackageGateToTheFallback() {
+
+        Map<String, String> bySimpleName = new HashMap<String, String>();
+        bySimpleName.put("gammamediator", "gamma");
+        MediatorAccessControl.MediatorElementIndex index = new MediatorAccessControl
+                .MediatorElementIndex(new HashMap<String, String>(), bySimpleName, 0, 0);
+
+        assertNull("a customer class must not match by simple name",
+                MediatorAccessControl.resolveElement(index, GammaMediator.class));
+    }
+
+    /** A class inside the Synapse mediator package does resolve through the fallback. */
+    public void testResolveElementAllowsTheFallbackInsideTheSynapsePackage() {
+
+        Map<String, String> bySimpleName = new HashMap<String, String>();
+        bySimpleName.put("stubmediator", "stub");
+        MediatorAccessControl.MediatorElementIndex index = new MediatorAccessControl
+                .MediatorElementIndex(new HashMap<String, String>(), bySimpleName, 0, 0);
+
+        assertEquals("stub", MediatorAccessControl.resolveElement(
+                index, org.apache.synapse.mediators.StubMediator.class));
     }
 }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/other/AlphaMediatorFactory.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/other/AlphaMediatorFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.config.xml.other;
+
+/**
+ * Shares its simple name with a factory in another package, so that the index join can be tested
+ * for the case where one implementation class is claimed by two mediator elements.
+ */
+public class AlphaMediatorFactory {
+}

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/other/GammaMediatorFactory.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/other/GammaMediatorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.config.xml.other;
+
+/** Shares its simple name with a factory that has no serializer, for the derived-name collision. */
+public class GammaMediatorFactory {
+}

--- a/modules/core/src/test/java/org/apache/synapse/mediators/StubMediator.java
+++ b/modules/core/src/test/java/org/apache/synapse/mediators/StubMediator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.synapse.mediators;
+
+/** Sits inside the Synapse mediator package so the fallback's package gate can be tested. */
+public class StubMediator {
+}


### PR DESCRIPTION
## Description

Mediator access control is configured per mediator element, through `synapse.mediators.access.control.{mode,list}`, and is currently evaluated in `MediatorFactoryFinder` against the XML element's local name.

The class mediator does not go through that path. `<class name="...">` resolves an arbitrary fully qualified class name and instantiates it directly, so an implementation named that way is never matched against the configured list. The result is that the same mediator receives two different decisions depending on which form is written — the element form is governed, the class form is not.

This change makes the two forms agree: the class a `<class>` element resolves is mapped back to the mediator element it is registered under, and the decision already configured for that element is applied.

### Changes

**`MediatorAccessControl.checkByClass(Class)`** resolves the class to its registered element and applies that element's configured decision.

**`ClassMediatorFactory`** calls the check once the class is resolved and before `newInstance()`, since instantiation runs static initialisers and the constructor. The call site sits below all three resolution paths: the Synapse library loader, the dynamic class mediator loaders and the default class loader.

### How the implementation is resolved to an element

The index is built by joining the two registries Synapse already maintains, rather than inferring the implementation class from a naming convention:

- `MediatorSerializerFinder` maps a **fully qualified implementation class name** to its serializer. Each serializer declares that name through `getMediatorClassName()`.
- `MediatorFactoryFinder` maps an **element QName** to its factory class.
- The two are joined on the stem shared by a mediator's factory and serializer class names, e.g. `TransactionMediatorFactory` and `TransactionMediatorSerializer` both reducing to `TransactionMediator`.

Taking the class from the serializer rather than deriving it from the factory name keeps the index correct where a mediator does not follow the naming convention. `ThrowErrorMediatorSerializer` declares `org.apache.synapse.mediators.v2.ThrowError`, which no derivation from `ThrowErrorMediatorFactory` would produce, because the `v2` mediators drop the `Mediator` suffix their factory name implies. Keying the result on the fully qualified name also means a class cannot inherit a decision merely by sharing a simple name with a Synapse implementation.

One element may be served by more than one implementation — `foreach` is built as either `ForEachMediator` or `ForEachMediatorV2` depending on its attributes — so a serializer stem matching no factory is resolved against the longest factory stem it extends, and anything still unresolved is logged. A name claimed by more than one element is excluded on either side of the join rather than bound to whichever was written last. The index is rebuilt when either registry changes size, and `ExtensionDeployer` invalidates it after registering mediator factories and serializers, because replacing an existing entry leaves the size unchanged. A failed build returns an uncached empty index, reported at ERROR, and is retried on the next class mediator.

A mediator with a factory but no serializer falls back to the name derived from its factory, restricted to `org.apache.synapse.mediators.`, because a derived name is not an identity.

### Behaviour

- **No new configuration.** `synapse.mediators.access.control.{mode,list}` remain the only policy input, and the check is a no-op when the mode is `NONE` or the configuration is absent, so a default distribution is unaffected.
- **Classes that do not back a registered mediator element are unaffected**, because the access control list never governed them. This covers custom mediators and any product mediator invoked through `<class>` that has no registered element of its own.
- **Rejection reuses `MediatorAccessControlException`**, so `AbstractListMediatorFactory` aggregates it and the sequence is refused at deployment in the same way a non-permitted element is. The explanatory message is logged at WARN, because the aggregated error reports only the element name and is otherwise indistinguishable from a direct element rejection.

### Verification

Exercised at runtime against a distribution built from this line, under three configurations — no access control configured, `ALLOW_LIST`, and `BLOCK_LIST` — with a restart between each.

With no configuration present, every case deploys and nothing is refused.

With a list configured, in both modes:

- A mediator named through `<class>` whose element is not permitted is refused, resolved to that element; the same mediator written as its own element is refused as before, unchanged.
- `ForEachMediatorV2` — the second implementation of `foreach`, which has a serializer but no factory of its own — is resolved through the longest-stem sweep and refused with the rest of that element.
- `ThrowError` is resolved to `throwError` from its serializer, which no factory-name derivation would produce.
- A mediator registered at runtime by `ExtensionDeployer`, living outside `org.apache.synapse`, is refused, which also exercises index invalidation on registration.
- Custom mediators loaded from `repository/components/lib` are deployed **and executed**, including one whose simple name is identical to a Synapse implementation behind a non-permitted element, and one that collides with a non-permitted element once the `Mediator` suffix leniency is applied. Driven through the gateway, each mediator's side effect is returned in the response body, so this is an execution-level result rather than a deployment-only one.
- A permitted element reached through `<class>` still deploys.
- No unresolved entries, ambiguous names or index build failures are logged in any phase.

### Tests

`MediatorAccessControlIndexTest` adds 11 unit tests over the join: the ordinary case, an element with two implementations, ambiguity on both sides of the join, the factory-without-serializer fallback, a serializer breaking the naming convention, an exact class-name match, and both sides of the fallback's package gate.
