### PR TITLE
Add coordination hardening: ensure at-most-once firing for coordinated tasks

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/startup/tasks/MessageInjector.java
+++ b/modules/core/src/main/java/org/apache/synapse/startup/tasks/MessageInjector.java
@@ -117,6 +117,35 @@ public class MessageInjector implements Task, ManagedLifecycle {
     private boolean isSequential = false;
 
     /**
+     * Caches the process-wide synchronous-injection setting on first use. When enabled, every message-injector
+     * task completes sequence mediation on its Quartz worker thread, even if the task itself is not configured
+     * for sequential execution. When disabled or absent, the task-level sequential setting remains authoritative.
+     */
+    private static Boolean globalSynchronousInjectionEnabled;
+
+    private static boolean isGlobalSynchronousInjectionEnabled() {
+        if (globalSynchronousInjectionEnabled == null) {
+            boolean synchronousInjectionEnabled = false;
+            try {
+                Object configuredValue = org.wso2.config.mapper.ConfigParser.getParsedConfigs()
+                        .get("task_handling.synchronous_injection");
+                synchronousInjectionEnabled = configuredValue != null
+                        && Boolean.parseBoolean(configuredValue.toString());
+            } catch (Throwable ignored) {
+                // Synapse can run outside Micro Integrator without the config-mapper runtime. In that case,
+                // preserve the existing task-level behavior by treating the global override as disabled.
+            }
+            if (synchronousInjectionEnabled) {
+                LogFactory.getLog(MessageInjector.class)
+                        .info("Global synchronous injection is enabled. Message-injector tasks will complete "
+                                + "sequence mediation on the Quartz worker thread, overriding each task setting.");
+            }
+            globalSynchronousInjectionEnabled = synchronousInjectionEnabled;
+        }
+        return globalSynchronousInjectionEnabled;
+    }
+
+    /**
      * Name of the proxy service which message should be injected
      */
     private String proxyName = null;
@@ -458,7 +487,7 @@ public class MessageInjector implements Task, ManagedLifecycle {
                         }
                     }
                     mc.pushFaultHandler(new MediatorFaultHandler(mc.getFaultSequence()));
-                    if (isSequential) {
+                    if (isSequential || isGlobalSynchronousInjectionEnabled()) {
                         mediateMessageSequentially(mc, seq);
                     } else {
                         synapseEnvironment.injectAsync(mc, seq);


### PR DESCRIPTION


 

## Purpose
 Coordinated task execution previously trusted each node's in-memory
  view of ownership: the leader resolved tasks by writing destined-node
  rows into the task store, each node scheduled its share in Quartz, and
  nothing at fire time re-checked that the firing node still owned the
  task. Any window in which two nodes both believed they owned a task —
  a paused JVM, a DB stall, a membership flap, heartbeat skew — produced
  duplicate fires.

  This change inverts that model: ownership is no longer something a
  node remembers, it is something a node proves at every fire. A fire
  runs only if the node first wins an atomic conditional update (a
  claim) on the new COORDINATED_TASK_CLAIM table; a node that loses the
  claim vetoes the Quartz trigger before the task body ever runs. The
  database row, not scheduler state, is the source of truth.

  Core mechanisms:

    * A global Quartz trigger listener performing the pre-body claim CAS, keyed by fire epoch, node incarnation and schedule fingerprint.
    * A boot lease with a lapse veto: a node that cannot prove liveness against the coordination DB resigns coordination and stops firing.
    * A delete/undeploy barrier: task removal opens a wave that stays open until every live owner confirms it stopped its copy; deleted tasks leave tombstones so a frozen node waking later loses its claim instead of firing.
    * A boot-pass protocol that seeds and repairs claim rows at armed startup, backed by a new NODE_ADVERTISEMENT table for node liveness.

  Everything sits behind a single master switch, coordination_hardening
  (default: false); with it off the runtime behaves bit-for-bit as
  stock. Fail-closed is the design rule throughout: when a node cannot
  prove it may fire, it does not fire.

  Fixes: https://github.com/wso2/product-integrator-mi/issues/5007